### PR TITLE
Added template support to Login Component

### DIFF
--- a/src/components/mgt-login/mgt-login.ts
+++ b/src/components/mgt-login/mgt-login.ts
@@ -256,7 +256,7 @@ export class MgtLogin extends MgtTemplatedComponent {
    * @memberof MgtLogin
    */
   protected renderFlyoutPersonDetails(personDetails: IDynamicPerson, personImage: string) {
-    const template = this.renderTemplate('flyout-person-details', null);
+    const template = this.renderTemplate('flyout-person-details', { personDetails, personImage });
     return (
       template ||
       html`
@@ -340,12 +340,15 @@ export class MgtLogin extends MgtTemplatedComponent {
    */
   protected renderSignedOutButtonContent() {
     const template = this.renderTemplate('signed-out-button-content', null);
-    return html`
-      <i class="login-icon ms-Icon ms-Icon--Contact"></i>
-      <span aria-label="Sign In">
-        Sign In
-      </span>
-    `;
+    return (
+      template ||
+      html`
+        <i class="login-icon ms-Icon ms-Icon--Contact"></i>
+        <span aria-label="Sign In">
+          Sign In
+        </span>
+      `
+    );
   }
 
   /**

--- a/src/components/mgt-login/mgt-login.ts
+++ b/src/components/mgt-login/mgt-login.ts
@@ -16,6 +16,8 @@ import '../mgt-person/mgt-person';
 import { MgtFlyout } from '../sub-components/mgt-flyout/mgt-flyout';
 import { styles } from './mgt-login-css';
 
+export type LoginButtonType = 'avatar' | 'name' | 'avatarAndName';
+
 /**
  * Web component button and flyout control to facilitate Microsoft identity platform authentication
  *
@@ -60,6 +62,11 @@ export class MgtLogin extends MgtBaseComponent {
   })
   public userDetails: IDynamicPerson;
 
+  @property({
+    attribute: 'button-type'
+  })
+  public buttonType: LoginButtonType;
+
   /**
    * Gets the flyout element
    *
@@ -82,6 +89,7 @@ export class MgtLogin extends MgtBaseComponent {
   constructor() {
     super();
     this._isFlyoutOpen = false;
+    this.buttonType = 'avatarAndName';
   }
 
   /**
@@ -264,15 +272,23 @@ export class MgtLogin extends MgtBaseComponent {
    */
   protected renderButtonContent() {
     if (this.userDetails) {
-      const avatarSize = 'small';
-      return html`
-        <mgt-person
-          .personDetails=${this.userDetails}
-          .personImage=${this._image}
-          .avatarSize=${avatarSize}
-          show-name
-        />
-      `;
+      if (this.buttonType === 'name') {
+        return html`
+          <span>
+            ${this.userDetails.displayName}
+          </span>
+        `;
+      } else {
+        const avatarSize = 'small';
+        return html`
+          <mgt-person
+            .personDetails=${this.userDetails}
+            .personImage=${this._image}
+            .avatarSize=${avatarSize}
+            .showName=${this.buttonType === 'avatarAndName'}
+          />
+        `;
+      }
     } else {
       return html`
         <i class="login-icon ms-Icon ms-Icon--Contact"></i>

--- a/src/components/mgt-login/mgt-login.ts
+++ b/src/components/mgt-login/mgt-login.ts
@@ -10,13 +10,12 @@ import { classMap } from 'lit-html/directives/class-map';
 import { IDynamicPerson } from '../../graph/types';
 import { Providers } from '../../Providers';
 import { ProviderState } from '../../providers/IProvider';
-import '../../styles/fabric-icon-font';
-import { MgtBaseComponent } from '../baseComponent';
-import '../mgt-person/mgt-person';
 import { MgtFlyout } from '../sub-components/mgt-flyout/mgt-flyout';
+import { MgtTemplatedComponent } from '../templatedComponent';
 import { styles } from './mgt-login-css';
 
-export type LoginButtonType = 'avatar' | 'name' | 'avatarAndName';
+import '../../styles/fabric-icon-font';
+import '../mgt-person/mgt-person';
 
 /**
  * Web component button and flyout control to facilitate Microsoft identity platform authentication
@@ -31,6 +30,11 @@ export type LoginButtonType = 'avatar' | 'name' | 'avatarAndName';
  * @fires logoutInitiated - Fired when logout is initiated by the user
  * @fires logoutCompleted - Fired when logout completed
  *
+ * @template signed-in-button-content (dataContext: {personDetails, personImage})
+ * @template signed-out-button-content (dataContext: null)
+ * @template flyout-commands (dataContext: {handleSignOut})
+ * @template flyout-person-details (dataContext: {personDetails, personImage})
+ *
  * @cssprop --font-size - {Length} Login font size
  * @cssprop --font-weight - {Length} Login font weight
  * @cssprop --height - {String} Login height percentage
@@ -43,7 +47,7 @@ export type LoginButtonType = 'avatar' | 'name' | 'avatarAndName';
  * @cssprop --popup-command-font-size - {Length} Popup command font size
  */
 @customElement('mgt-login')
-export class MgtLogin extends MgtBaseComponent {
+export class MgtLogin extends MgtTemplatedComponent {
   /**
    * Array of styles to apply to the element. The styles should be defined
    * using the `css` tag function.
@@ -61,11 +65,6 @@ export class MgtLogin extends MgtBaseComponent {
     type: Object
   })
   public userDetails: IDynamicPerson;
-
-  @property({
-    attribute: 'button-type'
-  })
-  public buttonType: LoginButtonType;
 
   /**
    * Gets the flyout element
@@ -89,7 +88,6 @@ export class MgtLogin extends MgtBaseComponent {
   constructor() {
     super();
     this._isFlyoutOpen = false;
-    this.buttonType = 'avatarAndName';
   }
 
   /**
@@ -236,33 +234,66 @@ export class MgtLogin extends MgtBaseComponent {
     if (!this.userDetails) {
       return;
     }
-    const avatarSize = 'large';
-
     return html`
       <div class="popup">
         <div class="popup-content">
           <div>
-            <mgt-person
-              .personDetails=${this.userDetails}
-              .personImage=${this._image}
-              .avatarSize=${avatarSize}
-              show-name
-              show-email
-            />
+            ${this.renderFlyoutPersonDetails(this.userDetails, this._image)}
           </div>
           <div class="popup-commands">
-            <ul>
-              <li>
-                <button class="popup-command" @click=${this.logout} aria-label="Sign Out">
-                  Sign Out
-                </button>
-              </li>
-            </ul>
+            ${this.renderFlyoutCommands()}
           </div>
         </div>
       </div>
     `;
   }
+
+  /**
+   * Render the flyout person details.
+   *
+   * @protected
+   * @returns
+   * @memberof MgtLogin
+   */
+  protected renderFlyoutPersonDetails(personDetails: IDynamicPerson, personImage: string) {
+    const template = this.renderTemplate('flyout-person-details', null);
+    return (
+      template ||
+      html`
+        <mgt-person
+          .personDetails=${personDetails}
+          .personImage=${personImage}
+          .avatarSize="large"
+          .showName=${true}
+          .showEmail=${true}
+        />
+      `
+    );
+  }
+
+  /**
+   * Render the flyout commands.
+   *
+   * @protected
+   * @returns
+   * @memberof MgtLogin
+   */
+  protected renderFlyoutCommands() {
+    const template = this.renderTemplate('flyout-commands', { handleSignOut: () => this.logout() });
+    return (
+      template ||
+      html`
+        <ul>
+          <li>
+            <button class="popup-command" @click=${this.logout} aria-label="Sign Out">
+              Sign Out
+            </button>
+          </li>
+        </ul>
+      `
+    );
+  }
+
   /**
    * Render the button content.
    *
@@ -272,31 +303,49 @@ export class MgtLogin extends MgtBaseComponent {
    */
   protected renderButtonContent() {
     if (this.userDetails) {
-      if (this.buttonType === 'name') {
-        return html`
-          <span>
-            ${this.userDetails.displayName}
-          </span>
-        `;
-      } else {
-        const avatarSize = 'small';
-        return html`
-          <mgt-person
-            .personDetails=${this.userDetails}
-            .personImage=${this._image}
-            .avatarSize=${avatarSize}
-            .showName=${this.buttonType === 'avatarAndName'}
-          />
-        `;
-      }
+      return this.renderSignedInButtonContent(this.userDetails, this._image);
     } else {
-      return html`
-        <i class="login-icon ms-Icon ms-Icon--Contact"></i>
-        <span aria-label="Sign In">
-          Sign In
-        </span>
-      `;
+      return this.renderSignedOutButtonContent();
     }
+  }
+
+  /**
+   * Render the button content when the user is signed in.
+   *
+   * @protected
+   * @returns
+   * @memberof MgtLogin
+   */
+  protected renderSignedInButtonContent(personDetails: IDynamicPerson, personImage: string) {
+    const template = this.renderTemplate('signed-in-button-content', { personDetails, personImage });
+    return (
+      template ||
+      html`
+        <mgt-person
+          .personDetails=${this.userDetails}
+          .personImage=${this._image}
+          .avatarSize="small"
+          .showName=${true}
+        />
+      `
+    );
+  }
+
+  /**
+   * Render the button content when the user is not signed in.
+   *
+   * @protected
+   * @returns
+   * @memberof MgtLogin
+   */
+  protected renderSignedOutButtonContent() {
+    const template = this.renderTemplate('signed-out-button-content', null);
+    return html`
+      <i class="login-icon ms-Icon ms-Icon--Contact"></i>
+      <span aria-label="Sign In">
+        Sign In
+      </span>
+    `;
   }
 
   /**

--- a/stories/components/login.stories.js
+++ b/stories/components/login.stories.js
@@ -12,7 +12,6 @@ import { withWebComponentsKnobs } from 'storybook-addon-web-components-knobs';
 import { withSignIn } from '../../.storybook/addons/signInAddon/signInAddon';
 import { withCodeEditor } from '../../.storybook/addons/codeEditorAddon/codeAddon';
 import '../../dist/es6/components/mgt-login/mgt-login';
-import '../../dist/es6/components/mgt-person/mgt-person';
 
 export default {
   title: 'Components | mgt-login',

--- a/stories/components/login.stories.js
+++ b/stories/components/login.stories.js
@@ -35,12 +35,10 @@ export const Templates = () => html`
     {{personDetails.givenName}}
   </template>
   <template data-type="flyout-commands">
-      <div>
-          <div>
-              <button data-props="{@click: handleSignOut}">Sign Out</button>
-              <button>Go to my profile</button>
-          </div>
-      </div>
+    <div>
+      <button data-props="{@click: handleSignOut}">Sign Out</button>
+      <button>Go to my profile</button>
+    </div>
   </template>
 </mgt-login>
 `;

--- a/stories/components/login.stories.js
+++ b/stories/components/login.stories.js
@@ -12,6 +12,7 @@ import { withWebComponentsKnobs } from 'storybook-addon-web-components-knobs';
 import { withSignIn } from '../../.storybook/addons/signInAddon/signInAddon';
 import { withCodeEditor } from '../../.storybook/addons/codeEditorAddon/codeAddon';
 import '../../dist/es6/components/mgt-login/mgt-login';
+import '../../dist/es6/components/mgt-person/mgt-person';
 
 export default {
   title: 'Components | mgt-login',
@@ -27,4 +28,20 @@ export default {
 
 export const Login = () => html`
   <mgt-login></mgt-login>
+`;
+
+export const Templates = () => html`
+<mgt-login>
+  <template data-type="signed-in-button-content">
+    {{personDetails.givenName}}
+  </template>
+  <template data-type="flyout-commands">
+      <div>
+          <div>
+              <button data-props="{@click: handleSignOut}">Sign Out</button>
+              <button>Go to my profile</button>
+          </div>
+      </div>
+  </template>
+</mgt-login>
 `;


### PR DESCRIPTION
### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This PR adds template support to mgt login, adding the following templates:

* signed-in-button-content (dataContext: {personDetails, personImage})
* signed-out-button-content (dataContext: null)
* flyout-commands (dataContext: {handleSignOut})
* flyout-person-details (dataContext: {personDetails, personImage})

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: https://github.com/microsoftgraph/microsoft-graph-docs/pull/8086
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
