### PR TITLE
handling picker y-overflow in ie11

### DIFF
--- a/src/components/mgt-people-picker/mgt-people-picker.scss
+++ b/src/components/mgt-people-picker/mgt-people-picker.scss
@@ -36,6 +36,8 @@ $font-color: var(--font-color, #323130);
   font-family: var(--default-font-family, 'Segoe UI');
   height: 38px;
   display: contents;
+  height: 100%;
+  overflow: hidden;
 }
 :host .root,
 mgt-people-picker .root {
@@ -44,7 +46,6 @@ mgt-people-picker .root {
 
 :host .people-picker,
 mgt-people-picker .people-picker {
-  position: relative;
   background-color: $input-background-color;
   padding-bottom: 6px;
   border: $input-border;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #437 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

- fixes overflow issue in ie11 with `overflow: hidden` 

-  **height: 100%** prevents overflow with teams channel picker overflow. 


### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
