### PR TITLE
teams-channel-picker dropdown scrolling

### DIFF
--- a/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.scss
+++ b/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.scss
@@ -204,6 +204,8 @@ $dropdown-item-selected-background: var(--dropdown-item-selected-background, #de
     font-weight: normal;
     color: $font-color;
     display: none;
+    max-height: 346px;
+    overflow-y: auto;
 
     &.visible {
       display: block;

--- a/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.ts
+++ b/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.ts
@@ -452,6 +452,12 @@ export class MgtTeamsChannelPicker extends MgtTemplatedComponent {
       selected: isSelected
     };
 
+    const dropDown = this.renderRoot.querySelector('.dropdown');
+
+    if (dropDown.children[this._focusedIndex]) {
+      dropDown.children[this._focusedIndex].scrollIntoView(false);
+    }
+
     return html`
       <div @click=${() => this.handleItemClick(itemState)} class="${classMap(classes)}">
         <div class="arrow">


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/CONTRIBUTING.md -->

Closes #473 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Updates the `teams-channel-picker` to use a fluent guideline standard for flyout height of 360px. (Total for flyout, adjusted in real `px` for margin) 

Overflow is now shown by a scroll bar, which is controlled by mouse or key user interaction. 

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
