### PR TITLE
Added support for template converters

### DIFF
--- a/samples/examples/templates.html
+++ b/samples/examples/templates.html
@@ -4,8 +4,11 @@
     <title>Microsoft Graph Toolkit Test</title>
 
     <script type="module" src="../../../dist/es6/index.js"></script>
+    <script type="module" src="../../../dist/es6/mock/mgt-mock-provider.js"></script>
   </head>
   <body>
+    <mgt-mock-provider></mgt-mock-provider>
+
     <mgt-agenda id="myDay">
       <template>
         <style>
@@ -43,7 +46,7 @@
           }
         </style>
         <button class="eventButton">
-          <div class="event-subject">{{ event.subject }}</div>
+          <div class="event-subject">{{{ testFunction(event.subject.toLowerCase()) }}}</div>
           <div data-for="attendee in event.attendees">
             <mgt-person person-query="{{ attendee.emailAddress.name }}" show-name show-email></mgt-person>
           </div>
@@ -59,6 +62,9 @@
 
     <script type="module">
       let myDay = document.getElementById('myDay');
+
+      myDay.templateConverters.testFunction = str => str.length;
+
       myDay.addEventListener('templateRendered', e => {
         if (e.detail && e.detail.context) {
           let button = e.detail.element.querySelector('.eventButton');

--- a/src/components/templatedComponent.ts
+++ b/src/components/templatedComponent.ts
@@ -14,6 +14,15 @@ export abstract class MgtTemplatedComponent extends MgtBaseComponent {
   private _slotNamesAddedDuringRender = [];
   protected templates = {};
 
+  public templateConverters: any = {};
+
+  constructor() {
+    super();
+
+    this.templateConverters.lower = (str: string) => str.toLowerCase();
+    this.templateConverters.upper = (str: string) => str.toUpperCase();
+  }
+
   protected update(changedProperties) {
     this.templates = this.getTemplates();
     this._slotNamesAddedDuringRender = [];
@@ -79,7 +88,7 @@ export abstract class MgtTemplatedComponent extends MgtBaseComponent {
       }
     }
 
-    let templateContent = TemplateHelper.renderTemplate(this.templates[templateType], context);
+    let templateContent = TemplateHelper.renderTemplate(this.templates[templateType], context, this.templateConverters);
 
     let div = document.createElement('div');
     div.slot = slotName;


### PR DESCRIPTION


### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Feature

### Description of the changes
This PR adds support for converters in our templates. Ex:

```html
<mgt-agenda id="myDay">
    <template data-type="event">
        <div>
            <div>{{ event.subject }}</div> <!-- this replaces event.subject with value -->
            <div>{{{ myConverter(event.subject }}}</div> <!-- this evaluates the expression -->
        </div>
    </template>
</mgt-agenda>

<script>
    let agenda = document.getElementById('myDay');
    agenda.templateConverters.myConverter = str => str.toUpperCase();
</script>
```


### PR checklist
- [ ] Added tests and all passed
- [ ] All public classes and methods have been documented
- [ ] Added appropriate documentation
- [ ] License header has been added to all new source files
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->