### PR TITLE
Templates - introducing $index and $parent

### DIFF
--- a/samples/examples/person-card-get.html
+++ b/samples/examples/person-card-get.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="https://unpkg.com/@microsoft/mgt/dist/bundle/mgt-loader.js"></script>
+    <!-- <script src="https://unpkg.com/@microsoft/mgt/dist/bundle/mgt-loader.js"></script> -->
+    <script type="module" src="../../dist/es6/index.js"></script>
+    <script type="module" src="../../dist/es6/mock/mgt-mock-provider.js"></script>
   </head>
 
   <body>
@@ -13,8 +15,9 @@
           <template data-type="additional-details">
             <mgt-get resource="/users/{{ person.id }}/profile" version="beta">
               <template>
+                {{{ console.log(this) }}}
                 <div>
-                  <div data-if="positions && positions.length">
+                  <!-- <div data-if="positions && positions.length">
                     <h2>Work history</h2>
                     <div data-for="position in positions">
                       <b>{{ position.detail.jobTitle }}</b> ({{ position.detail.company.department }})
@@ -37,16 +40,18 @@
                       </div>
                     </div>
                     <hr />
-                  </div>
-                  <div data-if="interests && interests.length">
+                  </div> -->
+                  <div>
                     <h2>Interests</h2>
-                    <span data-for="interest in interests"> {{ interest.displayName }}, </span>
+                    <span data-for="interest in interests">
+                      {{ interest.displayName }}<span data-if="$index < interests.length - 1">, </span></span
+                    >
                     <hr />
                   </div>
-                  <div data-if="languages && languages.length">
+                  <!-- <div data-if="languages && languages.length">
                     <h2>Languages</h2>
                     <span data-for="language in languages"> {{ language.displayName }}, </span>
-                  </div>
+                  </div> -->
                 </div>
               </template>
             </mgt-get>

--- a/samples/examples/person-card-get.html
+++ b/samples/examples/person-card-get.html
@@ -15,9 +15,8 @@
           <template data-type="additional-details">
             <mgt-get resource="/users/{{ person.id }}/profile" version="beta">
               <template>
-                {{{ console.log(this) }}}
                 <div>
-                  <!-- <div data-if="positions && positions.length">
+                  <div data-if="positions && positions.length">
                     <h2>Work history</h2>
                     <div data-for="position in positions">
                       <b>{{ position.detail.jobTitle }}</b> ({{ position.detail.company.department }})
@@ -40,18 +39,20 @@
                       </div>
                     </div>
                     <hr />
-                  </div> -->
+                  </div>
                   <div>
                     <h2>Interests</h2>
                     <span data-for="interest in interests">
-                      {{ interest.displayName }}<span data-if="$index < interests.length - 1">, </span></span
-                    >
+                      {{ interest.displayName }}<span data-if="$index < interests.length - 1">, </span>
+                    </span>
                     <hr />
                   </div>
-                  <!-- <div data-if="languages && languages.length">
+                  <div data-if="languages && languages.length">
                     <h2>Languages</h2>
-                    <span data-for="language in languages"> {{ language.displayName }}, </span>
-                  </div> -->
+                    <span data-for="language in languages">
+                      {{ language.displayName }}<span data-if="$index < languages.length - 1">, </span>
+                    </span>
+                  </div>
                 </div>
               </template>
             </mgt-get>

--- a/src/components/mgt-person-card/mgt-person-card.ts
+++ b/src/components/mgt-person-card/mgt-person-card.ts
@@ -137,15 +137,18 @@ export class MgtPersonCard extends MgtTemplatedComponent {
           <div class="job-title">${user.jobTitle}</div>
         `;
       }
+
+      const image = this.getImage();
+
       return html`
         <div class="root" @click=${this.handleClose}>
           <div class="default-view">
-            ${this.renderTemplate('default', { person: this.personDetails, personImage: this.personImage }) ||
+            ${this.renderTemplate('default', { person: this.personDetails, personImage: image }) ||
               html`
                 <mgt-person
                   class="person-image"
                   .personDetails=${this.personDetails}
-                  .personImage=${this.personImage}
+                  .personImage=${image}
                 ></mgt-person>
                 <div class="details">
                   <div class="display-name">${user.displayName}</div>
@@ -259,7 +262,7 @@ export class MgtPersonCard extends MgtTemplatedComponent {
                     <div class="custom-section">
                       ${this.renderTemplate('additional-details', {
                         person: this.personDetails,
-                        personImage: this.personImage
+                        personImage: this.getImage()
                       })}
                     </div>
                   `
@@ -372,5 +375,14 @@ export class MgtPersonCard extends MgtTemplatedComponent {
 
   private handleClose(e: Event) {
     e.stopPropagation();
+  }
+
+  private getImage(): string {
+    if (this.personImage && this.personImage !== '@') {
+      return this.personImage;
+    } else if (this.personDetails && (this.personDetails as any).personImage) {
+      return (this.personDetails as any).personImage;
+    }
+    return null;
   }
 }

--- a/src/components/templateHelper.ts
+++ b/src/components/templateHelper.ts
@@ -24,6 +24,11 @@ export class TemplateHelper {
    * @param converters the converter functions used to transform the data
    */
   public static renderTemplate(template: HTMLTemplateElement, context: object, converters?: object) {
+    // inherit context from parent template
+    if ((template as any).$parentTemplateContext) {
+      context = { ...context, $parent: (template as any).$parentTemplateContext };
+    }
+
     if (template.content && template.content.childNodes.length) {
       const templateContent = template.content.cloneNode(true);
       return this.renderNode(templateContent, context, converters);
@@ -36,8 +41,8 @@ export class TemplateHelper {
       return this.renderNode(div, context, converters);
     }
   }
-  private static _expression = /{{\s*[\w\.]+\s*}}/g;
-  private static _converterExpression = /{{{\s*[\w\.()]+\s*}}}/g;
+  private static _expression = /{{\s*([$\w]+)(\.[$\w]+)*\s*}}/g;
+  private static _converterExpression = /{{{\s*[$\w\.()]+\s*}}}/g;
 
   /**
    * Gets the value of an expanded key in an object
@@ -94,6 +99,9 @@ export class TemplateHelper {
   private static renderNode(node: Node, context: object, converters: object) {
     if (node.nodeName === '#text') {
       node.textContent = this.replaceExpression(node.textContent, context, converters);
+      return node;
+    } else if (node.nodeName === 'TEMPLATE') {
+      (node as any).$parentTemplateContext = context;
       return node;
     }
 
@@ -187,10 +195,11 @@ export class TemplateHelper {
           childElement.removeAttribute('data-for');
 
           for (let j = 0; j < list.length; j++) {
-            const newContext: any = {};
+            const newContext = {
+              $index: j,
+              ...context
+            };
             newContext[itemName] = list[j];
-            // tslint:disable-next-line: no-string-literal
-            newContext.index = j;
 
             const clone = childElement.cloneNode(true);
             this.renderNode(clone, newContext, converters);


### PR DESCRIPTION
### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This PR introduces new properties in the template context when binding:
* $index is added to the context of each item being looped with data-for. This is useful when a developer needs to know the index of an item being rendered
* $parent is added to the context of a template when rendered inside of another template. This is useful when the developer needs to use context from a parent template
* when looping, all context is preserved. Before only the item being looped was available

This PR also fixes an issue where person-card image was not passed as context to a template.
