### PR TITLE
Fix for templates not rendering children in the right order

### DIFF
--- a/src/components/mgt-person-card/mgt-person-card.ts
+++ b/src/components/mgt-person-card/mgt-person-card.ts
@@ -140,7 +140,7 @@ export class MgtPersonCard extends MgtTemplatedComponent {
       return html`
         <div class="root" @click=${this.handleClose}>
           <div class="default-view">
-            ${this.renderTemplate('default', { person: this.personDetails }) ||
+            ${this.renderTemplate('default', { person: this.personDetails, personImage: this.personImage }) ||
               html`
                 <mgt-person
                   class="person-image"
@@ -257,7 +257,10 @@ export class MgtPersonCard extends MgtTemplatedComponent {
                 ? html`
                     <div class="section-divider"></div>
                     <div class="custom-section">
-                      ${this.renderTemplate('additional-details', null)}
+                      ${this.renderTemplate('additional-details', {
+                        person: this.personDetails,
+                        personImage: this.personImage
+                      })}
                     </div>
                   `
                 : null}

--- a/src/components/templateHelper.ts
+++ b/src/components/templateHelper.ts
@@ -184,7 +184,6 @@ export class TemplateHelper {
           // first remove the child
           // we will need to make copy of the child for
           // each element in the list
-          nodeElement.removeChild(childElement);
           childElement.removeAttribute('data-for');
 
           for (let j = 0; j < list.length; j++) {
@@ -195,8 +194,10 @@ export class TemplateHelper {
 
             const clone = childElement.cloneNode(true);
             this.renderNode(clone, newContext, converters);
-            nodeElement.appendChild(clone);
+            nodeElement.insertBefore(clone, childElement);
           }
+
+          nodeElement.removeChild(childElement);
         }
       }
     }


### PR DESCRIPTION
### PR Type
- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This pr fixes an issue where a `data-for` loop is used in a template and items are rendered out of order.

This pr also adds the personDetails and personImage in the context of the templates in the person-card component