### PR TITLE
Fixes inherit-details not working unless there is a signed in provider

### DIFF
--- a/src/components/mgt-person-card/mgt-person-card.ts
+++ b/src/components/mgt-person-card/mgt-person-card.ts
@@ -501,6 +501,21 @@ export class MgtPersonCard extends MgtTemplatedComponent {
    * @memberof MgtPersonCard
    */
   protected async loadState() {
+    if (!this.personDetails && this.inheritDetails) {
+      // User person details inherited from parent tree
+      let parent = this.parentElement;
+      while (parent && parent.tagName !== 'MGT-PERSON') {
+        parent = parent.parentElement;
+      }
+
+      if (parent && (parent as MgtPerson).personDetails) {
+        this.personDetails = (parent as MgtPerson).personDetails;
+        this.personImage = (parent as MgtPerson).personImage;
+      }
+
+      return;
+    }
+
     const provider = Providers.globalProvider;
 
     // check if user is signed in
@@ -523,17 +538,6 @@ export class MgtPersonCard extends MgtTemplatedComponent {
         // in some cases we might only have name or email, but need to find the image
         // use @ for the image value to search for an image
         this.loadImage();
-      }
-    } else if (this.inheritDetails) {
-      // User person details inherited from parent tree
-      let parent = this.parentElement;
-      while (parent && parent.tagName !== 'MGT-PERSON') {
-        parent = parent.parentElement;
-      }
-
-      if (parent && (parent as MgtPerson).personDetails) {
-        this.personDetails = (parent as MgtPerson).personDetails;
-        this.personImage = (parent as MgtPerson).personImage;
       }
     } else if (this.userId || this.personQuery === 'me') {
       // Use userId or 'me' query to get the person and image

--- a/src/components/mgt-person-card/mgt-person-card.ts
+++ b/src/components/mgt-person-card/mgt-person-card.ts
@@ -512,8 +512,6 @@ export class MgtPersonCard extends MgtTemplatedComponent {
         this.personDetails = (parent as MgtPerson).personDetails;
         this.personImage = (parent as MgtPerson).personImage;
       }
-
-      return;
     }
 
     const provider = Providers.globalProvider;


### PR DESCRIPTION
### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This PR fixes an issue where `inherit-details` on person-card do not work unless there is a signed in provider. Some develoepers depend on `inherit-details` and do not use providers which causes a breaking issue.

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] Contains **NO** breaking changes

