### PR TITLE
[person] updating mouseEnter to not reset if click inside of the card

### DIFF
--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -294,7 +294,9 @@ export class MgtPerson extends MgtTemplatedComponent {
 
   private _handleMouseEnter(e: MouseEvent) {
     if (this.personCardInteraction !== PersonCardInteraction.hover) {
-      return;
+      if (!PersonCardInteraction.click) {
+        return;
+      }
     }
 
     clearTimeout(this._mouseEnterTimeout);

--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -293,14 +293,11 @@ export class MgtPerson extends MgtTemplatedComponent {
   }
 
   private _handleMouseEnter(e: MouseEvent) {
-    if (this.personCardInteraction !== PersonCardInteraction.hover) {
-      if (!PersonCardInteraction.click) {
-        return;
-      }
-    }
-
     clearTimeout(this._mouseEnterTimeout);
     clearTimeout(this._mouseLeaveTimeout);
+    if (this.personCardInteraction !== PersonCardInteraction.hover) {
+      return;
+    }
     this._mouseEnterTimeout = setTimeout(this._showPersonCard.bind(this), 500);
   }
 


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #203 
### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

adding condition to return if user clicks inside the card itself. 

### PR checklist
- [ ] Added tests and all passed
- [ ] All public classes and methods have been documented
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [ ] License header has been added to all new source files
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->