### PR TITLE
Fixed end date calculation for calendarview query

### DIFF
--- a/src/components/mgt-agenda/mgt-agenda.ts
+++ b/src/components/mgt-agenda/mgt-agenda.ts
@@ -206,8 +206,7 @@ export class MgtAgenda extends MgtTemplatedComponent {
       } else {
         let start = this.date ? new Date(this.date) : new Date();
         start.setHours(0, 0, 0, 0);
-        let end = new Date();
-        end.setHours(0, 0, 0, 0);
+        let end = new Date(start.getTime());
         end.setDate(start.getDate() + this.days);
         try {
           this.events = await p.graph.getEvents(start, end, this.groupId);


### PR DESCRIPTION
Closes #146 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Creating the `end` by passing `start.getTime()` to the constructor makes a copy of `start`. You can then add days to it as needed.

### PR checklist
- [ ] Added tests and all passed
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [x] License header has been added to all new source files
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->