### PR TITLE
person-card:person-image ie11 fix + people-picker: person-image alignment issue 

### DIFF
--- a/src/components/mgt-people-picker/mgt-people-picker.scss
+++ b/src/components/mgt-people-picker/mgt-people-picker.scss
@@ -207,6 +207,7 @@ mgt-person {
   margin-left: 12px;
 }
 .chosen-person {
+  max-height: 24px;
   --avatar-size-s: 24px;
   margin-left: 0px;
 }

--- a/src/components/mgt-person/mgt-person.scss
+++ b/src/components/mgt-person/mgt-person.scss
@@ -77,6 +77,10 @@ mgt-person .user-avatar {
     width: $avatar-size-s;
     height: $avatar-size-s;
   }
+  &.card {
+    width: 75px;
+    height: 75px;
+  }
 
   &.row-span-2 {
     width: $avatar-size;

--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -379,11 +379,13 @@ export class MgtPerson extends MgtTemplatedComponent {
   private renderImage() {
     if (this.personDetails) {
       const title = this.personCardInteraction === PersonCardInteraction.none ? this.personDetails.displayName : '';
+      // polyfill for person-card ie 11
+      const isPersonCard = this.classList[0] === 'person-image' ? 'card' : '';
 
       if (this.personImage && this.personImage !== '@') {
         return html`
           <img
-            class="user-avatar ${this.getImageRowSpanClass()} ${this.getImageSizeClass()}"
+            class="user-avatar ${this.getImageRowSpanClass()} ${this.getImageSizeClass()} ${isPersonCard}"
             title=${title}
             aria-label=${title}
             alt=${title}
@@ -393,7 +395,7 @@ export class MgtPerson extends MgtTemplatedComponent {
       } else {
         return html`
           <div
-            class="user-avatar initials ${this.getImageRowSpanClass()} ${this.getImageSizeClass()}"
+            class="user-avatar initials ${this.getImageRowSpanClass()} ${this.getImageSizeClass()} ${isPersonCard}"
             title=${title}
             aria-label=${title}
           >


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #158 
Closes #162 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

1) Person-card: person-image ie11 fix #158

SCSS variables don't seem to traverse the DOM well with nested shadowdoms in IE 11, making the image in `mgt-person` inaccessible to the person-card. Instead have a check for class "person-image" given via person-card, and render card size based on that. 

2) People-picker: person-image alignment #162 

Sets max height on person-image so that size doesn't exceed selected-person container. 

### PR checklist
- [ ] Added tests and all passed
- [ ] All public classes and methods have been documented
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [ ] License header has been added to all new source files
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->