### PR TITLE
People picker default search state for Groups and groupId

### DIFF
--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -676,6 +676,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
         this.requestUpdate();
         this.fireCustomEvent('selectionChanged', this.selectedPeople);
       }
+
       if (input) {
         people = [];
         if (this.type === PersonType.person || this.type === PersonType.any) {
@@ -701,7 +702,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
             }
           }
         }
-        // default group search with user input
+
         if ((this.type === PersonType.group || this.type === PersonType.any) && people.length < this.showMax) {
           people = [];
           try {

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -661,7 +661,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
           } else if (this.type === PersonType.person || this.type === PersonType.any) {
             people = await getPeople(graph);
           } else if (this.type === PersonType.group) {
-            const groups = (await findGroups(graph, input, this.showMax, this.groupType)) || [];
+            const groups = (await findGroups(graph, '', this.showMax, this.groupType)) || [];
             people = groups;
           }
           this.defaultPeople = people;
@@ -705,7 +705,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
         if ((this.type === PersonType.group || this.type === PersonType.any) && people.length < this.showMax) {
           people = [];
           try {
-            const groups = (await findGroups(graph, '', this.showMax, this.groupType)) || [];
+            const groups = (await findGroups(graph, input, this.showMax, this.groupType)) || [];
             people = people.concat(groups);
           } catch (e) {
             // nop

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -108,6 +108,13 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
   @property({
     attribute: 'type',
     converter: (value, type) => {
+      const capitalize = s => {
+        if (typeof s !== 'string') {
+          return '';
+        }
+        return s.charAt(0).toUpperCase() + s.toLowerCase().slice(1);
+      };
+      value = capitalize(value);
       if (!value || value.length === 0) {
         return PersonType.Any;
       }
@@ -712,7 +719,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
         }
       }
       // default group search without user input
-      if ((input.length === 0 && this.type === PersonType.Group) || this.type === PersonType.Any) {
+      if (input.length === 0 && this.type === PersonType.Group) {
         people = [];
         try {
           const groups = (await findGroups(graph, '', this.showMax, GroupType.Any)) || [];

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -652,8 +652,10 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
         if (this.defaultPeople) {
           people = this.defaultPeople;
         } else {
-          people = await getPeople(graph);
-          this.defaultPeople = people;
+          if (this.type === PersonType.Person || this.type === PersonType.Any) {
+            people = await getPeople(graph);
+            this.defaultPeople = people;
+          }
         }
         this._showLoading = false;
       }
@@ -701,14 +703,14 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
             }
           }
         }
-
-        if ((this.type === PersonType.Group || this.type === PersonType.Any) && people.length < this.showMax) {
-          try {
-            const groups = (await findGroups(graph, input, this.showMax, this.groupType)) || [];
-            people = people.concat(groups);
-          } catch (e) {
-            // nop
-          }
+      }
+      if (this.type === PersonType.Group || this.type === PersonType.Any) {
+        people = [];
+        try {
+          const groups = (await findGroups(graph, '', this.showMax, GroupType.Any)) || [];
+          people = people.concat(groups);
+        } catch (e) {
+          // nop
         }
       }
     }

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -141,7 +141,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     attribute: 'group-type',
     converter: (value, type) => {
       if (!value || value.length === 0) {
-        return GroupType.Any;
+        return GroupType.any;
       }
 
       const values = value.split(',');
@@ -155,7 +155,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       }
 
       if (groupTypes.length === 0) {
-        return GroupType.Any;
+        return GroupType.any;
       }
 
       // tslint:disable-next-line:no-bitwise
@@ -257,7 +257,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
 
   private _groupId: string;
   private _type: PersonType = PersonType.person;
-  private _groupType: GroupType = GroupType.Any;
+  private _groupType: GroupType = GroupType.any;
 
   private defaultPeople: IDynamicPerson[];
 

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -668,7 +668,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
         this.fireCustomEvent('selectionChanged', this.selectedPeople);
       }
 
-      if (this.groupId && input) {
+      if (this.groupId) {
         if (this._groupPeople === null) {
           try {
             this._groupPeople = await getPeopleFromGroup(graph, this.groupId);
@@ -678,7 +678,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
         }
 
         people = this._groupPeople || [];
-      } else if (input) {
+      } else if (!this.groupId && input) {
         people = [];
         if (this.type === PersonType.Person || this.type === PersonType.Any) {
           try {
@@ -703,8 +703,19 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
             }
           }
         }
+        // default group search with user input
+        if ((this.type === PersonType.Group || this.type === PersonType.Any) && people.length < this.showMax) {
+          people = [];
+          try {
+            const groups = (await findGroups(graph, '', this.showMax, this.groupType)) || [];
+            people = people.concat(groups);
+          } catch (e) {
+            // nop
+          }
+        }
       }
-      if (this.type === PersonType.Group || this.type === PersonType.Any) {
+      // default group search without user input
+      if ((input.length === 0 && this.type === PersonType.Group) || this.type === PersonType.Any) {
         people = [];
         try {
           const groups = (await findGroups(graph, '', this.showMax, GroupType.Any)) || [];

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -645,7 +645,6 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     if (!people && provider && provider.state === ProviderState.SignedIn) {
       const graph = provider.graph.forComponent(this);
 
-      // default common people
       if (!input.length && this._isFocused) {
         if (this.defaultPeople) {
           people = this.defaultPeople;
@@ -662,7 +661,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
           } else if (this.type === PersonType.person || this.type === PersonType.any) {
             people = await getPeople(graph);
           } else if (this.type === PersonType.group) {
-            const groups = (await findGroups(graph, '', this.showMax, GroupType.Any)) || [];
+            const groups = (await findGroups(graph, input, this.showMax, this.groupType)) || [];
             people = groups;
           }
           this.defaultPeople = people;

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -108,19 +108,13 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
   @property({
     attribute: 'type',
     converter: (value, type) => {
-      const capitalize = s => {
-        if (typeof s !== 'string') {
-          return '';
-        }
-        return s.charAt(0).toUpperCase() + s.toLowerCase().slice(1);
-      };
-      value = capitalize(value);
+      value = value.toLowerCase();
       if (!value || value.length === 0) {
-        return PersonType.Any;
+        return PersonType.any;
       }
 
       if (typeof PersonType[value] === 'undefined') {
-        return PersonType.Any;
+        return PersonType.any;
       } else {
         return PersonType[value];
       }
@@ -262,7 +256,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
   @property({ attribute: false }) private _showLoading: boolean;
 
   private _groupId: string;
-  private _type: PersonType = PersonType.Person;
+  private _type: PersonType = PersonType.person;
   private _groupType: GroupType = GroupType.Any;
 
   private defaultPeople: IDynamicPerson[];
@@ -665,9 +659,9 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
               }
             }
             people = this._groupPeople || [];
-          } else if (this.type === PersonType.Person || this.type === PersonType.Any) {
+          } else if (this.type === PersonType.person || this.type === PersonType.any) {
             people = await getPeople(graph);
-          } else if (this.type === PersonType.Group) {
+          } else if (this.type === PersonType.group) {
             const groups = (await findGroups(graph, '', this.showMax, GroupType.Any)) || [];
             people = groups;
           }
@@ -685,7 +679,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       }
       if (input) {
         people = [];
-        if (this.type === PersonType.Person || this.type === PersonType.Any) {
+        if (this.type === PersonType.person || this.type === PersonType.any) {
           try {
             people = (await findPeople(graph, input, this.showMax)) || [];
           } catch (e) {
@@ -709,7 +703,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
           }
         }
         // default group search with user input
-        if ((this.type === PersonType.Group || this.type === PersonType.Any) && people.length < this.showMax) {
+        if ((this.type === PersonType.group || this.type === PersonType.any) && people.length < this.showMax) {
           people = [];
           try {
             const groups = (await findGroups(graph, '', this.showMax, this.groupType)) || [];

--- a/src/graph/graph.groups.ts
+++ b/src/graph/graph.groups.ts
@@ -19,31 +19,31 @@ export enum GroupType {
   /**
    * Any group Type
    */
-  Any = 0,
+  any = 0,
 
   /**
    * Office 365 group
    */
   // tslint:disable-next-line:no-bitwise
-  Unified = 1 << 0,
+  unified = 1 << 0,
 
   /**
    * Security group
    */
   // tslint:disable-next-line:no-bitwise
-  Security = 1 << 1,
+  security = 1 << 1,
 
   /**
    * Mail Enabled Security group
    */
   // tslint:disable-next-line:no-bitwise
-  MailEnabledSecurity = 1 << 2,
+  mailenabledsecurity = 1 << 2,
 
   /**
    * Distribution Group
    */
   // tslint:disable-next-line:no-bitwise
-  Distribution = 1 << 3
+  distribution = 1 << 3
 }
 
 /**
@@ -53,14 +53,14 @@ export enum GroupType {
  * @param {IGraph} graph
  * @param {string} query - what to search for
  * @param {number} [top=10] - number of groups to return
- * @param {GroupType} [groupTypes=GroupType.Any] - the type of group to search for
+ * @param {GroupType} [groupTypes=GroupType.any] - the type of group to search for
  * @returns {Promise<Group[]>} An array of Groups
  */
 export async function findGroups(
   graph: IGraph,
   query: string,
   top: number = 10,
-  groupTypes: GroupType = GroupType.Any
+  groupTypes: GroupType = GroupType.any
 ): Promise<Group[]> {
   const scopes = 'Group.Read.All';
 
@@ -69,26 +69,26 @@ export async function findGroups(
     filterQuery = `(startswith(displayName,'${query}') or startswith(mailNickname,'${query}') or startswith(mail,'${query}'))`;
   }
 
-  if (groupTypes !== GroupType.Any) {
+  if (groupTypes !== GroupType.any) {
     const filterGroups = [];
 
     // tslint:disable-next-line:no-bitwise
-    if (GroupType.Unified === (groupTypes & GroupType.Unified)) {
+    if (GroupType.unified === (groupTypes & GroupType.unified)) {
       filterGroups.push("groupTypes/any(c:c+eq+'Unified')");
     }
 
     // tslint:disable-next-line:no-bitwise
-    if (GroupType.Security === (groupTypes & GroupType.Security)) {
+    if (GroupType.security === (groupTypes & GroupType.security)) {
       filterGroups.push('(mailEnabled eq false and securityEnabled eq true)');
     }
 
     // tslint:disable-next-line:no-bitwise
-    if (GroupType.MailEnabledSecurity === (groupTypes & GroupType.MailEnabledSecurity)) {
+    if (GroupType.mailenabledsecurity === (groupTypes & GroupType.mailenabledsecurity)) {
       filterGroups.push('(mailEnabled eq true and securityEnabled eq true)');
     }
 
     // tslint:disable-next-line:no-bitwise
-    if (GroupType.Distribution === (groupTypes & GroupType.Distribution)) {
+    if (GroupType.distribution === (groupTypes & GroupType.distribution)) {
       filterGroups.push('(mailEnabled eq true and securityEnabled eq false)');
     }
 

--- a/src/graph/graph.groups.ts
+++ b/src/graph/graph.groups.ts
@@ -64,7 +64,10 @@ export async function findGroups(
 ): Promise<Group[]> {
   const scopes = 'Group.Read.All';
 
-  let filterQuery = `(startswith(displayName,'${query}') or startswith(mailNickname,'${query}') or startswith(mail,'${query}'))`;
+  let filterQuery = '';
+  if (query !== '') {
+    filterQuery = `(startswith(displayName,'${query}') or startswith(mailNickname,'${query}') or startswith(mail,'${query}'))`;
+  }
 
   if (groupTypes !== GroupType.Any) {
     const filterGroups = [];

--- a/src/graph/graph.groups.ts
+++ b/src/graph/graph.groups.ts
@@ -92,7 +92,7 @@ export async function findGroups(
       filterGroups.push('(mailEnabled eq true and securityEnabled eq false)');
     }
 
-    filterQuery += ' and ' + filterGroups.join(' or ');
+    filterQuery += (query !== '' ? ' and ' : '') + filterGroups.join(' or ');
   }
 
   const result = await graph

--- a/src/graph/graph.people.ts
+++ b/src/graph/graph.people.ts
@@ -51,14 +51,13 @@ export async function findPeople(
 
   let filterQuery = '';
 
-  // converts personType to capitalized case
-  const personTypeString =
-    personType
-      .toString()
-      .charAt(0)
-      .toUpperCase() + personType.toString().slice(1);
-
   if (personType !== PersonType.any) {
+    // converts personType to capitalized case
+    const personTypeString =
+      personType
+        .toString()
+        .charAt(0)
+        .toUpperCase() + personType.toString().slice(1);
     filterQuery = `personType/class eq '${personTypeString}'`;
   }
 

--- a/src/graph/graph.people.ts
+++ b/src/graph/graph.people.ts
@@ -20,17 +20,17 @@ export enum PersonType {
   /**
    * Any type
    */
-  Any = 0,
+  any = 0,
 
   /**
    * A Person such as User or Contact
    */
-  Person = 'Person',
+  person = 'person',
 
   /**
    * A group
    */
-  Group = 'Group'
+  group = 'group'
 }
 
 /**
@@ -45,13 +45,13 @@ export async function findPeople(
   graph: IGraph,
   query: string,
   top: number = 10,
-  personType: PersonType = PersonType.Person
+  personType: PersonType = PersonType.person
 ): Promise<Person[]> {
   const scopes = 'people.read';
 
   let filterQuery = '';
 
-  if (personType !== PersonType.Any) {
+  if (personType !== PersonType.any) {
     filterQuery = `personType/class eq '${personType}'`;
   }
 

--- a/src/graph/graph.people.ts
+++ b/src/graph/graph.people.ts
@@ -38,7 +38,7 @@ export enum PersonType {
  *
  * @param {string} query
  * @param {number} [top=10] - number of people to return
- * @param {PersonType} [personType=PersonType.Person] - the type of person to search for
+ * @param {PersonType} [personType=PersonType.person] - the type of person to search for
  * @returns {(Promise<Person[]>)}
  */
 export async function findPeople(
@@ -51,8 +51,15 @@ export async function findPeople(
 
   let filterQuery = '';
 
+  // converts personType to capitalized case
+  const personTypeString =
+    personType
+      .toString()
+      .charAt(0)
+      .toUpperCase() + personType.toString().slice(1);
+
   if (personType !== PersonType.any) {
-    filterQuery = `personType/class eq '${personType}'`;
+    filterQuery = `personType/class eq '${personTypeString}'`;
   }
 
   const result = await graph

--- a/stories/components/login.stories.js
+++ b/stories/components/login.stories.js
@@ -36,7 +36,7 @@ export const Templates = () => html`
   </template>
   <template data-type="flyout-commands">
     <div>
-      <button data-props="{@click: handleSignOut}">Sign Out</button>
+      <button data-props="@click: handleSignOut">Sign Out</button>
       <button>Go to my profile</button>
     </div>
   </template>

--- a/stories/components/peoplePicker.stories.js
+++ b/stories/components/peoplePicker.stories.js
@@ -50,16 +50,16 @@ export const DarkMode = () => html`
 `;
 
 export const pickPeopleAndGroups = () => html`
-  <mgt-people-picker type="Any"></mgt-people-picker>
-  <!-- type can be "Any", "Person", "Group" -->
+  <mgt-people-picker type="any"></mgt-people-picker>
+  <!-- type can be "any", "person", "group" -->
 `;
 
 export const pickGroups = () => html`
-  <mgt-people-picker type="Group"></mgt-people-picker>
-  <!-- type can be "Any", "Person", "Group" -->
+  <mgt-people-picker type="group"></mgt-people-picker>
+  <!-- type can be "any", "person", "group" -->
 `;
 
 export const pickDistributionGroups = () => html`
-  <mgt-people-picker type="Group" group-type="Distribution"></mgt-people-picker>
-  <!-- group-type can be "Any", "Unified", "Security", "MailEnabledSecurity", "Distribution" -->
+  <mgt-people-picker type="group" group-type="distribution"></mgt-people-picker>
+  <!-- group-type can be "any", "unified", "security", "mailenabledsecurity", "distribution" -->
 `;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #470 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Updates the people picker default search states so that if attribute `Type="Group"` will force no input to search the general graph endpoint `/groups`.

groupId attribute also has updated search state for no input. 


### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [ ] License header has been added to all new source files (`npm run setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
