### PR TITLE
Update scope to get channels

### DIFF
--- a/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.ts
+++ b/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.ts
@@ -551,7 +551,7 @@ export class MgtTeamsChannelPicker extends MgtTemplatedComponent {
       const batch = provider.graph.createBatch();
 
       for (const [i, team] of teams.entries()) {
-        batch.get(`${i}`, `teams/${team.id}/channels`, ['user.read.all']);
+        batch.get(`${i}`, `teams/${team.id}/channels`, ['group.read.all']);
       }
       const response = await batch.execute();
       this.items = teams.map(t => {


### PR DESCRIPTION
Closes #443 

### PR Type
- Bugfix

### Description of the changes
Updated scope to get channels based on [documentation](https://docs.microsoft.com/en-us/graph/api/channel-list?view=graph-rest-1.0&tabs=http)

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Contains **NO** breaking changes
