### PR TITLE
Fixed error handling when setting personDetails on MgtPersonCard

### DIFF
--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -161,10 +161,10 @@ export class MgtPerson extends MgtTemplatedComponent {
     }
 
     this._personDetails = value;
-    if (!value) {
-      this._personAvatarBg = 'gray20';
-    } else {
+    if (value && value.displayName) {
       this._personAvatarBg = this.getColorFromName(value.displayName);
+    } else {
+      this._personAvatarBg = 'gray20';
     }
 
     this._fetchedImage = null;
@@ -592,7 +592,7 @@ export class MgtPerson extends MgtTemplatedComponent {
   ): TemplateResult {
     const title =
       this.personDetails && this.personCardInteraction === PersonCardInteraction.none
-        ? this.personDetails.displayName
+        ? this.personDetails.displayName || this.personDetails.mail || ''
         : '';
 
     const imageClasses = {
@@ -843,7 +843,7 @@ export class MgtPerson extends MgtTemplatedComponent {
   }
 
   private getTextFromProperty(personDetails: IDynamicPerson, prop: string) {
-    if (!property || property.length === 0) {
+    if (!prop || prop.length === 0) {
       return null;
     }
 

--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -592,7 +592,7 @@ export class MgtPerson extends MgtTemplatedComponent {
   ): TemplateResult {
     const title =
       this.personDetails && this.personCardInteraction === PersonCardInteraction.none
-        ? this.personDetails.displayName || this.personDetails.mail || ''
+        ? this.personDetails.displayName || getEmailFromGraphEntity(this.personDetails) || ''
         : '';
 
     const imageClasses = {

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -22,6 +22,13 @@ export type IDynamicPerson = (MicrosoftGraph.User | MicrosoftGraph.Person | Micr
    * @type {string}
    */
   personImage?: string;
+
+  /**
+   * Placeholder for user provided mail value. Used when setting personDetails manually.
+   *
+   * @type {string}
+   */
+  mail?: string;
 };
 
 /**

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -22,13 +22,6 @@ export type IDynamicPerson = (MicrosoftGraph.User | MicrosoftGraph.Person | Micr
    * @type {string}
    */
   personImage?: string;
-
-  /**
-   * Placeholder for user provided mail value. Used when setting personDetails manually.
-   *
-   * @type {string}
-   */
-  mail?: string;
 };
 
 /**


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #452
Closes #445 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
When specifying the personDetails object manually, MgtPerson no longer throws an error when the displayName is omitted. 

In addition, the title and aria-label attributes now show the mail value (or nothing), if the displayName value is omitted. 

The component will now gracefully handle the precense/omission of displayName/mail values gracefully in all cases.

### PR checklist
- [X] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [X] All public classes and methods have been documented
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [X] License header has been added to all new source files (`npm run setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
Note, this does not include the bug for providing an invalid url (#451). That will come in a follow up PR.