### PR TITLE
Restructured render methods in mgt-people

### DIFF
--- a/src/components/mgt-people/mgt-people.ts
+++ b/src/components/mgt-people/mgt-people.ts
@@ -6,7 +6,7 @@
  */
 
 import * as MicrosoftGraph from '@microsoft/microsoft-graph-types';
-import { customElement, html, property } from 'lit-element';
+import { customElement, html, property, TemplateResult } from 'lit-element';
 import { repeat } from 'lit-html/directives/repeat';
 import { getPeople, getPeopleFromGroup } from '../../graph/graph.people';
 import { getUsersForUserIds } from '../../graph/graph.user';
@@ -109,8 +109,9 @@ export class MgtPeople extends MgtTemplatedComponent {
   })
   public personCardInteraction: PersonCardInteraction = PersonCardInteraction.hover;
 
-  private hasFirstUpdated = false;
+  @property()
   private hasLoaded = false;
+  private hasFirstUpdated = false;
   private privateUserIds: string[];
 
   constructor() {
@@ -139,38 +140,108 @@ export class MgtPeople extends MgtTemplatedComponent {
    * a lit-html TemplateResult. Setting properties inside this method will *not*
    * trigger the element to update.
    */
-
   protected render() {
-    if (this.people && this.people.length) {
-      return (
-        this.renderTemplate('default', { people: this.people }) ||
-        html`
-          <ul class="people-list">
-            ${repeat(
-              this.people.slice(0, this.showMax),
-              p => p.id,
-              p => html`
-                <li class="people-person">
-                  ${this.renderTemplate('person', { person: p }, p.id) || this.renderPerson(p)}
-                </li>
-              `
-            )}
-            ${this.people.length > this.showMax
-              ? this.renderTemplate('overflow', {
-                  extra: this.people.length - this.showMax,
-                  max: this.showMax,
-                  people: this.people
-                }) ||
-                html`
-                    <li class="overflow"><span>+${this.people.length - this.showMax}<span></li>
-                  `
-              : null}
-          </ul>
-        `
-      );
-    } else {
-      return this.renderTemplate('no-data', null) || html``;
+    if (!this.hasLoaded) {
+      return this.renderLoading();
     }
+
+    if (!this.people || this.people.length === 0) {
+      return this.renderNoData();
+    }
+
+    return this.renderTemplate('default', { people: this.people, max: this.showMax }) || this.renderPeople();
+  }
+
+  /**
+   * Render the loading state.
+   *
+   * @protected
+   * @returns
+   * @memberof MgtPeople
+   */
+  protected renderLoading() {
+    return this.renderTemplate('loading', null) || html``;
+  }
+
+  /**
+   * Render the list of people.
+   *
+   * @protected
+   * @param {*} people
+   * @returns {TemplateResult}
+   * @memberof MgtPeople
+   */
+  protected renderPeople(): TemplateResult {
+    const maxPeople = this.people.slice(0, this.showMax);
+
+    return html`
+      <ul class="people-list">
+        ${repeat(
+          maxPeople,
+          p => p.id,
+          p => html`
+            <li class="people-person">
+              ${this.renderPerson(p)}
+            </li>
+          `
+        )}
+        ${this.people.length > this.showMax ? this.renderOverflow() : null}
+      </ul>
+    `;
+  }
+
+  /**
+   * Render the overflow content to represent any extra people, beyond the max.
+   *
+   * @protected
+   * @returns {TemplateResult}
+   * @memberof MgtPeople
+   */
+  protected renderOverflow(): TemplateResult {
+    const extra = this.people.length - this.showMax;
+    return (
+      this.renderTemplate('overflow', {
+        extra,
+        max: this.showMax,
+        people: this.people
+      }) ||
+      html`
+        <li class="overflow"><span>+${extra}<span></li>
+      `
+    );
+  }
+
+  /**
+   * Render an individual person.
+   *
+   * @protected
+   * @returns {TemplateResult}
+   * @memberof MgtPeople
+   */
+  protected renderPerson(person: MicrosoftGraph.User | MicrosoftGraph.Person | MicrosoftGraph.Contact): TemplateResult {
+    return (
+      this.renderTemplate('person', { person }, person.id) ||
+      // set image to @ to flag the mgt-person component to
+      // query the image from the graph
+      html`
+        <mgt-person
+          .personDetails=${person}
+          .personImage=${'@'}
+          .personCardInteraction=${this.personCardInteraction}
+        ></mgt-person>
+      `
+    );
+  }
+
+  /**
+   * render the no data state.
+   *
+   * @protected
+   * @returns {TemplateResult}
+   * @memberof MgtPeople
+   */
+  protected renderNoData(): TemplateResult {
+    return this.renderTemplate('no-data', null) || html``;
   }
 
   private async loadPeople() {
@@ -225,17 +296,5 @@ export class MgtPeople extends MgtTemplatedComponent {
       const newPeople = await getUsersForUserIds(graph, newToLoad);
       this.people = (this.people || []).concat(newPeople);
     }
-  }
-
-  private renderPerson(person: MicrosoftGraph.Person) {
-    // set image to @ to flag the mgt-person component to
-    // query the image from the graph
-    return html`
-      <mgt-person
-        .personDetails=${person}
-        .personImage=${'@'}
-        .personCardInteraction=${this.personCardInteraction}
-      ></mgt-person>
-    `;
   }
 }


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Contributes to #267 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

New render methods for `mgt-people`:
- `render()`
  - `renderLoading()` - Render the loading state.
  - `renderNoData()` - Render the no data state.
  - `renderPeople()` - Render the list of people using `renderPerson` and calls `renderOverflow` if necessary.
    - `renderPerson(person)` - Render an individual person.
  - `renderOverflow()` - Render the overflow content to represent any extra people, beyond the max.

Supported templates:
- `loading` - (*NEW*) Used while the component is loading state
- `no-data`
- `default`
- `person`
- `overflow`

All of the methods operate using public/protected props (except `renderPerson`) so I decided not to pass the values around, but I could be convinced otherwise. 

### PR checklist
- [X] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [X] All public classes and methods have been documented
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [X] License header has been added to all new source files (`npm run setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->

Docs:
https://github.com/microsoftgraph/microsoft-graph-docs/pull/7332

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoftgraph/microsoft-graph-toolkit/pull/314)