### PR TITLE
teams-channel-picker default input background color

### DIFF
--- a/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.scss
+++ b/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.scss
@@ -23,7 +23,7 @@ $input-border-top: var(--input-border-top, $input-border);
 
 $input-hover-color: var(--input-hover-color, #323130);
 $input-focus-color: var(--input-focus-color, #0078d4);
-$input-background-color: var(--input-background-color, transparent);
+$input-background-color: var(--input-background-color, white);
 
 $dropdown-item-hover-background: var(--dropdown-item-hover-background, #f1f1f1dd);
 $dropdown-background-color: var(--dropdown-background-color, white);


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->


### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

changes css variable `--input-background-color` 
**default value** from `transparent` to `white`

1. consistency with `mgt-people-picker`
2. ensures text visibility regardless of background by default

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
