### PR TITLE
Updated BaseGraph to always use the same client instance

### DIFF
--- a/src/BaseGraph.ts
+++ b/src/BaseGraph.ts
@@ -5,12 +5,13 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { Client, ResponseType } from '@microsoft/microsoft-graph-client';
+import { Client, GraphRequest, MiddlewareOptions, ResponseType } from '@microsoft/microsoft-graph-client';
 import * as MicrosoftGraph from '@microsoft/microsoft-graph-types';
 import * as MicrosoftGraphBeta from '@microsoft/microsoft-graph-types-beta';
-import { IProvider, prepScopes } from '.';
 import { MgtBaseComponent } from './components/baseComponent';
 import { Batch } from './utils/Batch';
+import { ComponentMiddlewareOptions } from './utils/ComponentMiddlewareOptions';
+import { prepScopes } from './utils/GraphHelpers';
 
 /**
  * The base Graph implementation.
@@ -29,21 +30,17 @@ export abstract class BaseGraph {
   public client: Client;
 
   /**
-   * a provider used for making calls
+   * name of a component for analytics
    *
    * @protected
-   * @type {IProvider}
+   * @type {string}
    * @memberof BaseGraph
    */
-  protected _provider: IProvider;
-
-  constructor(provider: IProvider) {
-    this._provider = provider;
-  }
+  protected componentName: string;
 
   /**
    * Returns a new instance of the Graph using the same
-   * provider and the provided component.
+   * client within the context of the provider.
    *
    * @param {MgtBaseComponent} component
    * @returns
@@ -52,13 +49,35 @@ export abstract class BaseGraph {
   public abstract forComponent(component: MgtBaseComponent): BaseGraph;
 
   /**
+   * Returns a new graph request for a specific component
+   * Used internally for analytics purposes
+   *
+   * @param {string} path
+   * @param {MgtBaseComponent} [component=null]
+   * @memberof Graph
+   */
+  public api(path: string): GraphRequest {
+    let request = this.client.api(path);
+    if (this.componentName) {
+      request.middlewareOptions = (options: MiddlewareOptions[]): GraphRequest => {
+        const requestObj = request as any;
+        requestObj._middlewareOptions = requestObj._middlewareOptions.concat(options);
+        return request;
+      };
+      request = request.middlewareOptions([new ComponentMiddlewareOptions(this.componentName)]);
+    }
+
+    return request;
+  }
+
+  /**
    * creates batch request
    *
    * @returns
    * @memberof BaseGraph
    */
   public createBatch() {
-    return new Batch(this.client);
+    return new Batch(this.client, this.componentName);
   }
 
   /**
@@ -68,8 +87,7 @@ export abstract class BaseGraph {
    * @memberof BaseGraph
    */
   public async getMe(): Promise<MicrosoftGraph.User> {
-    return this.client
-      .api('me')
+    return this.api('me')
       .middlewareOptions(prepScopes('user.read'))
       .get();
   }
@@ -83,8 +101,7 @@ export abstract class BaseGraph {
    */
   public async getUser(userPrincipleName: string): Promise<MicrosoftGraph.User> {
     const scopes = 'user.readbasic.all';
-    return this.client
-      .api(`/users/${userPrincipleName}`)
+    return this.api(`/users/${userPrincipleName}`)
       .middlewareOptions(prepScopes(scopes))
       .get();
   }
@@ -98,8 +115,7 @@ export abstract class BaseGraph {
    */
   public async findPerson(query: string): Promise<MicrosoftGraph.Person[]> {
     const scopes = 'people.read';
-    const result = await this.client
-      .api('/me/people')
+    const result = await this.api('/me/people')
       .search('"' + query + '"')
       .middlewareOptions(prepScopes(scopes))
       .get();
@@ -115,8 +131,7 @@ export abstract class BaseGraph {
    */
   public async findContactByEmail(email: string): Promise<MicrosoftGraph.Contact[]> {
     const scopes = 'contacts.read';
-    const result = await this.client
-      .api('/me/contacts')
+    const result = await this.api('/me/contacts')
       .filter(`emailAddresses/any(a:a/address eq '${email}')`)
       .middlewareOptions(prepScopes(scopes))
       .get();
@@ -194,8 +209,7 @@ export abstract class BaseGraph {
 
     uri += `/calendarview?${sdt}&${edt}`;
 
-    const calendarView = await this.client
-      .api(uri)
+    const calendarView = await this.api(uri)
       .middlewareOptions(prepScopes(scopes))
       .orderby('start/dateTime')
       .get();
@@ -212,8 +226,7 @@ export abstract class BaseGraph {
     const scopes = 'people.read';
 
     const uri = '/me/people';
-    const people = await this.client
-      .api(uri)
+    const people = await this.api(uri)
       .middlewareOptions(prepScopes(scopes))
       .filter("personType/class eq 'Person'")
       .get();
@@ -231,8 +244,7 @@ export abstract class BaseGraph {
     const scopes = 'people.read';
 
     const uri = `/groups/${groupId}/members`;
-    const people = await this.client
-      .api(uri)
+    const people = await this.api(uri)
       .middlewareOptions(prepScopes(scopes))
       .get();
     return people ? people.value : null;
@@ -249,8 +261,7 @@ export abstract class BaseGraph {
     const scopes = 'Group.Read.All';
 
     const uri = `/groups/${groupId}/planner/plans`;
-    const plans = await this.client
-      .api(uri)
+    const plans = await this.api(uri)
       .header('Cache-Control', 'no-store')
       .middlewareOptions(prepScopes(scopes))
       .get();
@@ -264,8 +275,7 @@ export abstract class BaseGraph {
    * @memberof BaseGraph
    */
   public async getAllMyPlannerPlans(): Promise<MicrosoftGraph.PlannerPlan[]> {
-    const plans = await this.client
-      .api('/me/planner/plans')
+    const plans = await this.api('/me/planner/plans')
       .header('Cache-Control', 'no-store')
       .middlewareOptions(prepScopes('Group.Read.All'))
       .get();
@@ -281,8 +291,7 @@ export abstract class BaseGraph {
    * @memberof BaseGraph
    */
   public async getSinglePlannerPlan(planId: string): Promise<MicrosoftGraph.PlannerPlan> {
-    const plan = await this.client
-      .api(`/planner/plans/${planId}`)
+    const plan = await this.api(`/planner/plans/${planId}`)
       .header('Cache-Control', 'no-store')
       .middlewareOptions(prepScopes('Group.Read.All'))
       .get();
@@ -298,8 +307,7 @@ export abstract class BaseGraph {
    * @memberof BaseGraph
    */
   public async getBucketsForPlannerPlan(planId: string): Promise<MicrosoftGraph.PlannerBucket[]> {
-    const buckets = await this.client
-      .api(`/planner/plans/${planId}/buckets`)
+    const buckets = await this.api(`/planner/plans/${planId}/buckets`)
       .header('Cache-Control', 'no-store')
       .middlewareOptions(prepScopes('Group.Read.All'))
       .get();
@@ -315,8 +323,7 @@ export abstract class BaseGraph {
    * @memberof BaseGraph
    */
   public async getTasksForPlannerBucket(bucketId: string): Promise<MicrosoftGraph.PlannerTask[]> {
-    const tasks = await this.client
-      .api(`/planner/buckets/${bucketId}/tasks`)
+    const tasks = await this.api(`/planner/buckets/${bucketId}/tasks`)
       .header('Cache-Control', 'no-store')
       .middlewareOptions(prepScopes('Group.Read.All'))
       .get();
@@ -334,8 +341,7 @@ export abstract class BaseGraph {
    * @memberof BaseGraph
    */
   public async setPlannerTaskDetails(taskId: string, details: MicrosoftGraph.PlannerTask, eTag: string): Promise<any> {
-    return await this.client
-      .api(`/planner/tasks/${taskId}`)
+    return await this.api(`/planner/tasks/${taskId}`)
       .header('Cache-Control', 'no-store')
       .middlewareOptions(prepScopes('Group.ReadWrite.All'))
       .header('If-Match', eTag)
@@ -405,8 +411,7 @@ export abstract class BaseGraph {
    * @memberof BaseGraph
    */
   public async addPlannerTask(newTask: MicrosoftGraph.PlannerTask): Promise<any> {
-    return this.client
-      .api('/planner/tasks')
+    return this.api('/planner/tasks')
       .header('Cache-Control', 'no-store')
       .middlewareOptions(prepScopes('Group.ReadWrite.All'))
       .post(newTask);
@@ -421,8 +426,7 @@ export abstract class BaseGraph {
    * @memberof BaseGraph
    */
   public async removePlannerTask(taskId: string, eTag: string): Promise<any> {
-    return this.client
-      .api(`/planner/tasks/${taskId}`)
+    return this.api(`/planner/tasks/${taskId}`)
       .header('Cache-Control', 'no-store')
       .header('If-Match', eTag)
       .middlewareOptions(prepScopes('Group.ReadWrite.All'))
@@ -438,8 +442,7 @@ export abstract class BaseGraph {
    * @memberof BaseGraph
    */
   public async getAllMyTodoGroups(): Promise<MicrosoftGraphBeta.OutlookTaskGroup[]> {
-    const groups = await this.client
-      .api('/me/outlook/taskGroups')
+    const groups = await this.api('/me/outlook/taskGroups')
       .header('Cache-Control', 'no-store')
       .version('beta')
       .middlewareOptions(prepScopes('Tasks.Read'))
@@ -456,8 +459,7 @@ export abstract class BaseGraph {
    * @memberof BaseGraph
    */
   public async getSingleTodoGroup(groupId: string): Promise<MicrosoftGraphBeta.OutlookTaskGroup> {
-    const group = await this.client
-      .api(`/me/outlook/taskGroups/${groupId}`)
+    const group = await this.api(`/me/outlook/taskGroups/${groupId}`)
       .header('Cache-Control', 'no-store')
       .version('beta')
       .middlewareOptions(prepScopes('Tasks.Read'))
@@ -474,8 +476,7 @@ export abstract class BaseGraph {
    * @memberof BaseGraph
    */
   public async getFoldersForTodoGroup(groupId: string): Promise<MicrosoftGraphBeta.OutlookTaskFolder[]> {
-    const folders = await this.client
-      .api(`/me/outlook/taskGroups/${groupId}/taskFolders`)
+    const folders = await this.api(`/me/outlook/taskGroups/${groupId}/taskFolders`)
       .header('Cache-Control', 'no-store')
       .version('beta')
       .middlewareOptions(prepScopes('Tasks.Read'))
@@ -492,8 +493,7 @@ export abstract class BaseGraph {
    * @memberof BaseGraph
    */
   public async getAllTodoTasksForFolder(folderId: string): Promise<MicrosoftGraphBeta.OutlookTask[]> {
-    const tasks = await this.client
-      .api(`/me/outlook/taskFolders/${folderId}/tasks`)
+    const tasks = await this.api(`/me/outlook/taskFolders/${folderId}/tasks`)
       .header('Cache-Control', 'no-store')
       .version('beta')
       .middlewareOptions(prepScopes('Tasks.Read'))
@@ -512,8 +512,7 @@ export abstract class BaseGraph {
    * @memberof BaseGraph
    */
   public async setTodoTaskDetails(taskId: string, task: any, eTag: string): Promise<MicrosoftGraphBeta.OutlookTask> {
-    return await this.client
-      .api(`/me/outlook/tasks/${taskId}`)
+    return await this.api(`/me/outlook/tasks/${taskId}`)
       .header('Cache-Control', 'no-store')
       .version('beta')
       .header('If-Match', eTag)
@@ -570,15 +569,13 @@ export abstract class BaseGraph {
     const { parentFolderId = null } = newTask;
 
     if (parentFolderId) {
-      return await this.client
-        .api(`/me/outlook/taskFolders/${parentFolderId}/tasks`)
+      return await this.api(`/me/outlook/taskFolders/${parentFolderId}/tasks`)
         .header('Cache-Control', 'no-store')
         .version('beta')
         .middlewareOptions(prepScopes('Tasks.ReadWrite'))
         .post(newTask);
     } else {
-      return await this.client
-        .api('/me/outlook/tasks')
+      return await this.api('/me/outlook/tasks')
         .header('Cache-Control', 'no-store')
         .version('beta')
         .middlewareOptions(prepScopes('Tasks.ReadWrite'))
@@ -595,8 +592,7 @@ export abstract class BaseGraph {
    * @memberof BaseGraph
    */
   public async removeTodoTask(taskId: string, eTag: string): Promise<any> {
-    return await this.client
-      .api(`/me/outlook/tasks/${taskId}`)
+    return await this.api(`/me/outlook/tasks/${taskId}`)
       .header('Cache-Control', 'no-store')
       .version('beta')
       .header('If-Match', eTag)
@@ -617,8 +613,7 @@ export abstract class BaseGraph {
 
   private async getPhotoForResource(resource: string, scopes: string[]): Promise<string> {
     try {
-      const blob = await this.client
-        .api(`${resource}/photo/$value`)
+      const blob = await this.api(`${resource}/photo/$value`)
         .version('beta')
         .responseType(ResponseType.BLOB)
         .middlewareOptions(prepScopes(...scopes))

--- a/src/BaseGraph.ts
+++ b/src/BaseGraph.ts
@@ -5,7 +5,7 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { Client, GraphRequest, MiddlewareOptions, ResponseType } from '@microsoft/microsoft-graph-client';
+import { Client, GraphRequest, Middleware, MiddlewareOptions, ResponseType } from '@microsoft/microsoft-graph-client';
 import * as MicrosoftGraph from '@microsoft/microsoft-graph-types';
 import * as MicrosoftGraphBeta from '@microsoft/microsoft-graph-types-beta';
 import { MgtBaseComponent } from './components/baseComponent';
@@ -598,6 +598,27 @@ export abstract class BaseGraph {
       .header('If-Match', eTag)
       .middlewareOptions(prepScopes('Tasks.ReadWrite'))
       .delete();
+  }
+
+  /**
+   * Helper method to chain Middleware when instantiating new Client
+   *
+   * @protected
+   * @param {...Middleware[]} middleware
+   * @returns {Middleware}
+   * @memberof BaseGraph
+   */
+  protected chainMiddleware(...middleware: Middleware[]): Middleware {
+    const rootMiddleware = middleware[0];
+    let current = rootMiddleware;
+    for (let i = 1; i < middleware.length; ++i) {
+      const next = middleware[i];
+      if (current.setNext) {
+        current.setNext(next);
+      }
+      current = next;
+    }
+    return rootMiddleware;
   }
 
   private blobToBase64(blob: Blob): Promise<string> {

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -62,17 +62,4 @@ export class Graph extends BaseGraph {
     graph.componentName = component.tagName.toLowerCase();
     return graph;
   }
-
-  private chainMiddleware(...middleware: Middleware[]): Middleware {
-    const rootMiddleware = middleware[0];
-    let current = rootMiddleware;
-    for (let i = 1; i < middleware.length; ++i) {
-      const next = middleware[i];
-      if (current.setNext) {
-        current.setNext(next);
-      }
-      current = next;
-    }
-    return rootMiddleware;
-  }
 }

--- a/src/components/mgt-agenda/mgt-agenda.ts
+++ b/src/components/mgt-agenda/mgt-agenda.ts
@@ -206,6 +206,7 @@ export class MgtAgenda extends MgtTemplatedComponent {
     const p = Providers.globalProvider;
     if (p && p.state === ProviderState.SignedIn) {
       this._loading = true;
+      const graph = p.graph.forComponent(this);
 
       if (this.eventQuery) {
         try {
@@ -219,8 +220,7 @@ export class MgtAgenda extends MgtTemplatedComponent {
             query = this.eventQuery;
           }
 
-          const graph = p.graph.forComponent(this);
-          let request = await graph.client.api(query);
+          let request = await graph.api(query);
 
           if (scope) {
             request = request.middlewareOptions(prepScopes(scope));
@@ -239,7 +239,7 @@ export class MgtAgenda extends MgtTemplatedComponent {
         const end = new Date(start.getTime());
         end.setDate(start.getDate() + this.days);
         try {
-          this.events = await p.graph.getEvents(start, end, this.groupId);
+          this.events = await graph.getEvents(start, end, this.groupId);
         } catch (error) {
           // noop - possible error with graph
         }

--- a/src/components/mgt-get/mgt-get.ts
+++ b/src/components/mgt-get/mgt-get.ts
@@ -153,7 +153,7 @@ export class MgtGet extends MgtTemplatedComponent {
       let response = null;
       try {
         const graph = provider.graph.forComponent(this);
-        let request = graph.client.api(this.resource).version(this.version);
+        let request = graph.api(this.resource).version(this.version);
 
         if (this.scopes && this.scopes.length) {
           request = request.middlewareOptions(prepScopes(...this.scopes));

--- a/src/components/mgt-login/mgt-login.ts
+++ b/src/components/mgt-login/mgt-login.ts
@@ -264,8 +264,7 @@ export class MgtLogin extends MgtBaseComponent {
     if (provider) {
       this._loading = true;
       if (provider.state === ProviderState.SignedIn) {
-        const graph = provider.graph.forComponent(this);
-        const batch = graph.createBatch();
+        const batch = provider.graph.forComponent(this).createBatch();
         batch.get('me', 'me', ['user.read']);
         batch.get('photo', 'me/photo/$value', ['user.read']);
         const response = await batch.execute();

--- a/src/mock/MockGraph.ts
+++ b/src/mock/MockGraph.ts
@@ -90,11 +90,10 @@ class MockMiddleware implements Middleware {
       const url = context.request as string;
       const baseLength = BASE_URL.length;
       context.request = url.substring(0, baseLength) + escape(url.substring(baseLength));
-
-      return await this._nextMiddleware.execute(context);
     } catch (error) {
-      throw error;
+      // ignore error
     }
+    return await this._nextMiddleware.execute(context);
   }
   /**
    * Handles setting of next middleware

--- a/src/mock/MockGraph.ts
+++ b/src/mock/MockGraph.ts
@@ -24,7 +24,7 @@ export class MockGraph extends BaseGraph {
   private static readonly ROOT_GRAPH_URL: string = 'https://graph.microsoft.com/';
 
   constructor(mockProvider: MockProvider) {
-    super(mockProvider);
+    super();
 
     this.client = Client.initWithMiddleware({
       authProvider: mockProvider,

--- a/src/utils/ComponentMiddlewareOptions.ts
+++ b/src/utils/ComponentMiddlewareOptions.ts
@@ -1,0 +1,34 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
+import { MiddlewareOptions } from '@microsoft/microsoft-graph-client';
+import { MgtBaseComponent } from '../components/baseComponent';
+
+/**
+ * Middleware Options used for component telemetry
+ *
+ * @export
+ * @class ComponentMiddlewareOptions
+ * @implements {MiddlewareOptions}
+ */
+export class ComponentMiddlewareOptions implements MiddlewareOptions {
+  /**
+   * The name of the component
+   *
+   * @type {string}
+   * @memberof ComponentMiddlewareOptions
+   */
+  public componentName: string;
+
+  constructor(component: MgtBaseComponent | string) {
+    if (typeof component === 'string') {
+      this.componentName = component;
+    } else {
+      this.componentName = component.tagName.toLowerCase();
+    }
+  }
+}

--- a/src/utils/SdkVersionMiddleware.ts
+++ b/src/utils/SdkVersionMiddleware.ts
@@ -49,11 +49,10 @@ export class SdkVersionMiddleware implements Middleware {
       // Join the header parts together and update the SdkVersion request header value
       const sdkVersionHeaderValue = headerParts.join(', ');
       setRequestHeader(context.request, context.options, 'SdkVersion', sdkVersionHeaderValue);
-
-      return await this._nextMiddleware.execute(context);
     } catch (error) {
-      throw error;
+      // ignore error
     }
+    return await this._nextMiddleware.execute(context);
   }
   /**
    * Handles setting of next middleware

--- a/src/utils/SdkVersionMiddleware.ts
+++ b/src/utils/SdkVersionMiddleware.ts
@@ -7,7 +7,7 @@
 
 import { Context, Middleware } from '@microsoft/microsoft-graph-client';
 import { getRequestHeader, setRequestHeader } from '@microsoft/microsoft-graph-client/lib/es/middleware/MiddlewareUtil';
-import { MgtBaseComponent } from '../components/baseComponent';
+import { ComponentMiddlewareOptions } from './ComponentMiddlewareOptions';
 import { PACKAGE_VERSION } from './version';
 
 /**
@@ -23,11 +23,6 @@ export class SdkVersionMiddleware implements Middleware {
    * A member to hold next middleware in the middleware chain
    */
   private _nextMiddleware: Middleware;
-  private _component?: MgtBaseComponent;
-
-  constructor(component?: MgtBaseComponent) {
-    this._component = component;
-  }
 
   // tslint:disable-next-line: completed-docs
   public async execute(context: Context): Promise<void> {
@@ -35,10 +30,12 @@ export class SdkVersionMiddleware implements Middleware {
       // Header parts must follow the format: 'name/version'
       const headerParts: string[] = [];
 
-      // Component version
-      if (this._component) {
-        const componentTagName = this._component.tagName.toLowerCase();
-        const componentVersion: string = `${componentTagName}/${PACKAGE_VERSION}`;
+      const componentOptions = context.middlewareControl.getMiddlewareOptions(
+        ComponentMiddlewareOptions
+      ) as ComponentMiddlewareOptions;
+
+      if (componentOptions) {
+        const componentVersion: string = `${componentOptions.componentName}/${PACKAGE_VERSION}`;
         headerParts.push(componentVersion);
       }
 


### PR DESCRIPTION

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This PR fixes an issue where a new graph client object was instantiated for each call made by a component. This caused issues with throttling since there is not one client to keep track of all requests. 

With these changes, the `Graph.forComponent` method still returns a new instance of Graph, but the graph client instance stays the same. 

To allow the header of each request to include the name of the component, a new `BaseGraph.api()` method was created that should be used internaly instead of `client.api()`. This method acts the same as `client.api()` with the exception that it injects the name of the component in the request by using a middleware option for each request.

In addition to the above change, this PR also updates the MockProvider to automatically escape the request url to avoid overwriting any methods that use query parameters. 

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes
