### PR TITLE
[mgt-people] setting overflow to align with peoplelist vertically

### DIFF
--- a/src/components/mgt-people/mgt-people.scss
+++ b/src/components/mgt-people/mgt-people.scss
@@ -16,14 +16,21 @@ mgt-people .people-list {
   list-style-type: none;
   margin: $list-margin;
   padding: 0;
-  font-family: var(--default-font-family, "Segoe UI");
+  font-family: var(--default-font-family, 'Segoe UI');
   font-style: normal;
   font-weight: normal;
   display: flex;
+  align-items: center;
 }
 
 :host .people-person,
 mgt-people .people-person {
   margin: $avatar-margin;
   display: flex;
+}
+:host .overflow,
+mgt-people .overflow {
+  span {
+    vertical-align: middle;
+  }
 }

--- a/src/components/mgt-people/mgt-people.ts
+++ b/src/components/mgt-people/mgt-people.ts
@@ -140,7 +140,7 @@ export class MgtPeople extends MgtTemplatedComponent {
                     people: this.people
                   }) ||
                   html`
-                    <li>+${this.people.length - this.showMax}</li>
+                    <li class="overflow"><span>+${this.people.length - this.showMax}<span></li>
                   `
                 : null}
             </ul>


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #198 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Adds overflow class to show-max conditionally rendered mgt-people. Both `align-items` in the parent, and `vertical-align` css properties are necessary for handling mgt-people standalone + mgt-people rendered in mgt-agenda.

### PR checklist
- [ ] Added tests and all passed
- [ ] All public classes and methods have been documented
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [ ] License header has been added to all new source files
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->