### PR TITLE
Fix linear gradient in safari

### DIFF
--- a/src/components/mgt-person-card/mgt-person-card.scss
+++ b/src/components/mgt-person-card/mgt-person-card.scss
@@ -40,7 +40,7 @@ $person-card-background-color: var(--person-card-background-color, #ffffff);
       display: grid;
       position: relative;
       overflow: hidden;
-      text-overflow: ellipse;
+      text-overflow: ellipsis;
       white-space: nowrap;
       background-color: transparent;
       width: 100%;
@@ -54,12 +54,12 @@ $person-card-background-color: var(--person-card-background-color, #ffffff);
           height: 100%;
           top: 0;
           right: 0;
-          background: linear-gradient(left, transparent, transparent 80%, $person-card-background-color);
-          background: -moz-linear-gradient(left, transparent, transparent 80%, $person-card-background-color);
-          background: -o-linear-gradient(left, transparent, transparent 80%, $person-card-background-color);
-          background: -ms-linear-gradient(left, transparent, transparent 80%, $person-card-background-color);
-          background: -webkit-linear-gradient(left, transparent, transparent 80%, $person-card-background-color);
-        }
+          background-image: linear-gradient(to right, rgba(255,255,255,0) 0%,rgba(255,255,255,0) 80%,$person-card-background-color 100%);
+          background-image: -moz-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,0) 80%,$person-card-background-color 100%);
+          background-image: -o-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,0) 80%,$person-card-background-color 100%);
+          background-image: -ms-linear-gradient(left right, rgba(255,255,255,0) 0%,rgba(255,255,255,0) 80%,$person-card-background-color 100%);
+          background-image: -webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,0) 80%,$person-card-background-color 100%);
+         }
       }
 
       .job-title {


### PR DESCRIPTION
Closes #433 

### PR Type
- Bugfix

### Description of the changes
Update linear gradient in css to fix safari madness...

Tested in Safari/Chrome/Edge Chromium

safari after update:
<img width="570" alt="Screen Shot 2020-06-03 at 3 37 29 PM" src="https://user-images.githubusercontent.com/7429891/83696251-d5eb0d80-a5b0-11ea-916f-b6871d6522c1.png">

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes
