### PR TITLE
[people-picker] font via inheritance of css variable fixing osx issue

### DIFF
--- a/src/components/mgt-people-picker/mgt-people-picker.scss
+++ b/src/components/mgt-people-picker/mgt-people-picker.scss
@@ -47,7 +47,7 @@ mgt-people-picker .people-list {
   width: 100%;
   text-align: left;
   list-style-type: none;
-  font-family: Segoe UI;
+  font-family: var(--default-font-family, 'Segoe UI');
   font-style: normal;
   font-weight: normal;
 
@@ -70,7 +70,6 @@ mgt-people-picker .people-selected-input {
   border: none;
   line-height: normal;
   outline: none;
-  font-family: Segoe UI;
   font-style: normal;
   font-weight: normal;
   font-size: 14px;
@@ -85,7 +84,6 @@ mgt-people-picker .people-selected-list {
   margin: 0 0 0 0;
   list-style-type: none;
   padding-left: 10px;
-  font-family: Segoe UI;
   font-style: normal;
   font-weight: normal;
 }
@@ -123,7 +121,6 @@ mgt-people-picker .list-person {
   flex-wrap: wrap;
   align-items: center;
   padding: 12px;
-  font-family: Segoe UI;
   font-style: normal;
   font-weight: 600;
   font-size: 14px;
@@ -193,7 +190,6 @@ mgt-people-picker .person-display-name {
   white-space: nowrap;
   text-overflow: ellipsis;
   margin-left: 8px;
-  font-family: Segoe UI;
   font-style: normal;
   font-weight: 600;
   font-size: 14px;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #231 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

All components of people-picker use the same font. 

### PR checklist
- [ ] Added tests and all passed
- [ ] All public classes and methods have been documented
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [ ] License header has been added to all new source files
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->