### PR TITLE
Draft: Add component header to graph calls

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -51,13 +51,13 @@ export class Graph {
       telemetryHandler.setNext(sdkVersionMiddleware);
 
       if (component) {
-        const componentMiddleware = new CustomHeaderMiddleware(function(): Promise<object> {
-          return new Promise((resolve, reject) => {
-            if (this._forComponent) {
+        const componentMiddleware = new CustomHeaderMiddleware(
+          (): Promise<object> => {
+            return new Promise((resolve, reject) => {
               resolve({ component: component.tagName });
-            }
-          });
-        });
+            });
+          }
+        );
         sdkVersionMiddleware.setNext(componentMiddleware);
         componentMiddleware.setNext(httpMessageHandler);
       } else {

--- a/src/components/mgt-login/mgt-login.ts
+++ b/src/components/mgt-login/mgt-login.ts
@@ -7,6 +7,7 @@
 
 import { User } from '@microsoft/microsoft-graph-types';
 import { customElement, html, property } from 'lit-element';
+import { Graph } from '../../Graph';
 import { Providers } from '../../Providers';
 import { ProviderState } from '../../providers/IProvider';
 import '../../styles/fabric-icon-font';
@@ -264,7 +265,8 @@ export class MgtLogin extends MgtBaseComponent {
     if (provider) {
       this._loading = true;
       if (provider.state === ProviderState.SignedIn) {
-        const batch = provider.graph.createBatch();
+        const client = new Graph(provider, this);
+        const batch = client.createBatch();
         batch.get('me', 'me', ['user.read']);
         batch.get('photo', 'me/photo/$value', ['user.read']);
         const response = await batch.execute();

--- a/src/components/mgt-people/mgt-people.ts
+++ b/src/components/mgt-people/mgt-people.ts
@@ -7,6 +7,7 @@
 
 import * as MicrosoftGraph from '@microsoft/microsoft-graph-types';
 import { customElement, html, property } from 'lit-element';
+import { Graph } from '../../Graph';
 import { Providers } from '../../Providers';
 import { ProviderState } from '../../providers/IProvider';
 import '../../styles/fabric-icon-font';
@@ -159,7 +160,7 @@ export class MgtPeople extends MgtTemplatedComponent {
       const provider = Providers.globalProvider;
 
       if (provider && provider.state === ProviderState.SignedIn) {
-        const client = Providers.globalProvider.graph;
+        const client = new Graph(provider, this);
 
         if (this.groupId) {
           this.people = await client.getPeopleFromGroup(this.groupId);


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->
Draft
<!--Closes #--> <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
 - Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
When the toolkit components call the graph, requests should include some metadata about the calling component. 
This change adds another middleware function to the Graph class to append a component header to any outgoing requests. 
To adopt the header, components just need to create a new Graph instance and pass in the calling component, instead of using the `Providers.globalProvider.graph` instance directly.

```
// Example from mgt-people
// const client = Providers.globalProvider.graph; // old
const client = new Graph(provider, this); // new

// Use the client instance as normal
if (this.groupId) {
    this.people = await client.getPeopleFromGroup(this.groupId);
...
```

### PR checklist
- [X] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [ ] All public classes and methods have been documented
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [X] License header has been added to all new source files (`npm run setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->