### PR TITLE
Login person card css fix

### DIFF
--- a/src/components/mgt-login/mgt-login.ts
+++ b/src/components/mgt-login/mgt-login.ts
@@ -222,12 +222,19 @@ export class MgtLogin extends MgtBaseComponent {
     if (!this.userDetails) {
       return;
     }
+    const avatarSize = 'large';
 
     return html`
       <div class="popup">
         <div class="popup-content">
           <div>
-            <mgt-person .personDetails=${this.userDetails} .personImage=${this._image} show-name show-email />
+            <mgt-person
+              .personDetails=${this.userDetails}
+              .personImage=${this._image}
+              .avatarSize=${avatarSize}
+              show-name
+              show-email
+            />
           </div>
           <div class="popup-commands">
             <ul>
@@ -251,8 +258,14 @@ export class MgtLogin extends MgtBaseComponent {
    */
   protected renderButtonContent() {
     if (this.userDetails) {
+      const avatarSize = 'small';
       return html`
-        <mgt-person .personDetails=${this.userDetails} .personImage=${this._image} show-name />
+        <mgt-person
+          .personDetails=${this.userDetails}
+          .personImage=${this._image}
+          .avatarSize=${avatarSize}
+          show-name
+        />
       `;
     } else {
       return html`


### PR DESCRIPTION
### PR Type
- Bugfix 

### Description of the changes
Presence PR introduced a new attribute avatarSize which will apply css accordingly to mgt-person and mgt-person-card. This broke login component because the attribute is not set correctly.

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. 
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes
