### PR TITLE
fix for backspace infinite loading, and refresh people-list upon deletion

### DIFF
--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -867,6 +867,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       this.userInput = '';
       // remove last person in selected list
       this.selectedPeople = this.selectedPeople.splice(0, this.selectedPeople.length - 1);
+      this.loadState();
       // reset flyout position
       this.hideFlyout();
       this.showFlyout();

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -867,6 +867,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       this.userInput = '';
       // remove last person in selected list
       this.selectedPeople = this.selectedPeople.splice(0, this.selectedPeople.length - 1);
+      this.loadState();
       // reset flyout position
       this.hideFlyout();
       this.showFlyout();
@@ -875,7 +876,9 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       return;
     }
 
-    this.handleUserSearch(input);
+    if (input.value) {
+      this.handleUserSearch(input);
+    }
   }
 
   private onPersonClick(person: IDynamicPerson): void {

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -867,7 +867,6 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       this.userInput = '';
       // remove last person in selected list
       this.selectedPeople = this.selectedPeople.splice(0, this.selectedPeople.length - 1);
-      this.loadState();
       // reset flyout position
       this.hideFlyout();
       this.showFlyout();
@@ -893,7 +892,6 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
    * @param input - input text
    */
   private handleUserSearch(input: HTMLInputElement) {
-    this._showLoading = true;
     if (!this._debouncedSearch) {
       this._debouncedSearch = debounce(async () => {
         // Wait a few milliseconds before showing the flyout.
@@ -915,8 +913,11 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       }, 400);
     }
 
-    this.userInput = input.value;
-    this._debouncedSearch();
+    if (this.userInput !== input.value) {
+      this._showLoading = true;
+      this.userInput = input.value;
+      this._debouncedSearch();
+    }
   }
 
   /**

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -876,9 +876,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       return;
     }
 
-    if (input.value) {
-      this.handleUserSearch(input);
-    }
+    this.handleUserSearch(input);
   }
 
   private onPersonClick(person: IDynamicPerson): void {
@@ -917,10 +915,8 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       }, 400);
     }
 
-    if (this.userInput !== input.value) {
-      this.userInput = input.value;
-      this._debouncedSearch();
-    }
+    this.userInput = input.value;
+    this._debouncedSearch();
   }
 
   /**


### PR DESCRIPTION

<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #436 
### PR Type
<!-- Please uncomment one ore more that apply to this PR -->
 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Checks for input value so backspace isn't registered as a potential search, if there is no value. This fixes the issue with infinite loading. 

`loadstate` called upon deletion so that people list is refreshed with the available people. 

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
