### PR TITLE
Added fetchImage and fixed image fetching in mgt-person

### DIFF
--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -17,6 +17,7 @@ import { Providers } from '../../Providers';
 import { ProviderState } from '../../providers/IProvider';
 import '../../styles/fabric-icon-font';
 import { debounce } from '../../utils/Utils';
+import { PersonCardInteraction } from '../PersonCardInteraction';
 import { MgtFlyout } from '../sub-components/mgt-flyout/mgt-flyout';
 import { MgtTemplatedComponent } from '../templatedComponent';
 import { styles } from './mgt-people-picker-css';
@@ -517,7 +518,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     return (
       this.renderTemplate('person', { person }, person.id) ||
       html`
-        <mgt-person .personDetails=${person} .personImage=${'@'}></mgt-person>
+        <mgt-person .personDetails=${person} .fetchImage=${true}></mgt-person>
         <div class="people-person-text-area" id="${person.displayName}">
           ${this.renderHighlightText(person)}
           <span class="${classMap(classes)}">${subTitle}</span>
@@ -539,9 +540,9 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       <mgt-person
         class="selected-person"
         .personDetails=${person}
-        .personImage=${'@'}
-        show-name
-        person-card="click"
+        .fetchImage=${true}
+        .showName=${true}
+        .personCardInteraction=${PersonCardInteraction.click}
       ></mgt-person>
     `;
   }

--- a/src/components/mgt-people/mgt-people.ts
+++ b/src/components/mgt-people/mgt-people.ts
@@ -281,7 +281,7 @@ export class MgtPeople extends MgtTemplatedComponent {
       html`
         <mgt-person
           .personDetails=${person}
-          .personImage=${'@'}
+          .fetchImage=${true}
           .avatarSize=${avatarSize}
           .personCardInteraction=${this.personCardInteraction}
           .showPresence=${this.showPresence}

--- a/src/components/mgt-person-card/mgt-person-card.ts
+++ b/src/components/mgt-person-card/mgt-person-card.ts
@@ -588,6 +588,7 @@ export class MgtPersonCard extends MgtTemplatedComponent {
         const person = await getUserWithPhoto(graph, id);
         this.personDetails = person;
         this.personImage = this.getImage();
+        this.personDetails.personImage = this.personImage;
       } else if (
         !this.personDetails.personImage &&
         ((this.fetchImage && !this.personImage) || this.personImage === '@')
@@ -595,6 +596,7 @@ export class MgtPersonCard extends MgtTemplatedComponent {
         // in some cases we might only have name or email, but need to find the image
         const image = await getPersonImage(graph, this.personDetails);
         if (image) {
+          this.personDetails.personImage = image;
           this.personImage = image;
         }
       }
@@ -612,6 +614,7 @@ export class MgtPersonCard extends MgtTemplatedComponent {
         this.personDetails = people[0];
         const image = await getPersonImage(graph, this.personDetails);
         if (image) {
+          this.personDetails.personImage = image;
           this.personImage = image;
         }
       }

--- a/src/components/mgt-person-card/mgt-person-card.ts
+++ b/src/components/mgt-person-card/mgt-person-card.ts
@@ -82,7 +82,6 @@ export class MgtPersonCard extends MgtTemplatedComponent {
 
   /**
    * Set the image of the person
-   * Set to '@' to look up image from the graph
    *
    * @type {string}
    * @memberof MgtPersonCard
@@ -92,6 +91,20 @@ export class MgtPersonCard extends MgtTemplatedComponent {
     type: String
   })
   public personImage: string;
+
+  /**
+   * Sets whether the person image should be fetched
+   * from the Microsoft Graph based on the personDetails
+   * provided by the user
+   *
+   * @type {boolean}
+   * @memberof MgtPerson
+   */
+  @property({
+    attribute: 'fetch-image',
+    type: Boolean
+  })
+  public fetchImage: boolean;
 
   /**
    * Gets or sets whether expanded details section is rendered
@@ -575,12 +588,13 @@ export class MgtPersonCard extends MgtTemplatedComponent {
         const person = await getUserWithPhoto(graph, id);
         this.personDetails = person;
         this.personImage = this.getImage();
-      } else if (this.personImage === '@' && !this.personDetails.personImage) {
+      } else if (
+        !this.personDetails.personImage &&
+        ((this.fetchImage && !this.personImage) || this.personImage === '@')
+      ) {
         // in some cases we might only have name or email, but need to find the image
-        // use @ for the image value to search for an image
         const image = await getPersonImage(graph, this.personDetails);
         if (image) {
-          this.personDetails.personImage = image;
           this.personImage = image;
         }
       }
@@ -598,7 +612,6 @@ export class MgtPersonCard extends MgtTemplatedComponent {
         this.personDetails = people[0];
         const image = await getPersonImage(graph, this.personDetails);
         if (image) {
-          this.personDetails.personImage = image;
           this.personImage = image;
         }
       }

--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -138,22 +138,40 @@ export class MgtPerson extends MgtTemplatedComponent {
     } else {
       this._personAvatarBg = this.getColorFromName(value.displayName);
     }
+
+    if (this.fetchImage) {
+      this.personImage = null;
+    }
+
+    this.requestStateUpdate();
     this.requestUpdate('personDetails');
   }
 
   /**
    * Set the image of the person
-   * Set to '@' to look up image from the graph
    *
    * @type {string}
    * @memberof MgtPersonCard
    */
   @property({
     attribute: 'person-image',
-    reflect: true,
     type: String
   })
   public personImage: string;
+
+  /**
+   * Sets whether the person image should be fetched
+   * from the Microsoft Graph based on the personDetails
+   * provided by the user
+   *
+   * @type {boolean}
+   * @memberof MgtPerson
+   */
+  @property({
+    attribute: 'fetch-image',
+    type: Boolean
+  })
+  public fetchImage: boolean;
 
   /**
    * Gets or sets presence of person
@@ -666,12 +684,9 @@ export class MgtPerson extends MgtTemplatedComponent {
     const graph = provider.graph.forComponent(this);
 
     if (this.personDetails) {
-      // in some cases we might only have name or email, but need to find the image
-      // use @ for the image value to search for an image
-      if (this.personImage === '@' && !this.personDetails.personImage) {
+      if (!this.personDetails.personImage && ((this.fetchImage && !this.personImage) || this.personImage === '@')) {
         const image = await getPersonImage(graph, this.personDetails);
         if (image) {
-          this.personDetails.personImage = image;
           this.personImage = image;
         }
       }
@@ -690,7 +705,6 @@ export class MgtPerson extends MgtTemplatedComponent {
         const image = await getPersonImage(graph, people[0]);
 
         if (image) {
-          this.personDetails.personImage = image;
           this.personImage = image;
         }
       }

--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -687,6 +687,7 @@ export class MgtPerson extends MgtTemplatedComponent {
       if (!this.personDetails.personImage && ((this.fetchImage && !this.personImage) || this.personImage === '@')) {
         const image = await getPersonImage(graph, this.personDetails);
         if (image) {
+          this.personDetails.personImage = image;
           this.personImage = image;
         }
       }
@@ -696,6 +697,7 @@ export class MgtPerson extends MgtTemplatedComponent {
 
       this.personDetails = person;
       this.personImage = this.getImage();
+      this.personDetails.personImage = this.personImage;
     } else if (this.personQuery) {
       // Use the personQuery to find our person.
       const people = await findPeople(graph, this.personQuery, 1);
@@ -705,6 +707,7 @@ export class MgtPerson extends MgtTemplatedComponent {
         const image = await getPersonImage(graph, people[0]);
 
         if (image) {
+          this.personDetails.personImage = image;
           this.personImage = image;
         }
       }

--- a/src/graph/graph.photos.ts
+++ b/src/graph/graph.photos.ts
@@ -75,8 +75,21 @@ export async function getPersonImage(graph: IGraph, person: IDynamicPerson) {
     const userPrincipalName = (person as MicrosoftGraph.Person).userPrincipalName;
     image = await getUserPhoto(graph, userPrincipalName);
   } else {
+    if (person.id) {
+      try {
+        image = await getUserPhoto(graph, person.id);
+      } catch (e) {
+        // nop
+      }
+    }
+
+    if (image) {
+      return image;
+    }
+
     // try to find a user by e-mail
     const email = getEmailFromGraphEntity(person);
+
     if (email) {
       const users = await findUserByEmail(graph, email);
       if (users && users.length) {

--- a/src/graph/graph.photos.ts
+++ b/src/graph/graph.photos.ts
@@ -76,15 +76,10 @@ export async function getPersonImage(graph: IGraph, person: IDynamicPerson) {
     image = await getUserPhoto(graph, userPrincipalName);
   } else {
     if (person.id) {
-      try {
-        image = await getUserPhoto(graph, person.id);
-      } catch (e) {
-        // nop
+      image = await getUserPhoto(graph, person.id);
+      if (image) {
+        return image;
       }
-    }
-
-    if (image) {
-      return image;
     }
 
     // try to find a user by e-mail


### PR DESCRIPTION
### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix 
- Feature 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This PR:
1. Adds a new property/attribute to `mgt-person`
    | Attribute     | Property     | Description                                                   |
    | -----------   | ----------   | ------------------------------------------------------------- |
    |  fetch-image  | fetchImage | Sets whether the person image should be fetched from the Microsoft Graph based on the `personDetails` provided by the user |
    
    This was previously possible by setting `personImage='@'` which is not discoverable or good practice. This is still possible for compatibility purposes, but not documented. 

2. Fixes an issue where the person card would not be able to find an image from the graph, even if the id is available in the person details.

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: https://github.com/microsoftgraph/microsoft-graph-docs/pull/8095
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes

### Other information