### PR TITLE
Fixed Agenda not loading on Edge classic

### DIFF
--- a/src/components/mgt-agenda/mgt-agenda.ts
+++ b/src/components/mgt-agenda/mgt-agenda.ts
@@ -68,7 +68,7 @@ export class MgtAgenda extends MgtTemplatedComponent {
     }
 
     this._date = value;
-    this.requestStateUpdate(true);
+    this.reloadState();
   }
 
   /**
@@ -88,7 +88,7 @@ export class MgtAgenda extends MgtTemplatedComponent {
     }
 
     this._groupId = value;
-    this.requestStateUpdate(true);
+    this.reloadState();
   }
 
   /**
@@ -108,7 +108,7 @@ export class MgtAgenda extends MgtTemplatedComponent {
     }
 
     this._days = value;
-    this.requestStateUpdate(true);
+    this.reloadState();
   }
 
   /**
@@ -128,7 +128,7 @@ export class MgtAgenda extends MgtTemplatedComponent {
     }
 
     this._eventQuery = value;
-    this.requestStateUpdate(true);
+    this.reloadState();
   }
 
   /**
@@ -234,20 +234,6 @@ export class MgtAgenda extends MgtTemplatedComponent {
         ${this.isLoadingState ? this.renderLoading() : html``}
       </div>
     `;
-  }
-
-  /**
-   * Request to reload the state.
-   * Use reload instead of load to ensure loading events are fired.
-   *
-   * @protected
-   * @memberof MgtBaseComponent
-   */
-  protected async requestStateUpdate(force?: boolean) {
-    if (force) {
-      this.events = null;
-    }
-    super.requestStateUpdate(force);
   }
 
   /**
@@ -537,6 +523,11 @@ export class MgtAgenda extends MgtTemplatedComponent {
         }
       }
     }
+  }
+
+  private async reloadState() {
+    this.events = null;
+    this.requestStateUpdate(true);
   }
 
   private onResize() {


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #453 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
The issue was caused because the overwritten `requestStateUpdate` was not getting called in Edge - possibly because of an Edge bug. The fix was to not overwrite `requestStateUpdate`.

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] Contains **NO** breaking changes

