### PR TITLE
Fix slot re-render for context updates

### DIFF
--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -138,3 +138,52 @@ export function debounce(func, time) {
     timeout = setTimeout(functionCall, time);
   };
 }
+/**
+ * Crude implementation of equivalence between the two specified arguments.
+ *
+ * The primary intent of this function is for comparing data contexts, which
+ * are expected to be object literals with potentially nested structures and
+ * where leaf values are primitives.
+ */
+export function equals(o1: any, o2: any) {
+  return equalsInternal(o1, o2, new Set());
+}
+/**
+ * Not exposed as it would undesirably leak implementation detail (`refs` argument).
+ *
+ * The `refs` argument is used to avoid infinite recursion due to circular references.
+ *
+ * @see equals
+ */
+function equalsInternal(o1: any, o2: any, refs: Set<object>) {
+  const o1Label = Object.prototype.toString.call(o1);
+  const o2Label = Object.prototype.toString.call(o2);
+  if (o1Label === o2Label && o1Label === '[object Object]' && !refs.has(o1)) {
+    refs.add(o1);
+    for (const k in o1) {
+      if (!equalsInternal(o1[k], o2[k], refs)) {
+        return false;
+      }
+    }
+    for (const k in o2) {
+      if (!o1.hasOwnProperty(k)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  if (o1Label === o2Label && o1Label === '[object Array]' && !refs.has(o1)) {
+    refs.add(o1);
+    if (o1.length !== o2.length) {
+      return false;
+    }
+    for (let i = 0; i < o1.length; i++) {
+      if (!equalsInternal(o1[i], o2[i], refs)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  // Everything else requires strict equality (e.g. primitives, functions, dates)
+  return o1 === o2;
+}

--- a/tests/Utils.tests.tsx
+++ b/tests/Utils.tests.tsx
@@ -1,0 +1,36 @@
+import * as Utils from '../src/utils/Utils';
+
+describe('objectEquals', () => {
+  const circularObject: any = {};
+  circularObject.a = circularObject;
+
+  const circularArray: any = [];
+  circularArray[0] = circularArray;
+
+  // Any other object that is not an object literal or an array will compare by reference
+  const simpleDate = new Date(0);
+
+  it.each([
+    [{}, {}],
+    [{ a: 1, b: true, c: 'foo' }, { c: 'foo', b: true, a: 1 }],
+    [{ a: [1, 2, 3] }, { a: [1, 2, 3] }],
+    [{ a: { b: { c: 1 } } }, { a: { b: { c: 1 } } }],
+    [{ a: [1, [2, [3]]] }, { a: [1, [2, [3]]] }],
+    [circularObject, circularObject],
+    [circularArray, circularArray],
+    [{ a: circularObject, b: circularArray }, { a: circularObject, b: circularArray }],
+    [{ a: simpleDate }, { a: simpleDate }]
+  ])('should return true between %p and %p', (o1: any, o2: any) => {
+    expect(Utils.equals(o1, o2)).toBe(true);
+  });
+
+  it.each([
+    [{ a: {} }, { a: [] }],
+    [{ a: [1, 2, 3] }, { a: [3, 2, 1] }],
+    [{ a: [1, [2, [3]]] }, { a: [1, [2, [4]]] }],
+    [{ a: { b: [{ c: 1 }, { d: [2, 3] }] } }, { a: { b: [{ c: 1 }, { d: [3, 2] }] } }],
+    [{ a: new Date(0) }, { a: new Date(0) }]
+  ])('should return false between %p and %p', (o1: any, o2: any) => {
+    expect(Utils.equals(o1, o2)).toBe(false);
+  });
+});


### PR DESCRIPTION
Hello,

This is a fix aimed at addressing #165.

The gist of the changes follow from some discussion in both #165 and #177.

To recap:
* The primary problem discovered was that any rendered slot element didn't re-render itself when its context data was updated
* The proposed changes will keep track of any context data previously used to render a slot and will effectively perform a re-render if the data has changed
* The change detection is done by a rather crude function that _should_ be sufficient for testing deep equality between objects

The test suite appears to be broken at this time. Specifically, the only test file I could find was `MsalProvider.tests.tsx`, and the TS compiler isn't happy about it. I've still added some tests for the `equals()` function used to do context diffing. They should all pass if run separately (i.e. `npm run test tests/Utils.tests.tsx`).

---

Closes #165