### PR TITLE
fixed issue where mgt-people was not updating when user-ids changed

### DIFF
--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -311,7 +311,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       });
 
       if (duplicatePeople.length === 0) {
-        this.selectedPeople.push(person);
+        this.selectedPeople = [...this.selectedPeople, person];
         this.fireCustomEvent('selectionChanged', this.selectedPeople);
 
         this.people = [];

--- a/src/components/mgt-people/mgt-people.ts
+++ b/src/components/mgt-people/mgt-people.ts
@@ -7,8 +7,9 @@
 
 import * as MicrosoftGraph from '@microsoft/microsoft-graph-types';
 import { customElement, html, property } from 'lit-element';
+import { repeat } from 'lit-html/directives/repeat';
 import { getPeople, getPeopleFromGroup } from '../../graph/graph.people';
-import { getUser } from '../../graph/graph.user';
+import { getUsersForUserIds } from '../../graph/graph.user';
 import { Providers } from '../../Providers';
 import { ProviderState } from '../../providers/IProvider';
 import '../../styles/fabric-icon-font';
@@ -78,7 +79,15 @@ export class MgtPeople extends MgtTemplatedComponent {
       return value.split(',');
     }
   })
-  public userIds: string[];
+  public get userIds(): string[] {
+    return this.privateUserIds;
+  }
+  public set userIds(value: string[]) {
+    const oldValue = this.userIds;
+    this.privateUserIds = value;
+    this.updateUserIds(value);
+    this.requestUpdate('userIds', oldValue);
+  }
 
   /**
    * Sets how the person-card is invoked
@@ -100,7 +109,9 @@ export class MgtPeople extends MgtTemplatedComponent {
   })
   public personCardInteraction: PersonCardInteraction = PersonCardInteraction.hover;
 
-  private _firstUpdated = false;
+  private hasFirstUpdated = false;
+  private hasLoaded = false;
+  private privateUserIds: string[];
 
   constructor() {
     super();
@@ -118,7 +129,7 @@ export class MgtPeople extends MgtTemplatedComponent {
    * * @param _changedProperties Map of changed properties with old values
    */
   protected firstUpdated() {
-    this._firstUpdated = true;
+    this.hasFirstUpdated = true;
     Providers.onProviderUpdated(() => this.loadPeople());
     this.loadPeople();
   }
@@ -135,13 +146,14 @@ export class MgtPeople extends MgtTemplatedComponent {
         this.renderTemplate('default', { people: this.people }) ||
         html`
           <ul class="people-list">
-            ${this.people.slice(0, this.showMax).map(
-              person =>
-                html`
-                  <li class="people-person">
-                    ${this.renderTemplate('person', { person }, person.displayName) || this.renderPerson(person)}
-                  </li>
-                `
+            ${repeat(
+              this.people.slice(0, this.showMax),
+              p => p.id,
+              p => html`
+                <li class="people-person">
+                  ${this.renderTemplate('person', { person: p }, p.id) || this.renderPerson(p)}
+                </li>
+              `
             )}
             ${this.people.length > this.showMax
               ? this.renderTemplate('overflow', {
@@ -162,7 +174,7 @@ export class MgtPeople extends MgtTemplatedComponent {
   }
 
   private async loadPeople() {
-    if (!this._firstUpdated) {
+    if (!this.hasFirstUpdated) {
       return;
     }
 
@@ -175,15 +187,43 @@ export class MgtPeople extends MgtTemplatedComponent {
         if (this.groupId) {
           this.people = await getPeopleFromGroup(graph, this.groupId);
         } else if (this.userIds) {
-          this.people = await Promise.all(
-            this.userIds.map(async userId => {
-              return await getUser(graph, userId);
-            })
-          );
+          this.people = await getUsersForUserIds(graph, this.userIds);
         } else {
           this.people = await getPeople(graph);
         }
       }
+    }
+
+    this.hasLoaded = true;
+  }
+
+  private async updateUserIds(newIds: string[]) {
+    if (!this.hasLoaded) {
+      return;
+    }
+
+    const newIdsSet = new Set(newIds);
+    this.people = this.people.filter(p => newIdsSet.has(p.id));
+    const oldIdsSet = new Set(this.people ? this.people.map(p => p.id) : []);
+
+    const newToLoad = [];
+
+    for (const id of newIds) {
+      if (!oldIdsSet.has(id)) {
+        newToLoad.push(id);
+      }
+    }
+
+    if (newToLoad && newToLoad.length > 0) {
+      const provider = Providers.globalProvider;
+      if (!provider || provider.state !== ProviderState.SignedIn) {
+        return;
+      }
+
+      const graph = provider.graph.forComponent(this);
+
+      const newPeople = await getUsersForUserIds(graph, newToLoad);
+      this.people = (this.people || []).concat(newPeople);
     }
   }
 


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #310 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This PR fixes #310 

As part of this:
* Ensured the current list of people get updated minimally by not fetching users already loaded in people
* Ensured constantly updating user-ids attribute keeps the list in order and elements are loaded properly
* All users are now also loaded using the batch API in one call


### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Contains **NO** breaking changes

### Other information
While working on this issue, I discovered and fixed an issue affecting how mgt-people-picker and mgt-people work together.

This code:

```js
picker.addEventListener('selectionChanged', e => {
  people.people = picker.selectedPeople;
});
```

was not working as expected because when selecting additional people in people picker, a person was appended to the selectedPeople array. Since the reference of the array never changed, the people component doesn't know the array changed, and observability is broken. By ensuring a new array is created when selecting people, it keeps the property observable.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoftgraph/microsoft-graph-toolkit/pull/311)