### PR TITLE
Adding taskFilter property to mgt-tasks

### DIFF
--- a/src/components/mgt-tasks/mgt-tasks.ts
+++ b/src/components/mgt-tasks/mgt-tasks.ts
@@ -5,8 +5,8 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { Person, PlannerAssignments, User } from '@microsoft/microsoft-graph-types';
-import { Contact, OutlookTaskFolder } from '@microsoft/microsoft-graph-types-beta';
+import { Person, PlannerAssignments, PlannerTask, User } from '@microsoft/microsoft-graph-types';
+import { Contact, OutlookTask, OutlookTaskFolder } from '@microsoft/microsoft-graph-types-beta';
 import { customElement, html, property } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map';
 import { repeat } from 'lit-html/directives/repeat';
@@ -192,6 +192,13 @@ export class MgtTasks extends MgtTemplatedComponent {
   @property({ attribute: 'group-id', type: String })
   public groupId: string = null;
 
+  /**
+   * Optional filter function when rendering tasks
+   *
+   * @memberof MgtTasks
+   */
+  public taskFilter: (task: PlannerTask | OutlookTask) => boolean;
+
   @property() private _isNewTaskVisible: boolean = false;
   @property() private _newTaskBeingAdded: boolean = false;
   @property() private _newTaskName: string = '';
@@ -313,10 +320,14 @@ export class MgtTasks extends MgtTemplatedComponent {
    * trigger the element to update.
    */
   protected render() {
-    const tasks = this._tasks
+    let tasks = this._tasks
       .filter(task => this.isTaskInSelectedGroupFilter(task))
       .filter(task => this.isTaskInSelectedFolderFilter(task))
       .filter(task => !this._hiddenTasks.includes(task.id));
+
+    if (this.taskFilter) {
+      tasks = tasks.filter(task => this.taskFilter(task._raw));
+    }
 
     const loadingTask = this._inTaskLoad && !this._hasDoneInitialLoad ? this.renderLoadingTask() : null;
 


### PR DESCRIPTION


### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This PR is adding the `taskFilter` property to the `mgt-tasks` component to allow additional filtering of tasks. The taskFilter must be a function that accepts a task object as a parameter and returns true if the task should be rendered, false otherwise. The task object can be a planner task or an outlook (todo) task depending on the source the developer is using.

For example, I developer could choose to only render tasks in a specific category by providing the following filter:

```js
let taskView = document.querySelector('mgt-tasks');
taskView.taskFilter = task => task.appliedCategories.category3;
```
