### PR TITLE
Exporting TeamsHelper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,5 @@ export * from './components/components';
 export * from './components/providers/providers';
 export * from './Providers';
 export * from './providers/providers';
+export { TeamsHelper } from './utils/TeamsHelper';
 export { prepScopes } from './utils/GraphHelpers';

--- a/src/utils/TeamsHelper.ts
+++ b/src/utils/TeamsHelper.ts
@@ -35,7 +35,7 @@ export class TeamsHelper {
    *
    * @readonly
    * @static
-   * @memberof TeamsProvider
+   * @memberof TeamsHelper
    */
   public static get isAvailable(): boolean {
     if (!this.microsoftTeamsLib) {
@@ -57,7 +57,7 @@ export class TeamsHelper {
    * @static
    * @param {string} deeplink
    * @param {(status: boolean, reason?: string) => void} [onComplete]
-   * @memberof TeamsProvider
+   * @memberof TeamsHelper
    */
   public static executeDeepLink(deeplink: string, onComplete?: (status: boolean, reason?: string) => void): void {
     const teams = this.microsoftTeamsLib;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes # <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
I recently updated the person card to use the new TeamsHelper, but forgot to export the TeamsHelper itself. `TeamsHelper` should be exposed so that developers can set the `microsoftTeamsLib` when running in Teams. This used to be accomplished through TeamsProvider, but we split it into a helper to support our ability to separate components from providers later on.

### PR checklist
- [X] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [X] All public classes and methods have been documented
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit)
- [X] License header has been added to all new source files (`npm run setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
