### PR TITLE
Adding signed-out attribute to mgt-mock-provider (#189)

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       depends-on="mgt-teams-provider"
     ></mgt-msal-provider>
 
-    <!-- <mgt-mock-provider signed-in></mgt-mock-provider> -->
+    <mgt-mock-provider></mgt-mock-provider>
 
     <mgt-login></mgt-login>
     <mgt-person person-query="me" show-name show-email person-card="hover"></mgt-person>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       depends-on="mgt-teams-provider"
     ></mgt-msal-provider>
 
-    <mgt-mock-provider></mgt-mock-provider>
+    <!-- <mgt-mock-provider></mgt-mock-provider> -->
 
     <mgt-login></mgt-login>
     <mgt-person person-query="me" show-name show-email person-card="hover"></mgt-person>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       depends-on="mgt-teams-provider"
     ></mgt-msal-provider>
 
-    <!-- <mgt-mock-provider></mgt-mock-provider> -->
+    <!-- <mgt-mock-provider signed-in></mgt-mock-provider> -->
 
     <mgt-login></mgt-login>
     <mgt-person person-query="me" show-name show-email person-card="hover"></mgt-person>

--- a/src/mock/mgt-mock-provider.ts
+++ b/src/mock/mgt-mock-provider.ts
@@ -5,7 +5,7 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { customElement, LitElement } from 'lit-element';
+import { customElement, LitElement, property } from 'lit-element';
 import { Providers } from '../Providers';
 import { MockProvider } from './MockProvider';
 /**
@@ -17,8 +17,25 @@ import { MockProvider } from './MockProvider';
  */
 @customElement('mgt-mock-provider')
 export class MgtMockProvider extends LitElement {
+  /**
+   * A property to allow the developer to start the sample logged out if they desired.
+   *
+   * @memberof MgtMockProvider
+   */
+  @property({
+    attribute: 'signed-in',
+    type: Boolean
+  })
+  public signedIn;
+
   constructor() {
     super();
-    Providers.globalProvider = new MockProvider(true);
+
+    // Access the 'signed-in' attribute directly.
+    // LitElement doesn't parse attributes early enough for us enact on them from the constructor.
+    const signedInVal = (<any>this).getAttribute('signed-in');
+    this.signedIn = signedInVal !== 'false' && signedInVal !== null;
+
+    Providers.globalProvider = new MockProvider(this.signedIn);
   }
 }

--- a/src/mock/mgt-mock-provider.ts
+++ b/src/mock/mgt-mock-provider.ts
@@ -6,9 +6,9 @@
  */
 
 import { customElement, LitElement, property } from 'lit-element';
+import { MgtBaseProvider } from '../components/providers/baseProvider';
 import { Providers } from '../Providers';
 import { MockProvider } from './MockProvider';
-import { MgtBaseProvider } from '../components/providers/baseProvider';
 /**
  * Sets global provider to a mock Provider
  *

--- a/src/mock/mgt-mock-provider.ts
+++ b/src/mock/mgt-mock-provider.ts
@@ -8,6 +8,7 @@
 import { customElement, LitElement, property } from 'lit-element';
 import { Providers } from '../Providers';
 import { MockProvider } from './MockProvider';
+import { MgtBaseProvider } from '../components/providers/baseProvider';
 /**
  * Sets global provider to a mock Provider
  *
@@ -16,26 +17,26 @@ import { MockProvider } from './MockProvider';
  * @extends {LitElement}
  */
 @customElement('mgt-mock-provider')
-export class MgtMockProvider extends LitElement {
+export class MgtMockProvider extends MgtBaseProvider {
   /**
    * A property to allow the developer to start the sample logged out if they desired.
    *
    * @memberof MgtMockProvider
    */
   @property({
-    attribute: 'signed-in',
+    attribute: 'signed-out',
     type: Boolean
   })
-  public signedIn;
+  public signedOut;
 
-  constructor() {
-    super();
-
-    // Access the 'signed-in' attribute directly.
-    // LitElement doesn't parse attributes early enough for us enact on them from the constructor.
-    const signedInVal = (<any>this).getAttribute('signed-in');
-    this.signedIn = signedInVal !== 'false' && signedInVal !== null;
-
-    Providers.globalProvider = new MockProvider(this.signedIn);
+  /**
+   * method called to initialize the provider. Each derived class should provide
+   * their own implementation
+   *
+   * @protected
+   * @memberof MgtBaseProvider
+   */
+  protected initializeProvider() {
+    Providers.globalProvider = new MockProvider(!this.signedOut);
   }
 }


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #189 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
 - Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Adding signed-out boolean property to mock provider tag in order to pass into construction of MockProvider.
This can be useful for testing or seeing the entire user experience of both disconnected and connected from the graph.

### PR checklist
- [ ] Added tests and all passed
- [X] All public classes and methods have been documented
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [ ] License header has been added to all new source files
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
I didn't see any existing docs for mgt-mock-provider, nor did I write any.