### PR TITLE
Person-card touch to hide issue + login refactor (window event)

### DIFF
--- a/src/components/mgt-login/mgt-login.ts
+++ b/src/components/mgt-login/mgt-login.ts
@@ -198,6 +198,10 @@ export class MgtLogin extends MgtBaseComponent {
   }
 
   private handleClick(e: MouseEvent) {
+    if (e.target === this) {
+      return;
+    }
+
     // get popup bounds
     const popup = this.renderRoot.querySelector('.popup');
     if (popup) {
@@ -279,7 +283,6 @@ export class MgtLogin extends MgtBaseComponent {
   }
 
   private onClick(event: MouseEvent) {
-    event.stopPropagation();
     if (this.userDetails) {
       // get login button bounds
       const loginButton = this.renderRoot.querySelector('.login-button');

--- a/src/components/mgt-login/mgt-login.ts
+++ b/src/components/mgt-login/mgt-login.ts
@@ -62,6 +62,26 @@ export class MgtLogin extends MgtBaseComponent {
     super();
     Providers.onProviderUpdated(() => this.loadState());
     this.loadState();
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  /**
+   * Determines if click was made
+   *
+   * @memberof MgtLogin
+   */
+  public connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener('click', this.handleClick);
+  }
+  /**
+   * Removes click event from window
+   *
+   * @memberof MgtLogin
+   */
+  public disconnectedCallback() {
+    window.removeEventListener('click', this.handleClick);
+    super.disconnectedCallback();
   }
 
   /**
@@ -160,26 +180,6 @@ export class MgtLogin extends MgtBaseComponent {
   }
 
   /**
-   * Invoked when the element is first updated. Implement to perform one time
-   * work on the element after update.
-   *
-   * Setting properties inside this method will trigger the element to update
-   * again after this update cycle completes.
-   *
-   * * @param _changedProperties Map of changed properties with old values
-   */
-  protected firstUpdated() {
-    window.addEventListener('click', (event: MouseEvent) => {
-      // get popup bounds
-      const popup = this.renderRoot.querySelector('.popup');
-      if (popup) {
-        this._popupRect = popup.getBoundingClientRect();
-        this._showMenu = false;
-      }
-    });
-  }
-
-  /**
    * Invoked on each update to perform rendering tasks. This method must return
    * a lit-html TemplateResult. Setting properties inside this method will *not*
    * trigger the element to update.
@@ -195,6 +195,15 @@ export class MgtLogin extends MgtBaseComponent {
         ${this.renderMenu()}
       </div>
     `;
+  }
+
+  private handleClick(e: MouseEvent) {
+    // get popup bounds
+    const popup = this.renderRoot.querySelector('.popup');
+    if (popup) {
+      this._popupRect = popup.getBoundingClientRect();
+      this._showMenu = false;
+    }
   }
 
   private renderLogIn() {

--- a/src/components/mgt-login/mgt-login.ts
+++ b/src/components/mgt-login/mgt-login.ts
@@ -62,25 +62,26 @@ export class MgtLogin extends MgtBaseComponent {
     super();
     Providers.onProviderUpdated(() => this.loadState());
     this.loadState();
-    this.handleClick = this.handleClick.bind(this);
+    this.handleWindowClick = this.handleWindowClick.bind(this);
   }
 
   /**
-   * Determines if click was made
+   * Invoked each time the custom element is appended into a document-connected element
    *
    * @memberof MgtLogin
    */
   public connectedCallback() {
     super.connectedCallback();
-    window.addEventListener('click', this.handleClick);
+    window.addEventListener('click', this.handleWindowClick);
   }
+
   /**
-   * Removes click event from window
+   * Invoked each time the custom element is disconnected from the document's DOM
    *
    * @memberof MgtLogin
    */
   public disconnectedCallback() {
-    window.removeEventListener('click', this.handleClick);
+    window.removeEventListener('click', this.handleWindowClick);
     super.disconnectedCallback();
   }
 
@@ -197,7 +198,7 @@ export class MgtLogin extends MgtBaseComponent {
     `;
   }
 
-  private handleClick(e: MouseEvent) {
+  private handleWindowClick(e: MouseEvent) {
     if (e.target === this) {
       return;
     }

--- a/src/components/mgt-person/mgt-person.scss
+++ b/src/components/mgt-person/mgt-person.scss
@@ -20,7 +20,7 @@ $email-font-size: var(--email-font-size, #{$ms-font-size-s});
 $email-color: var(--email-color, #{$ms-color-neutralPrimary});
 
 :host {
-  display: inherit;
+  display: inline-block;
 }
 
 :host .root {

--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -125,7 +125,7 @@ export class MgtPerson extends MgtTemplatedComponent {
 
   constructor() {
     super();
-    this.handleClick = this.handleClick.bind(this);
+    this.handleWindowClick = this.handleWindowClick.bind(this);
   }
 
   /**
@@ -167,7 +167,7 @@ export class MgtPerson extends MgtTemplatedComponent {
    */
   public connectedCallback() {
     super.connectedCallback();
-    window.addEventListener('click', this.handleClick);
+    window.addEventListener('click', this.handleWindowClick);
   }
 
   /**
@@ -176,7 +176,7 @@ export class MgtPerson extends MgtTemplatedComponent {
    * @memberof MgtPerson
    */
   public disconnectedCallback() {
-    window.removeEventListener('click', this.handleClick);
+    window.removeEventListener('click', this.handleWindowClick);
     super.disconnectedCallback();
   }
 
@@ -227,7 +227,7 @@ export class MgtPerson extends MgtTemplatedComponent {
     }
   }
 
-  private handleClick(e: MouseEvent) {
+  private handleWindowClick(e: MouseEvent) {
     if (this.isPersonCardVisible && e.target !== this) {
       this.hidePersonCard();
     }

--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -226,6 +226,9 @@ export class MgtPerson extends MgtTemplatedComponent {
   }
 
   private handleClick(e: MouseEvent) {
+    if (this.personCardInteraction === PersonCardInteraction.click && !this.isPersonCardVisible) {
+      this.showPersonCard();
+    }
     if (this.isPersonCardVisible && e.target !== this) {
       this.hidePersonCard();
     }

--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -121,6 +121,8 @@ export class MgtPerson extends MgtTemplatedComponent {
   @property({ attribute: false }) private isPersonCardVisible: boolean = false;
   @property({ attribute: false }) private personCardShouldRender: boolean = false;
 
+  @property({}) private isTouch = false;
+
   private _mouseLeaveTimeout;
   private _mouseEnterTimeout;
 
@@ -234,10 +236,16 @@ export class MgtPerson extends MgtTemplatedComponent {
     if (this.isPersonCardVisible && e.target !== this) {
       this.hidePersonCard();
     }
+    window.setTimeout(() => {
+      if (this.isTouch) {
+        this.isTouch = false;
+      }
+    }, 50);
   }
 
   private handleTouch(e: TouchEvent) {
     if (!this.isPersonCardVisible && e.target === this) {
+      this.isTouch = true;
       this.showPersonCard();
     }
   }
@@ -326,10 +334,10 @@ export class MgtPerson extends MgtTemplatedComponent {
 
     this.requestUpdate();
   }
-  private handleMouseClick() {
+  private handleMouseClick(e: MouseEvent) {
     if (this.personCardInteraction === PersonCardInteraction.click && !this.isPersonCardVisible) {
       this.showPersonCard();
-    } else {
+    } else if (!this.isTouch) {
       this.hidePersonCard();
     }
   }
@@ -337,7 +345,7 @@ export class MgtPerson extends MgtTemplatedComponent {
   private handleMouseEnter(e: MouseEvent) {
     clearTimeout(this._mouseEnterTimeout);
     clearTimeout(this._mouseLeaveTimeout);
-    if (this.personCardInteraction !== PersonCardInteraction.hover) {
+    if (this.personCardInteraction !== PersonCardInteraction.hover || this.isTouch) {
       return;
     }
     this._mouseEnterTimeout = setTimeout(this.showPersonCard.bind(this), 500);

--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -124,6 +124,11 @@ export class MgtPerson extends MgtTemplatedComponent {
   private _mouseLeaveTimeout;
   private _mouseEnterTimeout;
 
+  constructor() {
+    super();
+    this.handleTouch = this.handleTouch.bind(this);
+  }
+
   /**
    * Synchronizes property values when attributes change.
    *
@@ -154,6 +159,25 @@ export class MgtPerson extends MgtTemplatedComponent {
   public firstUpdated() {
     Providers.onProviderUpdated(() => this.loadData());
     this.loadData();
+  }
+
+  /**
+   * Determines if touch was made
+   *
+   * @memberof MgtPerson
+   */
+  public connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener('touchstart', this.handleTouch);
+  }
+  /**
+   * Removes touch event from window
+   *
+   * @memberof MgtPerson
+   */
+  public disconnectedCallback() {
+    window.removeEventListener('touchstart', this.handleTouch);
+    super.disconnectedCallback();
   }
 
   /**
@@ -200,6 +224,12 @@ export class MgtPerson extends MgtTemplatedComponent {
       const parent = initials.parentNode as HTMLElement;
       const height = parent.getBoundingClientRect().height;
       initials.style.fontSize = `${height * 0.5}px`;
+    }
+  }
+
+  private handleTouch(e: TouchEvent) {
+    if (this.isPersonCardVisible && e.target !== this) {
+      this.hidePersonCard();
     }
   }
 

--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -8,7 +8,6 @@
 import * as MicrosoftGraph from '@microsoft/microsoft-graph-types';
 import { customElement, html, property, PropertyValues, TemplateResult } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map';
-import { styleMap } from 'lit-html/directives/style-map';
 import { Providers } from '../../Providers';
 import { ProviderState } from '../../providers/IProvider';
 import '../../styles/fabric-icon-font';
@@ -121,15 +120,12 @@ export class MgtPerson extends MgtTemplatedComponent {
   @property({ attribute: false }) private isPersonCardVisible: boolean = false;
   @property({ attribute: false }) private personCardShouldRender: boolean = false;
 
-  private isTouch = false;
-
   private _mouseLeaveTimeout;
   private _mouseEnterTimeout;
 
   constructor() {
     super();
     this.handleClick = this.handleClick.bind(this);
-    this.handleTouch = this.handleTouch.bind(this);
   }
 
   /**
@@ -165,23 +161,22 @@ export class MgtPerson extends MgtTemplatedComponent {
   }
 
   /**
-   * Determines if touch was made
+   * Invoked each time the custom element is appended into a document-connected element
    *
    * @memberof MgtPerson
    */
   public connectedCallback() {
     super.connectedCallback();
     window.addEventListener('click', this.handleClick);
-    this.addEventListener('touchstart', this.handleTouch);
   }
+
   /**
-   * Removes touch event from window
+   * Invoked each time the custom element is disconnected from the document's DOM
    *
    * @memberof MgtPerson
    */
   public disconnectedCallback() {
     window.removeEventListener('click', this.handleClick);
-    this.removeEventListener('touchstart', this.handleTouch);
     super.disconnectedCallback();
   }
 
@@ -235,18 +230,6 @@ export class MgtPerson extends MgtTemplatedComponent {
   private handleClick(e: MouseEvent) {
     if (this.isPersonCardVisible && e.target !== this) {
       this.hidePersonCard();
-    }
-    window.setTimeout(() => {
-      if (this.isTouch) {
-        this.isTouch = false;
-      }
-    }, 400);
-  }
-
-  private handleTouch(e: TouchEvent) {
-    if (!this.isPersonCardVisible && e.target === this) {
-      this.isTouch = true;
-      this.showPersonCard();
     }
   }
 
@@ -334,18 +317,17 @@ export class MgtPerson extends MgtTemplatedComponent {
 
     this.requestUpdate();
   }
+
   private handleMouseClick(e: MouseEvent) {
-    if (this.personCardInteraction === PersonCardInteraction.click && !this.isPersonCardVisible) {
+    if (this.personCardInteraction !== PersonCardInteraction.none && !this.isPersonCardVisible) {
       this.showPersonCard();
-    } else if (!this.isTouch) {
-      this.hidePersonCard();
     }
   }
 
   private handleMouseEnter(e: MouseEvent) {
     clearTimeout(this._mouseEnterTimeout);
     clearTimeout(this._mouseLeaveTimeout);
-    if (this.personCardInteraction !== PersonCardInteraction.hover || !this.isTouch) {
+    if (this.personCardInteraction !== PersonCardInteraction.hover) {
       return;
     }
     this._mouseEnterTimeout = setTimeout(this.showPersonCard.bind(this), 500);

--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -126,6 +126,7 @@ export class MgtPerson extends MgtTemplatedComponent {
 
   constructor() {
     super();
+    this.handleClick = this.handleClick.bind(this);
     this.handleTouch = this.handleTouch.bind(this);
   }
 
@@ -168,7 +169,8 @@ export class MgtPerson extends MgtTemplatedComponent {
    */
   public connectedCallback() {
     super.connectedCallback();
-    window.addEventListener('touchstart', this.handleTouch);
+    window.addEventListener('click', this.handleClick);
+    this.addEventListener('touchstart', this.handleTouch);
   }
   /**
    * Removes touch event from window
@@ -176,7 +178,8 @@ export class MgtPerson extends MgtTemplatedComponent {
    * @memberof MgtPerson
    */
   public disconnectedCallback() {
-    window.removeEventListener('touchstart', this.handleTouch);
+    window.removeEventListener('click', this.handleClick);
+    this.removeEventListener('touchstart', this.handleTouch);
     super.disconnectedCallback();
   }
 
@@ -196,12 +199,7 @@ export class MgtPerson extends MgtTemplatedComponent {
       `;
 
     return html`
-      <div
-        class="root"
-        @mouseenter=${this.handleMouseEnter}
-        @mouseleave=${this.handleMouseLeave}
-        @click=${this.handleMouseClick}
-      >
+      <div class="root" @mouseenter=${this.handleMouseEnter} @mouseleave=${this.handleMouseLeave}>
         ${this.renderFlyout(person)}
       </div>
     `;
@@ -227,9 +225,15 @@ export class MgtPerson extends MgtTemplatedComponent {
     }
   }
 
-  private handleTouch(e: TouchEvent) {
+  private handleClick(e: MouseEvent) {
     if (this.isPersonCardVisible && e.target !== this) {
       this.hidePersonCard();
+    }
+  }
+
+  private handleTouch(e: TouchEvent) {
+    if (!this.isPersonCardVisible && e.target === this) {
+      this.showPersonCard();
     }
   }
 
@@ -316,14 +320,6 @@ export class MgtPerson extends MgtTemplatedComponent {
     }
 
     this.requestUpdate();
-  }
-
-  private handleMouseClick() {
-    if (this.personCardInteraction === PersonCardInteraction.click && !this.isPersonCardVisible) {
-      this.showPersonCard();
-    } else {
-      this.hidePersonCard();
-    }
   }
 
   private handleMouseEnter(e: MouseEvent) {

--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -121,7 +121,7 @@ export class MgtPerson extends MgtTemplatedComponent {
   @property({ attribute: false }) private isPersonCardVisible: boolean = false;
   @property({ attribute: false }) private personCardShouldRender: boolean = false;
 
-  @property({}) private isTouch = false;
+  private isTouch = false;
 
   private _mouseLeaveTimeout;
   private _mouseEnterTimeout;
@@ -240,7 +240,7 @@ export class MgtPerson extends MgtTemplatedComponent {
       if (this.isTouch) {
         this.isTouch = false;
       }
-    }, 50);
+    }, 400);
   }
 
   private handleTouch(e: TouchEvent) {
@@ -345,7 +345,7 @@ export class MgtPerson extends MgtTemplatedComponent {
   private handleMouseEnter(e: MouseEvent) {
     clearTimeout(this._mouseEnterTimeout);
     clearTimeout(this._mouseLeaveTimeout);
-    if (this.personCardInteraction !== PersonCardInteraction.hover || this.isTouch) {
+    if (this.personCardInteraction !== PersonCardInteraction.hover || !this.isTouch) {
       return;
     }
     this._mouseEnterTimeout = setTimeout(this.showPersonCard.bind(this), 500);

--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -199,7 +199,12 @@ export class MgtPerson extends MgtTemplatedComponent {
       `;
 
     return html`
-      <div class="root" @mouseenter=${this.handleMouseEnter} @mouseleave=${this.handleMouseLeave}>
+      <div
+        class="root"
+        @click=${this.handleMouseClick}
+        @mouseenter=${this.handleMouseEnter}
+        @mouseleave=${this.handleMouseLeave}
+      >
         ${this.renderFlyout(person)}
       </div>
     `;
@@ -226,9 +231,6 @@ export class MgtPerson extends MgtTemplatedComponent {
   }
 
   private handleClick(e: MouseEvent) {
-    if (this.personCardInteraction === PersonCardInteraction.click && !this.isPersonCardVisible) {
-      this.showPersonCard();
-    }
     if (this.isPersonCardVisible && e.target !== this) {
       this.hidePersonCard();
     }
@@ -323,6 +325,13 @@ export class MgtPerson extends MgtTemplatedComponent {
     }
 
     this.requestUpdate();
+  }
+  private handleMouseClick() {
+    if (this.personCardInteraction === PersonCardInteraction.click && !this.isPersonCardVisible) {
+      this.showPersonCard();
+    } else {
+      this.hidePersonCard();
+    }
   }
 
   private handleMouseEnter(e: MouseEvent) {


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #168 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix

### Description of the changes

Two things:

1. This was meant originally to fix the touch issue described in the issue above. After changes were made to the card hide functionality the issue no longer seemed present. 

   However,

   The person-card if in expanded view, touch events will not hide the person-card. The user previously would have to close only by touching the person icon again. The new functionality will hide the person-card if the user `touch` anywhere else *but* the card. 

2. Refactors `mgt-login`  click event was originally handled in the firstUpdated cycle. Now is attached and detached properly. 

### PR checklist
- [ ] Added tests and all passed
- [ ] All public classes and methods have been documented
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [ ] License header has been added to all new source files
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->