### PR TITLE
Fixed issue where presence was not getting cleared

### DIFF
--- a/src/components/mgt-person-card/mgt-person-card.ts
+++ b/src/components/mgt-person-card/mgt-person-card.ts
@@ -78,7 +78,19 @@ export class MgtPersonCard extends MgtTemplatedComponent {
     attribute: 'person-details',
     type: Object
   })
-  public personDetails: IDynamicPerson;
+  public get personDetails(): IDynamicPerson {
+    return this._personDetails;
+  }
+  public set personDetails(value: IDynamicPerson) {
+    if (this._personDetails === value) {
+      return;
+    }
+
+    this._personDetails = value;
+
+    this.requestStateUpdate();
+    this.requestUpdate('personDetails');
+  }
 
   /**
    * Set the image of the person
@@ -152,6 +164,8 @@ export class MgtPersonCard extends MgtTemplatedComponent {
     type: Object
   })
   public personPresence: MicrosoftGraphBeta.Presence;
+
+  private _personDetails: IDynamicPerson;
 
   /**
    * Invoked each time the custom element is appended into a document-connected element

--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -143,6 +143,10 @@ export class MgtPerson extends MgtTemplatedComponent {
       this.personImage = null;
     }
 
+    if (this.showPresence) {
+      this.personPresence = null;
+    }
+
     this.requestStateUpdate();
     this.requestUpdate('personDetails');
   }


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes # <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This PR fixes an issue in situations where the personDetails are set by the developer and the presence is fetched based on the personDetails. However if the personDetails was set before, the old presence never gets cleared and it never gets updated. 

This issue repros in frameworks such as React where the framework changes the property of a component when properties change, but they do not rerender the component.

The fix is to clear the presence information when the personDetails are set.

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
