### PR TITLE
Include image data for person component context

### DIFF
--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -185,7 +185,7 @@ export class MgtPerson extends MgtTemplatedComponent {
    */
   public render() {
     const person =
-      this.renderTemplate('default', { person: this.personDetails }) ||
+      this.renderTemplate('default', { person: this.personDetails, personImage: this.personImage }) ||
       html`
         <div class="person-root">
           ${this.renderImage()} ${this.renderDetails()}


### PR DESCRIPTION
Closes #167

Hello,

This is a minor fix aimed at addressing #167.

The change is simple enough. However, I dug a little deeper to verify the change and I think there's a separate issue with the component template rendering pipeline which causes custom template definitions to not work.

Specifically, something feels a little off to me with this block:

https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/3f7814c74f202b6492a64744bed7c73579c62c43/src/components/templatedComponent.ts#L91-L97

For the `Person` component with a custom template, I observed a `<div slot="default" data-generated="template">` being appended on the initial render (i.e. no person data yet). Once person data becomes available, the above block of code appears to short-circuit the component re-render. This means even though person context data is available, none of that will be used to generate an updated template view.

I found that replacing the immediate return with `this.removeChild(this.children[i]);` looks like it fixes this problem. The idea here is that the previous slot element rendered gets removed and re-appended with the freshly rendered template. However, I didn't include this change because it seems like it might break something I'm unaware of. Happy to discuss further on the latter.