### PR TITLE
Close icon center in safari

### DIFF
--- a/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.scss
+++ b/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.scss
@@ -120,10 +120,9 @@ $dropdown-item-selected-background: var(--dropdown-item-selected-background, #de
       .close-icon {
         display: inline-block;
         position: absolute;
-        right: 0;
+        right: 10px;
         line-height: normal;
         font-family: 'FabricMDL2Icons';
-        padding: 8px 10px 10px 8px;
         margin-bottom: 1px;
         cursor: pointer;
         color: $placeholder-default-color;


### PR DESCRIPTION
Closes #441 
### PR Type
 - Bugfix 

### Description of the changes
Center the close button
Safari:
<img width="552" alt="Screen Shot 2020-06-03 at 2 02 05 PM" src="https://user-images.githubusercontent.com/7429891/83689062-41c67980-a5a3-11ea-9d18-907e907d1808.png">
Chrome:
<img width="625" alt="Screen Shot 2020-06-03 at 2 02 27 PM" src="https://user-images.githubusercontent.com/7429891/83689067-4428d380-a5a3-11ea-91b0-b052712a62bf.png">

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Contains **NO** breaking changes

