### PR TITLE
Added Proxy provider

### DIFF
--- a/src/components/providers/mgt-msal-provider.ts
+++ b/src/components/providers/mgt-msal-provider.ts
@@ -29,6 +29,7 @@ export class MgtMsalProvider extends MgtBaseProvider {
     type: String
   })
   public clientId = '';
+
   /**
    * The login type that should be used: popup or redirect
    *
@@ -57,8 +58,9 @@ export class MgtMsalProvider extends MgtBaseProvider {
     type: String
   })
   public scopes;
+
   /**
-   * Gets weather this provider can be used in this environment
+   * Gets whether this provider can be used in this environment
    *
    * @readonly
    * @memberof MgtMsalProvider

--- a/src/components/providers/mgt-proxy-provider.ts
+++ b/src/components/providers/mgt-proxy-provider.ts
@@ -8,35 +8,45 @@
 import { customElement, LitElement, property } from 'lit-element';
 import { Providers } from '../../Providers';
 import { ProxyProvider } from '../../providers/ProxyProvider';
+import { MgtBaseProvider } from './baseProvider';
+
 /**
- * Authentication Library Provider for Proxy Auth thru an api server
+ * Authentication component for ProxyProvider
  *
  * @export
  * @class MgtProxyProvider
  * @extends {LitElement}
  */
 @customElement('mgt-proxy-provider')
-export class MgtProxyProvider extends LitElement {
+export class MgtProxyProvider extends MgtBaseProvider {
   /**
-   * String alphanumerical value relation to a specific user
+   * The base url to the proxy api
    *
    * @type {string}
    * @memberof MgtProxyProvider
    */
   @property({ attribute: 'graph-proxy-url' }) public graphProxyUrl: string;
+
   /**
-   * Invoked when the element is first updated and performs validation
+   * Gets whether this provider can be used in this environment
    *
-   * @param {*} changedProperties
-   * @memberof MgtProxyProvider
+   * @readonly
+   * @memberof MgtMsalProvider
    */
-  public firstUpdated(changedProperties) {
-    this.validateAuthProps();
+  public get isAvailable() {
+    return true;
   }
 
-  private validateAuthProps() {
+  /**
+   * method called to initialize the provider. Each derived class should provide their own implementation.
+   *
+   * @protected
+   * @memberof MgtProxyProvider
+   */
+  protected initializeProvider() {
     if (this.graphProxyUrl !== undefined) {
-      Providers.globalProvider = new ProxyProvider(this.graphProxyUrl);
+      this.provider = new ProxyProvider(this.graphProxyUrl);
+      Providers.globalProvider = this.provider;
     }
   }
 }

--- a/src/components/providers/mgt-proxy-provider.ts
+++ b/src/components/providers/mgt-proxy-provider.ts
@@ -1,0 +1,42 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
+import { customElement, LitElement, property } from 'lit-element';
+import { Providers } from '../../Providers';
+import { ProxyProvider } from '../../providers/ProxyProvider';
+/**
+ * Authentication Library Provider for Proxy Auth thru an api server
+ *
+ * @export
+ * @class MgtProxyProvider
+ * @extends {LitElement}
+ */
+@customElement('mgt-proxy-provider')
+export class MgtProxyProvider extends LitElement {
+  /**
+   * String alphanumerical value relation to a specific user
+   *
+   * @type {string}
+   * @memberof MgtProxyProvider
+   */
+  @property({ attribute: 'graph-proxy-url' }) public graphProxyUrl: string;
+  /**
+   * Invoked when the element is first updated and performs validation
+   *
+   * @param {*} changedProperties
+   * @memberof MgtProxyProvider
+   */
+  public firstUpdated(changedProperties) {
+    this.validateAuthProps();
+  }
+
+  private validateAuthProps() {
+    if (this.graphProxyUrl !== undefined) {
+      Providers.globalProvider = new ProxyProvider(this.graphProxyUrl);
+    }
+  }
+}

--- a/src/components/providers/providers.ts
+++ b/src/components/providers/providers.ts
@@ -8,3 +8,4 @@
 export * from './mgt-msal-provider';
 export * from './mgt-teams-provider';
 export * from './mgt-wam-provider';
+export * from './mgt-proxy-provider';

--- a/src/providers/ProxyProvider.ts
+++ b/src/providers/ProxyProvider.ts
@@ -1,0 +1,98 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
+import { Client } from '@microsoft/microsoft-graph-client';
+import * as MicrosoftGraph from '@microsoft/microsoft-graph-types';
+import { Graph } from '../Graph';
+import { IProvider, ProviderState } from '../providers/IProvider';
+/**
+ * Proxy Provider access token for Microsoft Graph APIs
+ *
+ * @export
+ * @class ProxyProvider
+ * @extends {IProvider}
+ */
+export class ProxyProvider extends IProvider {
+  // tslint:disable-next-line: completed-docs
+  public provider: any;
+
+  /**
+   * new instance of proxy graph provider
+   *
+   * @memberof ProxyProvider
+   */
+  public graph: Graph;
+  constructor(graphProxyUrl: string) {
+    super();
+    this.graph = new ProxyGraph(graphProxyUrl, this);
+    this.graph.getMe().then(
+      user => {
+        if (user != null) {
+          this.setState(ProviderState.SignedIn);
+        } else {
+          this.setState(ProviderState.SignedOut);
+        }
+      },
+      err => {
+        this.setState(ProviderState.SignedOut);
+      }
+    );
+  }
+
+  /**
+   * sets Provider state to SignedIn
+   *
+   * @returns {Promise<void>}
+   * @memberof ProxyProvider
+   */
+  public async login(): Promise<void> {
+    this.setState(ProviderState.SignedIn);
+  }
+  /**
+   * sets Provider state to signed out
+   *
+   * @returns {Promise<void>}
+   * @memberof ProxyProvider
+   */
+  public async logout(): Promise<void> {
+    this.setState(ProviderState.Loading);
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    this.setState(ProviderState.SignedOut);
+  }
+  /**
+   * Promise returning token from graph.microsoft.com
+   *
+   * @returns {Promise<string>}
+   * @memberof ProxyProvider
+   */
+  public getAccessToken(): Promise<string> {
+    return Promise.resolve('{token:https://graph.microsoft.com/}');
+  }
+}
+
+/**
+ * ProxyGraph Instance
+ *
+ * @export
+ * @class ProxyGraph
+ * @extends {Graph}
+ */
+// tslint:disable-next-line: max-classes-per-file
+export class ProxyGraph extends Graph {
+  private readonly baseUrl: string;
+
+  constructor(baseUrl: string, provider: ProxyProvider) {
+    super(null);
+
+    this.baseUrl = baseUrl;
+
+    this.client = Client.initWithMiddleware({
+      authProvider: provider,
+      baseUrl: this.baseUrl
+    });
+  }
+}

--- a/src/providers/ProxyProvider.ts
+++ b/src/providers/ProxyProvider.ts
@@ -5,19 +5,10 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import {
-  Client,
-  Context,
-  HTTPMessageHandler,
-  Middleware,
-  RetryHandler,
-  RetryHandlerOptions,
-  TelemetryHandler
-} from '@microsoft/microsoft-graph-client';
-import { setRequestHeader } from '@microsoft/microsoft-graph-client/lib/es/middleware/MiddlewareUtil';
 import { Graph } from '../Graph';
 import { IProvider, ProviderState } from '../providers/IProvider';
-import { SdkVersionMiddleware } from '../utils/SdkVersionMiddleware';
+import { ProxyGraph } from '../utils/ProxyGraph';
+
 /**
  * Proxy Provider access token for Microsoft Graph APIs
  *
@@ -57,81 +48,5 @@ export class ProxyProvider extends IProvider {
    */
   public getAccessToken(): Promise<string> {
     return null;
-  }
-}
-
-/**
- * ProxyGraph Instance
- *
- * @export
- * @class ProxyGraph
- * @extends {Graph}
- */
-// tslint:disable-next-line: max-classes-per-file
-export class ProxyGraph extends Graph {
-  constructor(baseUrl: string, getCustomHeaders: () => Promise<object>) {
-    super(null);
-
-    const retryHandler = new RetryHandler(new RetryHandlerOptions());
-    const telemetryHandler = new TelemetryHandler();
-    const sdkVersionMiddleware = new SdkVersionMiddleware();
-    const customHeaderMiddleware = new CustomHeaderMiddleware(getCustomHeaders);
-    const httpMessageHandler = new HTTPMessageHandler();
-
-    retryHandler.setNext(telemetryHandler);
-    telemetryHandler.setNext(sdkVersionMiddleware);
-    sdkVersionMiddleware.setNext(customHeaderMiddleware);
-    customHeaderMiddleware.setNext(httpMessageHandler);
-
-    this.client = Client.initWithMiddleware({
-      baseUrl,
-      middleware: retryHandler
-    });
-  }
-}
-
-/**
- * Custom Middleware to add custom headers when making calls
- * through the proxy provider
- *
- * @class CustomHeaderMiddleware
- * @implements {Middleware}
- */
-// tslint:disable-next-line: max-classes-per-file
-class CustomHeaderMiddleware implements Middleware {
-  private nextMiddleware: Middleware;
-  private _getCustomHeaders: () => Promise<object>;
-
-  public constructor(getCustomHeaders: () => Promise<object>) {
-    this._getCustomHeaders = getCustomHeaders;
-  }
-
-  /**
-   * Execute the current middleware
-   *
-   * @param {Context} context
-   * @returns {Promise<void>}
-   * @memberof CustomHeaderMiddleware
-   */
-  public async execute(context: Context): Promise<void> {
-    if (this._getCustomHeaders) {
-      const headers = await this._getCustomHeaders();
-      for (const key in headers) {
-        if (headers.hasOwnProperty(key)) {
-          setRequestHeader(context.request, context.options, key, headers[key]);
-        }
-      }
-    }
-    return await this.nextMiddleware.execute(context);
-  }
-
-  /**
-   * Handles setting of next middleware
-   *
-   * @param {Middleware} next
-   * @memberof SdkVersionMiddleware
-   */
-  public setNext(next: Middleware): void {
-    this.nextMiddleware = next;
   }
 }

--- a/src/providers/providers.ts
+++ b/src/providers/providers.ts
@@ -10,3 +10,4 @@ export * from './MsalProvider';
 export * from './SharePointProvider';
 export * from './TeamsProvider';
 export * from './SimpleProvider';
+export * from './ProxyProvider';

--- a/src/utils/CustomHeaderMiddleware.ts
+++ b/src/utils/CustomHeaderMiddleware.ts
@@ -1,0 +1,55 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
+import { Context, Middleware } from '@microsoft/microsoft-graph-client';
+import { setRequestHeader } from '@microsoft/microsoft-graph-client/lib/es/middleware/MiddlewareUtil';
+
+/**
+ * Custom Middleware to add custom headers when making calls
+ * through the proxy provider
+ *
+ * @class CustomHeaderMiddleware
+ * @implements {Middleware}
+ */
+// tslint:disable-next-line: max-classes-per-file
+export class CustomHeaderMiddleware implements Middleware {
+  private nextMiddleware: Middleware;
+  private _getCustomHeaders: () => Promise<object>;
+
+  public constructor(getCustomHeaders: () => Promise<object>) {
+    this._getCustomHeaders = getCustomHeaders;
+  }
+
+  /**
+   * Execute the current middleware
+   *
+   * @param {Context} context
+   * @returns {Promise<void>}
+   * @memberof CustomHeaderMiddleware
+   */
+  public async execute(context: Context): Promise<void> {
+    if (this._getCustomHeaders) {
+      const headers = await this._getCustomHeaders();
+      for (const key in headers) {
+        if (headers.hasOwnProperty(key)) {
+          setRequestHeader(context.request, context.options, key, headers[key]);
+        }
+      }
+    }
+    return await this.nextMiddleware.execute(context);
+  }
+
+  /**
+   * Handles setting of next middleware
+   *
+   * @param {Middleware} next
+   * @memberof SdkVersionMiddleware
+   */
+  public setNext(next: Middleware): void {
+    this.nextMiddleware = next;
+  }
+}

--- a/src/utils/ProxyGraph.ts
+++ b/src/utils/ProxyGraph.ts
@@ -1,0 +1,47 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
+import {
+  Client,
+  HTTPMessageHandler,
+  RetryHandler,
+  RetryHandlerOptions,
+  TelemetryHandler
+} from '@microsoft/microsoft-graph-client';
+import { Graph } from '../Graph';
+import { CustomHeaderMiddleware } from './CustomHeaderMiddleware';
+import { SdkVersionMiddleware } from './SdkVersionMiddleware';
+
+/**
+ * ProxyGraph Instance
+ *
+ * @export
+ * @class ProxyGraph
+ * @extends {Graph}
+ */
+// tslint:disable-next-line: max-classes-per-file
+export class ProxyGraph extends Graph {
+  constructor(baseUrl: string, getCustomHeaders: () => Promise<object>) {
+    super(null);
+
+    const retryHandler = new RetryHandler(new RetryHandlerOptions());
+    const telemetryHandler = new TelemetryHandler();
+    const sdkVersionMiddleware = new SdkVersionMiddleware();
+    const customHeaderMiddleware = new CustomHeaderMiddleware(getCustomHeaders);
+    const httpMessageHandler = new HTTPMessageHandler();
+
+    retryHandler.setNext(telemetryHandler);
+    telemetryHandler.setNext(sdkVersionMiddleware);
+    sdkVersionMiddleware.setNext(customHeaderMiddleware);
+    customHeaderMiddleware.setNext(httpMessageHandler);
+
+    this.client = Client.initWithMiddleware({
+      baseUrl,
+      middleware: retryHandler
+    });
+  }
+}

--- a/src/utils/SdkVersionMiddleware.ts
+++ b/src/utils/SdkVersionMiddleware.ts
@@ -26,7 +26,7 @@ export class SdkVersionMiddleware implements Middleware {
   // tslint:disable-next-line: completed-docs
   public async execute(context: Context): Promise<void> {
     try {
-      let sdkVersionValue: string = `mgt/${PACKAGE_VERSION}`; // todo - add real version
+      let sdkVersionValue: string = `mgt/${PACKAGE_VERSION}`;
 
       sdkVersionValue += ', ' + getRequestHeader(context.request, context.options, 'SdkVersion');
 


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes # <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Adds a proxy provider, so users can use their own server side auth with the graph and still use mgt without needing to signing in twice.

### PR checklist
- [ ] Added tests and all passed
- [X] All public classes and methods have been documented
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [X] License header has been added to all new source files
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->