### PR TITLE
display flex brings the initials up with the images

### DIFF
--- a/src/components/mgt-person/mgt-person.scss
+++ b/src/components/mgt-person/mgt-person.scss
@@ -19,8 +19,12 @@ $color: var(--color, #{$ms-color-neutralDark});
 $email-font-size: var(--email-font-size, #{$ms-font-size-s});
 $email-color: var(--email-color, #{$ms-color-neutralPrimary});
 
+:host {
+  display: inherit;
+}
+
 :host .root {
-  display: flex;
+  display: inline-block;
   color: $color;
   position: relative;
 }

--- a/src/components/mgt-person/mgt-person.scss
+++ b/src/components/mgt-person/mgt-person.scss
@@ -20,7 +20,7 @@ $email-font-size: var(--email-font-size, #{$ms-font-size-s});
 $email-color: var(--email-color, #{$ms-color-neutralPrimary});
 
 :host .root {
-  display: inline-block;
+  display: flex;
   color: $color;
   position: relative;
 }


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #169 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix

### Description of the changes
People with no image in and just initials were misaligned with other users who did have an image. The change I made was to make the `mgt-person` container `display: flex` instead of inline-block. This allows the default container to take up as much room as it needs to without using any extra space explicitly.

### Before:
![s](http://cloud.loganarnett.com/eb67694f5b7f/Image%2525202019-10-10%252520at%2525209.40.40%252520AM.png)
### After:
![s](http://cloud.loganarnett.com/cecd2f3d1c86/Image%2525202019-10-10%252520at%2525209.40.16%252520AM.png)

### PR checklist
- [ ] Added tests and all passed
- [ ] All public classes and methods have been documented
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [ ] License header has been added to all new source files
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->