### PR TITLE
email prop added to dynamicPerson, userDetails setting issue

### DIFF
--- a/src/components/mgt-login/mgt-login.ts
+++ b/src/components/mgt-login/mgt-login.ts
@@ -157,7 +157,7 @@ export class MgtLogin extends MgtBaseComponent {
    */
   protected async loadState() {
     const provider = Providers.globalProvider;
-    if (provider) {
+    if (provider && !this.userDetails) {
       if (provider.state === ProviderState.SignedIn) {
         const batch = provider.graph.forComponent(this).createBatch();
         batch.get('me', 'me', ['user.read']);

--- a/src/graph/graph.people.ts
+++ b/src/graph/graph.people.ts
@@ -67,11 +67,10 @@ export async function getPeopleFromGroup(graph: IGraph, groupId: string): Promis
  * returns a promise that resolves after specified time
  * @param time in milliseconds
  */
-export function getEmailFromGraphEntity(entity: User | Person | Contact | IDynamicPerson): string {
+export function getEmailFromGraphEntity(entity: IDynamicPerson): string {
   const person = entity as Person;
   const user = entity as User;
   const contact = entity as Contact;
-  const dynamicPerson = entity as IDynamicPerson;
 
   if (user.mail) {
     return user.mail;
@@ -79,8 +78,6 @@ export function getEmailFromGraphEntity(entity: User | Person | Contact | IDynam
     return person.scoredEmailAddresses[0].address;
   } else if (contact.emailAddresses && contact.emailAddresses.length) {
     return contact.emailAddresses[0].address;
-  } else if (dynamicPerson.email) {
-    return dynamicPerson.email;
   }
   return null;
 }

--- a/src/graph/graph.people.ts
+++ b/src/graph/graph.people.ts
@@ -8,6 +8,7 @@
 import { Contact, Person, User } from '@microsoft/microsoft-graph-types';
 import { IGraph } from '../IGraph';
 import { prepScopes } from '../utils/GraphHelpers';
+import { IDynamicPerson } from './types';
 
 /**
  * async promise, returns all Graph people who are most relevant contacts to the signed in user.
@@ -66,10 +67,11 @@ export async function getPeopleFromGroup(graph: IGraph, groupId: string): Promis
  * returns a promise that resolves after specified time
  * @param time in milliseconds
  */
-export function getEmailFromGraphEntity(entity: User | Person | Contact): string {
+export function getEmailFromGraphEntity(entity: User | Person | Contact | IDynamicPerson): string {
   const person = entity as Person;
   const user = entity as User;
   const contact = entity as Contact;
+  const dynamicPerson = entity as IDynamicPerson;
 
   if (user.mail) {
     return user.mail;
@@ -77,8 +79,9 @@ export function getEmailFromGraphEntity(entity: User | Person | Contact): string
     return person.scoredEmailAddresses[0].address;
   } else if (contact.emailAddresses && contact.emailAddresses.length) {
     return contact.emailAddresses[0].address;
+  } else if (dynamicPerson.email) {
+    return dynamicPerson.email;
   }
-
   return null;
 }
 

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -22,6 +22,13 @@ export type IDynamicPerson = (MicrosoftGraph.User | MicrosoftGraph.Person | Micr
    * @type {string}
    */
   personImage?: string;
+
+  /**
+   * personDetails.email is a toolkit injected property to manually set a singular email address for a user.
+   *
+   * @type {string}
+   */
+  email?: string;
 };
 
 /**

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -22,13 +22,6 @@ export type IDynamicPerson = (MicrosoftGraph.User | MicrosoftGraph.Person | Micr
    * @type {string}
    */
   personImage?: string;
-
-  /**
-   * personDetails.email is a toolkit injected property to manually set a singular email address for a user.
-   *
-   * @type {string}
-   */
-  email?: string;
 };
 
 /**


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->


### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
 Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
1. email Prop to IDynamicPerson
The ability to set `userDetails` on the `mgt-login` component is as follows in documentation: 
```
let loginControl = document.getElementById('myLoginControl');
loginControl.userDetails = {
    displayName: 'Nikola Metulev',
    email: 'nikola@contoso.com',
    personImage: 'url'
}
```

However, the `mgt-person` component (leveraged in the mgt-login for render) uses the function `getEmailFromGraphEntity()` to determine which type of user object for its respective properties. User (using `mail`), Person (using `scoredEmailAddresses`), and contact (`emailAddresses`) seems to not satisfy our case for user set email. I propose we use the new `email` prop on our dynamic person, otherwise the `mail` prop on User. 

2. userDetails in loadState()

userDetails is overwritten by the batch calls in the `mgt-login`, this doesn't seem to be necessary at all, if the userDetails are provided so I've updated the escape clause. 

```
  protected async loadState() {
    const provider = Providers.globalProvider;
    if (provider && !this.userDetails) {
```
 


### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
