### PR TITLE
Fixed mgt-agenda days not working and added support for paging

### DIFF
--- a/src/components/mgt-agenda/mgt-agenda.graph.ts
+++ b/src/components/mgt-agenda/mgt-agenda.graph.ts
@@ -8,9 +8,10 @@
 import * as MicrosoftGraph from '@microsoft/microsoft-graph-types';
 import { IGraph } from '../../IGraph';
 import { prepScopes } from '../../utils/GraphHelpers';
+import { GraphPageIterator } from '../../utils/GraphPageIterator';
 
 /**
- * async promise, returns Calender events associated with either the logged in user or a specific groupId
+ * returns Calender events iterator associated with either the logged in user or a specific groupId
  *
  * @param {Date} startDateTime
  * @param {Date} endDateTime
@@ -18,12 +19,12 @@ import { prepScopes } from '../../utils/GraphHelpers';
  * @returns {(Promise<Event[]>)}
  * @memberof Graph
  */
-export async function getEvents(
+export function getEventsPageIterator(
   graph: IGraph,
   startDateTime: Date,
   endDateTime: Date,
   groupId?: string
-): Promise<MicrosoftGraph.Event[]> {
+): Promise<GraphPageIterator<MicrosoftGraph.Event>> {
   const scopes = 'calendars.read';
 
   const sdt = `startdatetime=${startDateTime.toISOString()}`;
@@ -39,10 +40,10 @@ export async function getEvents(
 
   uri += `/calendarview?${sdt}&${edt}`;
 
-  const calendarView = await graph
+  const request = graph
     .api(uri)
     .middlewareOptions(prepScopes(scopes))
-    .orderby('start/dateTime')
-    .get();
-  return calendarView ? calendarView.value : null;
+    .orderby('start/dateTime');
+
+  return GraphPageIterator.create<MicrosoftGraph.Event>(graph, request);
 }

--- a/src/components/mgt-agenda/mgt-agenda.ts
+++ b/src/components/mgt-agenda/mgt-agenda.ts
@@ -50,35 +50,44 @@ export class MgtAgenda extends MgtTemplatedComponent {
   }
 
   /**
-   * array containing events from user agenda.
-   * @type {Array<MicrosoftGraph.Event>}
-   */
-  @property({
-    attribute: 'events'
-  })
-  public events: MicrosoftGraph.Event[];
-
-  /**
-   * allows developer to define agenda to group events by day.
-   * @type {Boolean}
-   */
-  @property({
-    attribute: 'group-by-day',
-    reflect: true,
-    type: Boolean
-  })
-  public groupByDay: boolean;
-
-  /**
    * stores current date for initial calender selection in events.
    * @type {string}
    */
   @property({
     attribute: 'date',
-    reflect: true,
     type: String
   })
-  public date: string;
+  public get date(): string {
+    return this._date;
+  }
+  public set date(value) {
+    if (this._date === value) {
+      return;
+    }
+
+    this._date = value;
+    this.requestStateUpdate(true);
+  }
+
+  /**
+   * determines if agenda events come from specific group
+   * @type {string}
+   */
+  @property({
+    attribute: 'group-id',
+    type: String
+  })
+  public get groupId(): string {
+    return this._groupId;
+  }
+  public set groupId(value) {
+    if (this._groupId === value) {
+      return;
+    }
+
+    this._groupId = value;
+    this.requestStateUpdate(true);
+  }
 
   /**
    * sets number of days until end date, 3 is the default
@@ -86,10 +95,19 @@ export class MgtAgenda extends MgtTemplatedComponent {
    */
   @property({
     attribute: 'days',
-    reflect: true,
     type: Number
   })
-  public days: number;
+  public get days(): number {
+    return this._days;
+  }
+  public set days(value) {
+    if (this._days === value) {
+      return;
+    }
+
+    this._days = value;
+    this.requestStateUpdate(true);
+  }
 
   /**
    * allows developer to specify a different graph query that retrieves events
@@ -99,7 +117,26 @@ export class MgtAgenda extends MgtTemplatedComponent {
     attribute: 'event-query',
     type: String
   })
-  public eventQuery: string;
+  public get eventQuery(): string {
+    return this._eventQuery;
+  }
+  public set eventQuery(value) {
+    if (this._eventQuery === value) {
+      return;
+    }
+
+    this._eventQuery = value;
+    this.requestStateUpdate(true);
+  }
+
+  /**
+   * array containing events from user agenda.
+   * @type {Array<MicrosoftGraph.Event>}
+   */
+  @property({
+    attribute: 'events'
+  })
+  public events: MicrosoftGraph.Event[];
 
   /**
    * allows developer to define max number of events shown
@@ -112,14 +149,14 @@ export class MgtAgenda extends MgtTemplatedComponent {
   public showMax: number;
 
   /**
-   * determines if agenda events come from specific group
-   * @type {string}
+   * allows developer to define agenda to group events by day.
+   * @type {Boolean}
    */
   @property({
-    attribute: 'group-id',
-    type: String
+    attribute: 'group-by-day',
+    type: Boolean
   })
-  public groupId: string;
+  public groupByDay: boolean;
 
   /**
    * determines width available for agenda component.
@@ -127,9 +164,13 @@ export class MgtAgenda extends MgtTemplatedComponent {
    */
   @property({ attribute: false }) private _isNarrow: boolean;
 
+  private _eventQuery: string;
+  private _days: number = 3;
+  private _groupId: string;
+  private _date: string;
+
   constructor() {
     super();
-    this.days = 3;
     this.onResize = this.onResize.bind(this);
   }
 
@@ -152,22 +193,6 @@ export class MgtAgenda extends MgtTemplatedComponent {
   public disconnectedCallback() {
     window.removeEventListener('resize', this.onResize);
     super.disconnectedCallback();
-  }
-
-  /**
-   * Synchronizes property values when attributes change.
-   *
-   * @param {*} name
-   * @param {*} oldValue
-   * @param {*} newValue
-   * @memberof MgtAgenda
-   */
-  public attributeChangedCallback(name, oldValue, newValue) {
-    if (oldValue !== newValue && (name === 'date' || name === 'days' || name === 'group-id')) {
-      this.events = null;
-      this.requestStateUpdate();
-    }
-    super.attributeChangedCallback(name, oldValue, newValue);
   }
 
   /**
@@ -206,6 +231,20 @@ export class MgtAgenda extends MgtTemplatedComponent {
         ${this.groupByDay ? this.renderGroups(events) : this.renderEvents(events)}
       </div>
     `;
+  }
+
+  /**
+   * Request to reload the state.
+   * Use reload instead of load to ensure loading events are fired.
+   *
+   * @protected
+   * @memberof MgtBaseComponent
+   */
+  protected async requestStateUpdate(force?: boolean) {
+    if (force) {
+      this.events = null;
+    }
+    super.requestStateUpdate(force);
   }
 
   /**

--- a/src/utils/GraphPageIterator.ts
+++ b/src/utils/GraphPageIterator.ts
@@ -1,0 +1,93 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
+import { GraphRequest } from '@microsoft/microsoft-graph-client';
+import { IGraph } from '../IGraph';
+
+/**
+ * A helper class to assist in getting multiple pages from a resource
+ *
+ * @export
+ * @class GraphPageIterator
+ * @template T
+ */
+export class GraphPageIterator<T> {
+  /**
+   * Gets all the items already fetched for this request
+   *
+   * @readonly
+   * @type {T[]}
+   * @memberof GraphPageIterator
+   */
+  public get value(): T[] {
+    return this._value;
+  }
+
+  /**
+   * Gets wheather this request has more pages
+   *
+   * @readonly
+   * @type {boolean}
+   * @memberof GraphPageIterator
+   */
+  public get hasNext(): boolean {
+    return !!this._nextLink;
+  }
+
+  /**
+   * Creates a new GraphPageIterator
+   *
+   * @static
+   * @template T - the type of entities expected from this request
+   * @param {IGraph} graph - the graph instance to use for making requests
+   * @param {GraphRequest} request - the initial request
+   * @param {string} [version] - optional version to use for the requests - by default uses the default version
+   * from the graph parameter
+   * @returns a GraphPageIterator
+   * @memberof GraphPageIterator
+   */
+  public static async create<T>(graph: IGraph, request: GraphRequest, version?: string) {
+    const response = await request.get();
+    if (response && response.value) {
+      const iterator = new GraphPageIterator<T>();
+      iterator._graph = graph;
+      iterator._value = response.value;
+      iterator._nextLink = response['@odata.nextLink'];
+      iterator._version = version || graph.version;
+      return iterator;
+    }
+
+    return null;
+  }
+
+  private _graph: IGraph;
+  private _nextLink: string;
+  private _version: string;
+  private _value: T[];
+
+  /**
+   * Gets the next page for this request
+   *
+   * @returns {Promise<T[]>}
+   * @memberof GraphPageIterator
+   */
+  public async next(): Promise<T[]> {
+    if (this._nextLink) {
+      const nextResource = this._nextLink.split(this._version)[1];
+      const response = await this._graph
+        .api(nextResource)
+        .version(this._version)
+        .get();
+      if (response && response.value && response.value.length) {
+        this._value = this._value.concat(response.value);
+        this._nextLink = response['@odata.nextLink'];
+        return response.value;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #339 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
The issue here was caused by couple issues:
1. The loadState method was getting called before firstUpdated. I added a flag in baseComponent to wait until firstUpdated fires before calling the method
1. The `attributeChangedCallback` was calling loadState before the setter for the property had a chance to update. I removed `attributeChangedCallback` and created setters for attributes that affect the data state. These setters now call `requestStateUpdate(true)` when changed
1. If `days` is more than few days and the calendar has more than 10 events in that timeframe, the Graph api is paged and only 10 events will be returned. Created a helper to help fetching all the events.

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes

