### PR TITLE
[mgt-person-card] added inherit-details attribute 

### DIFF
--- a/samples/examples/person-card.html
+++ b/samples/examples/person-card.html
@@ -33,13 +33,13 @@
 
     <mgt-person person-query="me" show-name show-email person-card="hover">
       <template data-type="person-card">
-        <mgt-person-card person-details="{{ person }}" person-image="{{ personImage }}"></mgt-person-card>
+        <mgt-person-card inherit-details></mgt-person-card>
       </template>
     </mgt-person>
 
     <mgt-person person-query="me" show-name show-email person-card="click">
       <template data-type="person-card">
-        <mgt-person-card person-details="{{ person }}" person-image="{{ personImage }}">
+        <mgt-person-card inherit-details>
           <template data-type="additional-details">
             <div class="details">
               Here is some additional content here

--- a/src/components/mgt-person-card/mgt-person-card.ts
+++ b/src/components/mgt-person-card/mgt-person-card.ts
@@ -4,7 +4,7 @@ import { Providers } from '../../Providers';
 import { ProviderState } from '../../providers/IProvider';
 import { getEmailFromGraphEntity } from '../../utils/graphHelpers';
 import { getSvg, SvgIcon } from '../../utils/svgHelper';
-import { PersonCardInteraction } from '../mgt-person/mgt-person';
+import { MgtPerson, PersonCardInteraction } from '../mgt-person/mgt-person';
 import { MgtTemplatedComponent } from '../templatedComponent';
 import { styles } from './mgt-person-card-css';
 /**
@@ -38,6 +38,7 @@ export class MgtPersonCard extends MgtTemplatedComponent {
     type: Object
   })
   public personDetails: MicrosoftGraph.User | MicrosoftGraph.Person | MicrosoftGraph.Contact;
+
   /**
    * Set the image of the person
    * Set to '@' to look up image from the graph
@@ -54,7 +55,7 @@ export class MgtPersonCard extends MgtTemplatedComponent {
   /**
    * Gets or sets whether additional details section is rendered
    *
-   * @type {string}
+   * @type {boolean}
    * @memberof MgtPersonCard
    */
   @property({
@@ -62,6 +63,19 @@ export class MgtPersonCard extends MgtTemplatedComponent {
     type: Boolean
   })
   public isExpanded: boolean = false;
+
+  /**
+   * Gets or sets whether additional details should be inherited from an mgt-person parent
+   * Useful when used as template in an mgt-person component
+   *
+   * @type {boolean}
+   * @memberof MgtPersonCard
+   */
+  @property({
+    attribute: 'inherit-details',
+    type: Boolean
+  })
+  public inheritDetails: boolean = false;
 
   /**
    * Synchronizes property values when attributes change.
@@ -321,6 +335,18 @@ export class MgtPersonCard extends MgtTemplatedComponent {
   }
 
   private async loadData() {
+    if (this.inheritDetails) {
+      let parent = this.parentElement;
+      while (parent && parent.tagName !== 'MGT-PERSON') {
+        parent = parent.parentElement;
+      }
+
+      if (parent && (parent as MgtPerson).personDetails) {
+        this.personDetails = (parent as MgtPerson).personDetails;
+        this.personImage = (parent as MgtPerson).personImage;
+      }
+    }
+
     if (this.personDetails) {
       return;
     }


### PR DESCRIPTION
### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This PR adds the `inherit-details` attribute to ѝmgt-person-cardѝ. When this attribute is set, the person card will walk the parent tree until it finds an `mgt-person` component and use the same `person-details` and `person-image`. This is useful when the `mgt-person-card` component is used in aн `mgt-person` template. 

Before this attribute, the developer would have to use template binding:

```html
<mgt-person person-query="me" show-name show-email person-card="hover">
  <template data-type="person-card">
    <mgt-person-card person-details="{{ person }}" person-image="{{ personImage }}"></mgt-person-card>
  </template>
</mgt-person>
```

With `inherit-details`, the developer just needs to set the attribute:

```html
<mgt-person person-query="me" show-name show-email person-card="hover">
  <template data-type="person-card">
    <mgt-person-card inherit-details></mgt-person-card>
  </template>
</mgt-person>
```
