### PR TITLE
Channel picker wrap && close button re-arrange

### DIFF
--- a/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.scss
+++ b/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.scss
@@ -67,7 +67,7 @@ $dropdown-item-selected-background: var(--dropdown-item-selected-background, #de
     .channel-chosen-list {
       min-height: 29px;
       display: flex;
-      flex-wrap: wrap;
+      flex-wrap: nowrap;
       vertical-align: middle;
       margin: 0 0 0 0;
       list-style-type: none;
@@ -106,7 +106,7 @@ $dropdown-item-selected-background: var(--dropdown-item-selected-background, #de
         font-weight: normal;
         font-size: 14px;
         line-height: 19px;
-        background-color: $input-background-color;
+        background-color: transparent;
         color: $font-color;
         padding-left: 5px;
         &::placeholder {
@@ -120,7 +120,8 @@ $dropdown-item-selected-background: var(--dropdown-item-selected-background, #de
       .close-icon {
         display: inline-block;
         position: absolute;
-        right: 10px;
+        right: 0;
+        padding: 10px;
         line-height: normal;
         font-family: 'FabricMDL2Icons';
         margin-bottom: 1px;

--- a/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.ts
+++ b/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.ts
@@ -287,7 +287,7 @@ export class MgtTeamsChannelPicker extends MgtTemplatedComponent {
               ${!this._selectedItemState ? getSvg(SvgIcon.Search, '#252424') : ''}
             </div>
             <div class="channel-chosen-list">
-              ${this.renderSelected()} ${this.renderInput()}
+              ${this.renderSelected()} ${this.renderInput()} ${this.renderCloseButton()}
             </div>
           </div>
           <div class=${classMap(dropdownClasses)}>${this.renderDropdown()}</div>
@@ -313,9 +313,6 @@ export class MgtTeamsChannelPicker extends MgtTemplatedComponent {
         <div class="selected-team-name">${this._selectedItemState.parent.item.displayName}</div>
         <div class="arrow">${getSvg(SvgIcon.TeamSeparator, '#B3B0AD')}</div>
         ${this._selectedItemState.item.displayName}
-        <div class="close-icon" @click="${() => this.selectChannel(null)}">
-          
-        </div>
       </li>
       <div class="search-icon">
         ${this._isFocused ? getSvg(SvgIcon.Search, '#252424') : ''}
@@ -348,6 +345,21 @@ export class MgtTeamsChannelPicker extends MgtTemplatedComponent {
           role="input"
           @input=${e => this.handleInputChanged(e)}
         />
+      </div>
+    `;
+  }
+
+  /**
+   * Renders close button
+   *
+   * @protected
+   * @returns
+   * @memberof MgtTeamsChannelPicker
+   */
+  protected renderCloseButton() {
+    return html`
+      <div class="close-icon" @click="${() => this.selectChannel(null)}">
+        
       </div>
     `;
   }


### PR DESCRIPTION
Closes #467 

### PR Type
- Bugfix 

### Description of the changes
Renders close button as the last child of the group.
Add no wrap for container
Change input background for overflow

Tested in Safari/Chrome/Edge Chromium
<img width="503" alt="Screen Shot 2020-06-04 at 1 26 38 PM" src="https://user-images.githubusercontent.com/7429891/83806905-0ee5b980-a667-11ea-82e4-09d68ad9ffbd.png">

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes

