### PR TITLE
Fix Storybook iframe embed with extra scroll

### DIFF
--- a/.storybook/addons/codeEditorAddon/codeAddon.js
+++ b/.storybook/addons/codeEditorAddon/codeAddon.js
@@ -62,6 +62,7 @@ export const withCodeEditor = makeDecorator({
 
     let storyHtml;
     const root = document.createElement('div');
+    let storyElementWrapper = document.createElement('div');
     let storyElement;
 
     if (story.strings) {
@@ -98,14 +99,16 @@ export const withCodeEditor = makeDecorator({
 
     const separator = document.createElement('div');
 
-    setupEditorResize(storyElement, separator, editor, () => editor.layout());
+    setupEditorResize(storyElementWrapper, separator, editor, () => editor.layout());
 
     root.className = 'story-mgt-root';
+    storyElementWrapper.className = 'story-mgt-preview-wrapper';
     storyElement.className = 'story-mgt-preview';
     separator.className = 'story-mgt-separator';
     editor.className = 'story-mgt-editor';
 
-    root.appendChild(storyElement);
+    root.appendChild(storyElementWrapper);
+    storyElementWrapper.appendChild(storyElement);
     root.appendChild(separator);
     root.appendChild(editor);
 

--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -17,16 +17,16 @@
   }
 
   .story-mgt-preview {
+    margin: 0.5em;
+  }
+
+  .story-mgt-preview-wrapper {
     position: relative;
     height: 100%;
-    width: calc(50% - 1em);
+    width: 50%;
     float: left;
     overflow: auto;
     background-color: #ffffff;
-  }
-
-  .story-mgt-preview:first-child {
-    margin: 0.5em;
   }
 
   .story-mgt-editor {
@@ -61,8 +61,8 @@
   }
 
   @media (max-width: 768px) {
-    .story-mgt-preview {
-      height: calc(50% - 1em);
+    .story-mgt-preview-wrapper {
+      height: 50%;
       width: 100%;
     }
 
@@ -74,7 +74,7 @@
     .story-mgt-separator {
       cursor: ns-resize;
       width: 100%;
-      height: 1px;
+      height: 0px;
     }
 
     .story-mgt-separator:after {


### PR DESCRIPTION
Closes #308 

### PR Type
- Bugfix 

### Description of the changes
Add wrapper to have preview area own its margin

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [ ] All public classes and methods have been documented
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoftgraph/microsoft-graph-toolkit/pull/317)