### PR TITLE
Added light dismiss logic to mgt-flyout and implemented in mgt-login

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,11 +10,11 @@
     <!-- <script src="./node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script> -->
 
     <script src="https://unpkg.com/@microsoft/teams-js/dist/MicrosoftTeams.min.js" crossorigin="anonymous"></script>
-
-    <!-- <script src="./dist/bundle/mgt-loader.js"></script> -->
-
+    <script src="./dist/bundle/mgt-loader.js"></script>
+    <!--
     <script type="module" src="dist/es6/index.js"></script>
     <script type="module" src="./dist/es6/mock/mgt-mock-provider.js"></script>
+    -->
   </head>
 
   <body>

--- a/index.html
+++ b/index.html
@@ -10,11 +10,11 @@
     <!-- <script src="./node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script> -->
 
     <script src="https://unpkg.com/@microsoft/teams-js/dist/MicrosoftTeams.min.js" crossorigin="anonymous"></script>
-    <script src="./dist/bundle/mgt-loader.js"></script>
-    <!--
+
+    <!-- <script src="./dist/bundle/mgt-loader.js"></script> -->
+
     <script type="module" src="dist/es6/index.js"></script>
     <script type="module" src="./dist/es6/mock/mgt-mock-provider.js"></script>
-    -->
   </head>
 
   <body>

--- a/src/components/mgt-login/mgt-login.scss
+++ b/src/components/mgt-login/mgt-login.scss
@@ -64,6 +64,10 @@ mgt-login .login-button {
     opacity: 0.4;
     pointer-events: none;
   }
+
+  &.no-click {
+    pointer-events: none;
+  }
 }
 
 :host .login-icon,

--- a/src/components/mgt-login/mgt-login.ts
+++ b/src/components/mgt-login/mgt-login.ts
@@ -6,12 +6,14 @@
  */
 
 import { User } from '@microsoft/microsoft-graph-types';
-import { customElement, html, property } from 'lit-element';
+import { customElement, html, property, query } from 'lit-element';
+import { classMap } from 'lit-html/directives/class-map';
 import { Providers } from '../../Providers';
 import { ProviderState } from '../../providers/IProvider';
 import '../../styles/fabric-icon-font';
 import { MgtBaseComponent } from '../baseComponent';
 import '../mgt-person/mgt-person';
+import { MgtFlyout } from '../sub-components/mgt-flyout/mgt-flyout';
 import { styles } from './mgt-login-css';
 
 /**
@@ -52,13 +54,27 @@ export class MgtLogin extends MgtBaseComponent {
   })
   public userDetails: User;
 
-  private _image: string;
+  /**
+   * Gets the flyout element
+   *
+   * @protected
+   * @type {MgtFlyout}
+   * @memberof MgtLogin
+   */
+  @query('.flyout') protected flyout: MgtFlyout;
 
   /**
    * determines if login menu popup should be showing
    * @type {boolean}
    */
-  @property({ attribute: false }) private _showFlyout: boolean;
+  @property({ attribute: false }) private _isFlyoutOpen: boolean;
+
+  private _image: string;
+
+  constructor() {
+    super();
+    this._isFlyoutOpen = false;
+  }
 
   /**
    * Invoked each time the custom element is appended into a document-connected element
@@ -161,8 +177,12 @@ export class MgtLogin extends MgtBaseComponent {
    * @memberof MgtLogin
    */
   protected renderButton() {
+    const classes = {
+      'login-button': true,
+      'no-click': this._isFlyoutOpen
+    };
     return html`
-      <button ?disabled="${this.isLoadingState}" @click=${this.onClick} class="login-button" role="button">
+      <button ?disabled="${this.isLoadingState}" @click=${this.onClick} class=${classMap(classes)} role="button">
         ${this.renderButtonContent()}
       </button>
     `;
@@ -176,8 +196,13 @@ export class MgtLogin extends MgtBaseComponent {
    */
   protected renderFlyout() {
     return html`
-      <mgt-flyout light-dismiss .isOpen=${this._showFlyout} @onclose=${this.hideFlyout}>
-        <div slot="flyout" class="flyout">
+      <mgt-flyout
+        class="flyout"
+        light-dismiss
+        @opened=${() => (this._isFlyoutOpen = true)}
+        @closed=${() => (this._isFlyoutOpen = false)}
+      >
+        <div slot="flyout">
           ${this.renderFlyoutContent()}
         </div>
       </mgt-flyout>
@@ -244,7 +269,10 @@ export class MgtLogin extends MgtBaseComponent {
    * @memberof MgtLogin
    */
   protected showFlyout(): void {
-    this._showFlyout = true;
+    const flyout = this.flyout;
+    if (flyout) {
+      flyout.open();
+    }
   }
 
   /**
@@ -254,22 +282,15 @@ export class MgtLogin extends MgtBaseComponent {
    * @memberof MgtLogin
    */
   protected hideFlyout(): void {
-    this._showFlyout = false;
-  }
-
-  /**
-   * Toggle the state of the flyout.
-   *
-   * @protected
-   * @memberof MgtLogin
-   */
-  protected toggleFlyout(): void {
-    this._showFlyout = !this._showFlyout;
+    const flyout = this.flyout;
+    if (flyout) {
+      flyout.close();
+    }
   }
 
   private onClick() {
     if (this.userDetails) {
-      this.toggleFlyout();
+      this.showFlyout();
     } else {
       this.login();
     }

--- a/src/components/mgt-login/mgt-login.ts
+++ b/src/components/mgt-login/mgt-login.ts
@@ -68,17 +68,6 @@ export class MgtLogin extends MgtBaseComponent {
   public connectedCallback() {
     super.connectedCallback();
     this.addEventListener('click', e => e.stopPropagation());
-    window.addEventListener('click', e => this.handleWindowClick(e));
-  }
-
-  /**
-   * Invoked each time the custom element is disconnected from the document's DOM
-   *
-   * @memberof MgtLogin
-   */
-  public disconnectedCallback() {
-    window.removeEventListener('click', e => this.handleWindowClick(e));
-    super.disconnectedCallback();
   }
 
   /**
@@ -187,7 +176,7 @@ export class MgtLogin extends MgtBaseComponent {
    */
   protected renderFlyout() {
     return html`
-      <mgt-flyout .isOpen=${this._showFlyout}>
+      <mgt-flyout light-dismiss .isOpen=${this._showFlyout} @onclose=${this.hideFlyout}>
         <div slot="flyout" class="flyout">
           ${this.renderFlyoutContent()}
         </div>
@@ -278,11 +267,7 @@ export class MgtLogin extends MgtBaseComponent {
     this._showFlyout = !this._showFlyout;
   }
 
-  private handleWindowClick(e: MouseEvent) {
-    this.hideFlyout();
-  }
-
-  private onClick(event: MouseEvent) {
+  private onClick() {
     if (this.userDetails) {
       this.toggleFlyout();
     } else {


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes nothing <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

I've added a `light-dismiss` property to the `mgt-flyout` subcomponent. Nobody asked for this, but I see repeated logic throughout components manually managing the visibility state of flyouts. Most of the time we simply need light dismiss logic, so pulling that functionality into `mgt-flyout` should allow us to simplify.

Assuming we all like the feature, I'll do another PR to apply it to the other components.

#### Other notes:
Inspired by the existing [`onclose` event](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onclose) used for `<dialog>` elements, `mgt-flyout` now emits an `onclose` event when the flyout is closed. This is used by calling components so they can sync their internal `isOpen` state with that of the flyout in light dismiss scenarios.

### PR checklist
- [X] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [X] All public classes and methods have been documented
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [X] License header has been added to all new source files (`npm run setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
