### PR TITLE
people-picker behavior on focus and selection

### DIFF
--- a/src/components/mgt-people-picker/mgt-people-picker.scss
+++ b/src/components/mgt-people-picker/mgt-people-picker.scss
@@ -77,6 +77,10 @@ mgt-people-picker .flyout-root {
 
 :host .people-selected-input,
 mgt-people-picker .people-selected-input {
+  box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  flex: 1 0 auto;
   font-family: var(--default-font-family, 'Segoe UI');
   position: relative;
   border: none;
@@ -98,6 +102,7 @@ mgt-people-picker .people-selected-input {
 
 :host .people-selected-list,
 mgt-people-picker .people-selected-list {
+  flex: 1 0 auto;
   display: flex;
   flex-wrap: wrap;
   vertical-align: middle;
@@ -173,6 +178,7 @@ mgt-people-picker .input-search.input-search--start {
 :host .people-picker-input,
 mgt-people-picker .people-picker-input {
   display: flex;
+  flex-wrap: wrap;
   order: 2;
   background-color: $input-background-color;
   margin: $avatar-margin;
@@ -299,4 +305,8 @@ mgt-people-picker .people-person-text-area {
   max-height: 40px;
   overflow: hidden;
   color: $font-color;
+}
+
+mgt-flyout {
+  flex: 1 0 auto;
 }

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -303,7 +303,6 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     if (!peopleInput) {
       return;
     }
-    this.handleFlyout();
     peopleInput.focus(options);
     peopleInput.select();
   }
@@ -352,11 +351,10 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     };
     return html`
       <div class=${classMap(inputClasses)} @click=${e => this.focus(e)}>
-        <div class="people-picker-input">
-          <div class="people-selected-list">
-            ${selectedPeopleTemplate} ${flyoutTemplate}
-          </div>
+        <div class="people-selected-list">
+          ${selectedPeopleTemplate} ${flyoutTemplate}
         </div>
+        <div class="people-picker-input"></div>
       </div>
     `;
   }

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -266,6 +266,8 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
   // List of people requested if group property is provided
   private _groupPeople: IDynamicPerson[];
   private _debouncedSearch: { (): void; (): void };
+
+  private madeSelection = false;
   @internalProperty() private _isFocused = false;
 
   @internalProperty() private _foundPeople: IDynamicPerson[];
@@ -314,10 +316,14 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     }
 
     if (shouldShow) {
-      window.requestAnimationFrame(() => {
-        // Mouse is focused on input
-        this.showFlyout();
-      });
+      if (!this.madeSelection) {
+        window.requestAnimationFrame(() => {
+          // Mouse is focused on input
+          this.showFlyout();
+        });
+      } else {
+        this.madeSelection = false;
+      }
     }
   }
 
@@ -789,6 +795,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
 
         this.loadState();
         this._foundPeople = [];
+        this.madeSelection = true;
       }
     }
   }
@@ -884,7 +891,6 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     if (this.selectionMode === 'single') {
       return;
     }
-    this.focus();
   }
 
   /**

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -643,7 +643,6 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
    * set's `this.groupPeople` to those members.
    */
   protected async loadState(): Promise<void> {
-    console.log('loadstate');
     let people = this.people;
     const input = this.userInput.toLowerCase();
 
@@ -755,7 +754,6 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
    * @memberof MgtPeoplePicker
    */
   protected showFlyout(): void {
-    console.log('show flyout');
     const flyout = this.flyout;
     if (flyout) {
       flyout.open();
@@ -810,12 +808,10 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     }
     this._showLoading = true;
     this.loadState();
-    console.log('gained focus');
   }
 
   private lostFocus() {
     this._isFocused = false;
-    console.log('lostfocus');
   }
 
   private renderHighlightText(person: IDynamicPerson): TemplateResult {
@@ -878,6 +874,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       this.userInput = '';
       // remove last person in selected list
       this.selectedPeople = this.selectedPeople.splice(0, this.selectedPeople.length - 1);
+      this.loadState();
       this.hideFlyout();
       // fire selected people changed event
       this.fireCustomEvent('selectionChanged', this.selectedPeople);
@@ -932,6 +929,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     }
 
     if (this.userInput !== input.value) {
+      this._showLoading = true;
       this.userInput = input.value;
       this._debouncedSearch();
     }

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -460,7 +460,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
             <div class="people-person">
               ${this.renderTemplate('selected-person', { person }, `selected-${person.id}`) ||
                 this.renderSelectedPerson(person)}
-              <div class="CloseIcon" @click="${() => this.removePerson(person)}">\uE711</div>
+              <div class="CloseIcon" @click="${e => this.removePerson(person, e)}">\uE711</div>
             </div>
           `
       )}
@@ -765,7 +765,8 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
    * Removes person from selected people
    * @param person - person and details pertaining to user selected
    */
-  protected removePerson(person: IDynamicPerson): void {
+  protected removePerson(person: IDynamicPerson, e: MouseEvent): void {
+    e.stopPropagation();
     const filteredPersonArr = this.selectedPeople.filter(p => {
       return p.id !== person.id;
     });
@@ -874,9 +875,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       this.userInput = '';
       // remove last person in selected list
       this.selectedPeople = this.selectedPeople.splice(0, this.selectedPeople.length - 1);
-      // reset flyout position
       this.hideFlyout();
-      this.showFlyout();
       // fire selected people changed event
       this.fireCustomEvent('selectionChanged', this.selectedPeople);
       return;

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -448,23 +448,6 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       )}
     `;
   }
-
-  private handleFlyout() {
-    // handles hiding control if default people have no more selections available
-    const peopleLeft = this.filterPeople(this.defaultPeople);
-    let shouldShow = true;
-    if (peopleLeft && peopleLeft.length === 0) {
-      shouldShow = false;
-    }
-
-    if (shouldShow) {
-      window.requestAnimationFrame(() => {
-        // Mouse is focused on input
-        this.showFlyout();
-      });
-    }
-  }
-
   /**
    * Render the flyout chrome.
    *
@@ -795,6 +778,22 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
         this.loadState();
         this._foundPeople = [];
       }
+    }
+  }
+
+  private handleFlyout() {
+    // handles hiding control if default people have no more selections available
+    const peopleLeft = this.filterPeople(this.defaultPeople);
+    let shouldShow = true;
+    if (peopleLeft && peopleLeft.length === 0) {
+      shouldShow = false;
+    }
+
+    if (shouldShow) {
+      window.requestAnimationFrame(() => {
+        // Mouse is focused on input
+        this.showFlyout();
+      });
     }
   }
 

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -903,7 +903,6 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
    * @param input - input text
    */
   private handleUserSearch(input: HTMLInputElement) {
-    this._showLoading = true;
     if (!this._debouncedSearch) {
       this._debouncedSearch = debounce(async () => {
         // Wait a few milliseconds before showing the flyout.

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -560,7 +560,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
               'list-person': true
             };
             return html`
-              <li class="${classMap(listPersonClasses)}" @click="${e => this.onPersonClick(person, e)}">
+              <li class="${classMap(listPersonClasses)}" @click="${e => this.onPersonClick(person)}">
                 ${this.renderPersonResult(person)}
               </li>
             `;
@@ -880,8 +880,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     this.handleUserSearch(input);
   }
 
-  private onPersonClick(person: IDynamicPerson, e: MouseEvent): void {
-    e.stopPropagation();
+  private onPersonClick(person: IDynamicPerson): void {
     this.addPerson(person);
     this.hideFlyout();
 

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -354,7 +354,6 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
         <div class="people-selected-list">
           ${selectedPeopleTemplate} ${flyoutTemplate}
         </div>
-        <div class="people-picker-input"></div>
       </div>
     `;
   }
@@ -902,6 +901,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
    */
   private handleUserSearch(input: HTMLInputElement) {
     if (!this._debouncedSearch) {
+      this._showLoading = true;
       this._debouncedSearch = debounce(async () => {
         // Wait a few milliseconds before showing the flyout.
         // This helps prevent loading state flickering while the user is actively changing the query.
@@ -923,7 +923,6 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     }
 
     if (this.userInput !== input.value) {
-      this._showLoading = true;
       this.userInput = input.value;
       this._debouncedSearch();
     }

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -267,7 +267,6 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
   private _groupPeople: IDynamicPerson[];
   private _debouncedSearch: { (): void; (): void };
 
-  private madeSelection = false;
   @internalProperty() private _isFocused = false;
 
   @internalProperty() private _foundPeople: IDynamicPerson[];
@@ -795,7 +794,6 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
 
         this.loadState();
         this._foundPeople = [];
-        this.madeSelection = true;
       }
     }
   }

--- a/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -670,8 +670,8 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
           }
           this.defaultPeople = people;
         }
-        this._showLoading = false;
       }
+      this._showLoading = false;
 
       if (this.defaultSelectedUserIds && !this.selectedPeople.length) {
         const defaultSelectedUsers = await getUsersForUserIds(graph, this.defaultSelectedUserIds);


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #456 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Upon selection of people in the `mgt-people-picker` the people flyout will now not show unless the user refocuses in the input area. 

deletion of a selection behaves similarity now too. 

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
