### PR TITLE
Fix for unicode regex in IE/firefox

### DIFF
--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -585,14 +585,21 @@ export class MgtPerson extends MgtTemplatedComponent {
     if (!initials && person.displayName) {
       const name = person.displayName.split(/\s+/);
       for (let i = 0; i < 2 && i < name.length; i++) {
-        if (name[i][0] && name[i][0].match(/\p{L}/gu)) {
-          // check if letter
+        if (name[i][0] && this.isLetter(name[i][0])) {
           initials += name[i][0].toUpperCase();
         }
       }
     }
 
     return initials;
+  }
+
+  private isLetter(char: string) {
+    try {
+      return char.match(new RegExp('\\p{L}', 'u'));
+    } catch (e) {
+      return char.toLowerCase() !== char.toUpperCase();
+    }
   }
 
   private handleMouseClick(e: MouseEvent) {


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #406  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Firefox and some other browsers do not implement 'u' for uncicode regex. The fix adds a fallback in those browsers.

Tested in Edge, Chrome, Firefox and IE11

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
