### PR TITLE
Fix person card default font family

### DIFF
--- a/src/components/mgt-person-card/mgt-person-card.scss
+++ b/src/components/mgt-person-card/mgt-person-card.scss
@@ -15,7 +15,7 @@ $color: var(--color, #{$ms-color-neutralDark});
   width: 340px;
   background: #ffffff;
   box-shadow: 0px 0px 4.55172px rgba(0, 0, 0, 0.16);
-  font-family: var(--default-font-family);
+  font-family: var(--default-font-family, 'Segoe UI');
 
   .default-view {
     display: flex;

--- a/src/components/mgt-person-card/mgt-person-card.scss
+++ b/src/components/mgt-person-card/mgt-person-card.scss
@@ -4,6 +4,8 @@
  * See License in the project root for license information.
  * -------------------------------------------------------------------------------------------
  */
+
+@import '../../styles/shared-styles.scss';
 @import '../../../node_modules/office-ui-fabric-core/dist/sass/References';
 
 $font-size: var(--font-size, #{$ms-font-size-m});
@@ -15,7 +17,7 @@ $color: var(--color, #{$ms-color-neutralDark});
   width: 340px;
   background: #ffffff;
   box-shadow: 0px 0px 4.55172px rgba(0, 0, 0, 0.16);
-  font-family: var(--default-font-family, 'Segoe UI');
+  font-family: var(--default-font-family);
 
   .default-view {
     display: flex;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #323 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

This fixes the issue where `mgt-person-card` displays the incorrect font when used as a standalone component. 

### PR checklist
- [X] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [X] All public classes and methods have been documented
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [X] License header has been added to all new source files (`npm run setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->

Test with the following code:
```
<mgt-person person-query="me"></mgt-person>
<mgt-person-card></mgt-person-card>
<script>
  const person = document.querySelector('mgt-person');
  const personCard = document.querySelector('mgt-person-card');
  person.addEventListener('loadingCompleted', () => {
    personCard.personDetails = person.personDetails;
  });
</script>
```