### PR TITLE
Add default provider when addons are not loaded

### DIFF
--- a/.storybook/signInAddon.js
+++ b/.storybook/signInAddon.js
@@ -14,6 +14,8 @@ export const withSignIn = makeDecorator({
   wrapper: (getStory, context, { parameters }) => {
     const mockProvider = new MockProvider(true);
 
+    Providers.globalProvider = mockProvider;
+
     const channel = addons.getChannel();
 
     channel.on(SETPROVIDER_EVENT, params => {
@@ -26,8 +28,6 @@ export const withSignIn = makeDecorator({
         } else if (params.state !== ProviderState.SignedIn && currentProvider !== mockProvider) {
           Providers.globalProvider = mockProvider;
         }
-      } else {
-        Providers.globalProvider = mockProvider;
       }
     });
 


### PR DESCRIPTION
### PR Type
- Bugfix

### Description of the changes
When story is loaded inside of iframe, provider will be set as mock provider.

### PR checklist
- [X ] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [ X] All public classes and methods have been documented
- [ X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [X ] License header has been added to all new source files (`npm run setLicense`)
- [X ] Contains **NO** breaking changes


