### PR TITLE
[mgt-person] Fixed avatar size when no person is loaded

### DIFF
--- a/src/components/mgt-person/mgt-person.scss
+++ b/src/components/mgt-person/mgt-person.scss
@@ -10,8 +10,6 @@
 
 $avatar-size-s: var(--avatar-size-s, 24px);
 $avatar-size: var(--avatar-size, 48px);
-$avatar-font-size-s: var(--avatar-font-size--s, 16px);
-$avatar-font-size: var(--avatar-font-size, 32px);
 $avatar-border: var(--avatar-border, 0);
 $initials-color: var(--initials-color, white);
 $initials-background-color: var(--initials-background-color, #{$ms-color-magenta});
@@ -38,7 +36,7 @@ mgt-person .root {
   position: relative;
   display: flex;
   align-items: center;
-  font-family: var(--default-font-family, "Segoe UI");
+  font-family: var(--default-font-family, 'Segoe UI');
 }
 
 :host .Details,
@@ -88,10 +86,12 @@ mgt-person .user-avatar {
 :host .avatar-icon,
 mgt-person .avatar-icon {
   flex: 1 1 auto;
-  font-size: $avatar-font-size;
+  line-height: 1;
+  margin: 0;
+  font-size: $avatar-size;
 
   &.small {
-    font-size: $avatar-font-size-s;
+    font-size: $avatar-size-s;
   }
 
   &.row-span-2 {


### PR DESCRIPTION
### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
There is a difference in size between a loaded person and when no person is loaded in the mgt-person component. This PR makes sure both avatars are the same size
