### PR TITLE
Issue #166: added color css var to mgt-person comp

### DIFF
--- a/src/components/mgt-person/mgt-person.scss
+++ b/src/components/mgt-person/mgt-person.scss
@@ -21,6 +21,7 @@ $email-color: var(--email-color, #{$ms-color-neutralPrimary});
 
 :host .root {
   display: inline-block;
+  color: $color;
   position: relative;
 }
 


### PR DESCRIPTION
Closes #166 

### PR Type
Bugfix

### Description of the changes
added color var to the mgt-person component

### Enviornment
OS: Mac OS Majave Version 10.14.6
Browser: Chrome Version 77.0.3865.90
Framework: none
Context: Web
Version: 1.0.0

### PR checklist
- [x] Added tests and all passed
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [x] License header has been added to all new source files
- [x] Contains **NO** breaking changes

![Screen Shot 2019-10-07 at 7 36 54 PM](https://user-images.githubusercontent.com/5263612/66357205-07d1a480-e93c-11e9-83fb-4324b7d554bf.png)
