### PR TITLE
Fix for nested templates in Edge Classic

### DIFF
--- a/src/components/templateHelper.ts
+++ b/src/components/templateHelper.ts
@@ -50,7 +50,7 @@ export class TemplateHelper {
       const div = document.createElement('div');
       // tslint:disable-next-line: prefer-for-of
       for (let i = 0; i < template.childNodes.length; i++) {
-        div.appendChild(template.childNodes[i].cloneNode(true));
+        div.appendChild(this.simpleCloneNode(template.childNodes[i]));
       }
       rendered = this.renderNode(div, root, context, additionalContext);
     }
@@ -61,6 +61,26 @@ export class TemplateHelper {
   }
 
   private static _expression = /{{+\s*[$\w\.()\[\]]+\s*}}+/g;
+
+  // simple implementation of deep cloneNode
+  // required for nested templates in polyfilled browsers
+  private static simpleCloneNode(node: ChildNode) {
+    if (!node) {
+      return null;
+    }
+
+    const clone = node.cloneNode(false);
+
+    // tslint:disable-next-line:prefer-for-of
+    for (let i = 0; i < node.childNodes.length; i++) {
+      const childClone = this.simpleCloneNode(node.childNodes[i]);
+      if (childClone) {
+        clone.appendChild(childClone);
+      }
+    }
+
+    return clone;
+  }
 
   private static expandExpressionsAsString(str: string, context: object, additionalContext: object) {
     return str.replace(this._expression, match => {


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #407  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

The issue was caused by the `cloneNode` function only when running in Edge in a React app. After investigation, I discovered the native `cloneNode` method was not cloning nested `<teamplate>` elements and was causing the issue in #407. This PR adds a simple cloneNode implementation that works with any element. 

Tested in Chrome, Edge, Edge Classic, Firefox, IE

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Contains **NO** breaking changes

