### PR TITLE
[Agenda] Adding eventClick event

### DIFF
--- a/src/components/mgt-agenda/mgt-agenda.ts
+++ b/src/components/mgt-agenda/mgt-agenda.ts
@@ -302,7 +302,7 @@ export class MgtAgenda extends MgtTemplatedComponent {
         ${events.map(
           event =>
             html`
-              <li>
+              <li @click=${() => this.eventClicked(event)}>
                 ${this.renderTemplate('event', { event }, event.id) || this.renderEvent(event)}
               </li>
             `
@@ -397,6 +397,10 @@ export class MgtAgenda extends MgtTemplatedComponent {
         )}
       ></mgt-people>
     `;
+  }
+
+  private eventClicked(event: MicrosoftGraph.Event) {
+    this.fireCustomEvent('eventClick', { event });
   }
 
   private getEventTimeString(event: MicrosoftGraph.Event) {


### PR DESCRIPTION
### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Adding an `eventClick` event when a user clicks or taps on an event. 

Usage:
```js
let agenda = document.querySelector('mgt-agenda');
agenda.addEventListener('eventClick', e => {
  console.log(e.detail.event.subject);
});
```

