### PR TITLE
Add css custom property to change mgt person background color

### DIFF
--- a/src/components/mgt-person-card/mgt-person-card.scss
+++ b/src/components/mgt-person-card/mgt-person-card.scss
@@ -30,8 +30,12 @@ $person-card-background-color: var(--person-card-background-color, #ffffff);
     display: flex;
     padding: 18px 14px;
 
-    mgt-person.person-image {
-      --avatar-size: 75px;
+    mgt-person {
+      --background-color: var(--person-card-background-color, #ffffff);
+
+      &.person-image {
+        --avatar-size: 75px;
+      }
     }
 
     .details {
@@ -54,12 +58,37 @@ $person-card-background-color: var(--person-card-background-color, #ffffff);
           height: 100%;
           top: 0;
           right: 0;
-          background-image: linear-gradient(to right, rgba(255,255,255,0) 0%,rgba(255,255,255,0) 80%,$person-card-background-color 100%);
-          background-image: -moz-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,0) 80%,$person-card-background-color 100%);
-          background-image: -o-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,0) 80%,$person-card-background-color 100%);
-          background-image: -ms-linear-gradient(left right, rgba(255,255,255,0) 0%,rgba(255,255,255,0) 80%,$person-card-background-color 100%);
-          background-image: -webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,0) 80%,$person-card-background-color 100%);
-         }
+          background-image: linear-gradient(
+            to right,
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 0) 80%,
+            $person-card-background-color 100%
+          );
+          background-image: -moz-linear-gradient(
+            left,
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 0) 80%,
+            $person-card-background-color 100%
+          );
+          background-image: -o-linear-gradient(
+            left,
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 0) 80%,
+            $person-card-background-color 100%
+          );
+          background-image: -ms-linear-gradient(
+            left,
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 0) 80%,
+            $person-card-background-color 100%
+          );
+          background-image: -webkit-linear-gradient(
+            left,
+            rgba(255, 255, 255, 0) 0%,
+            rgba(255, 255, 255, 0) 80%,
+            $person-card-background-color 100%
+          );
+        }
       }
 
       .job-title {

--- a/src/components/mgt-person/mgt-person.scss
+++ b/src/components/mgt-person/mgt-person.scss
@@ -21,6 +21,7 @@ $font-size: var(--font-size, #{$ms-font-size-m});
 $font-weight: var(--font-weight, #{$ms-font-weight-semibold});
 $color: var(--color, #{$ms-color-neutralDark});
 $text-transform: var(text-transform, none);
+$background-color: var(--background-color, #ffffff);
 
 $line2-font-size: var(--line2-font-size, var(--email-font-size, #{$ms-font-size-s}));
 $line2-font-weight: var(--line2-font-weight, 400);
@@ -67,6 +68,7 @@ mgt-person .person-root {
   position: relative;
   display: flex;
   align-items: center;
+  background-color: $background-color;
 
   .user-avatar {
     width: $avatar-size;
@@ -83,11 +85,11 @@ mgt-person .person-root {
       top: calc(#{$avatar-size} * 0.72 - 4px);
       width: calc(v#{$avatar-size} * 0.28);
       height: calc(#{$avatar-size} * 0.28);
-      border: 2px solid #ffffff;
+      border: 2px solid $background-color;
       border-radius: 50%;
 
       .presence-oof-offline-wrapper {
-        background-color: #ffffff;
+        background-color: $background-color;
         border-color: $presence-color-oof;
 
         .presence-oof-offline svg {
@@ -110,7 +112,7 @@ mgt-person .person-root {
         align-items: center;
 
         &.presence-offline {
-          background-color: #ffffff;
+          background-color: $background-color;
           border-color: $presence-color-invisible;
         }
 
@@ -120,7 +122,7 @@ mgt-person .person-root {
         }
 
         &.presence-oof-available {
-          background-color: #ffffff;
+          background-color: $background-color;
           border-color: $presence-color-online;
         }
 
@@ -135,7 +137,7 @@ mgt-person .person-root {
         }
 
         &.presence-oof-dnd {
-          background-color: #ffffff;
+          background-color: $background-color;
           border-color: $presence-color-dnd;
         }
 
@@ -145,7 +147,7 @@ mgt-person .person-root {
         }
 
         &.presence-oof-busy {
-          background-color: #ffffff;
+          background-color: $background-color;
           border-color: $presence-color-dnd;
         }
       }
@@ -159,7 +161,7 @@ mgt-person .person-root {
 
       .presence-available::before {
         content: $ms-icon-code-SkypeCheck;
-        color: #ffffff;
+        color: $background-color;
         margin-left: calc(#{$avatar-size} * 0.07 - 2px);
       }
 
@@ -171,13 +173,13 @@ mgt-person .person-root {
 
       .presence-away::before {
         content: $ms-icon-code-SkypeClock;
-        color: #ffffff;
+        color: $background-color;
         margin-left: calc(#{$avatar-size} * 0.07 - 2px);
       }
 
       .presence-dnd::before {
         content: $ms-icon-code-SkypeMinus;
-        color: #ffffff;
+        color: $background-color;
         margin-left: calc(#{$avatar-size} * 0.07 - 2px);
       }
 

--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -66,6 +66,7 @@ export enum PersonViewType {
  * @cssprop --font-size - {Length} Font size
  * @cssprop --font-weight - {Length} Font weight
  * @cssprop --color - {Color} Color
+ * @cssprop --background-color - {Color} Background color
  * @cssprop --text-transform - {String} text transform
  * @cssprop --line2-font-size - {Length} Line 2 font size
  * @cssprop --line2-font-weight - {Length} Line 2 font weight


### PR DESCRIPTION
Closes #429 

### PR Type
 - Bugfix

### Description of the changes
Added a css custom property to mgt-person. By changing this property, the background color will be set as well as the background color, border color, and icon color of presence badge. Example as below:
<img width="938" alt="Screen Shot 2020-06-26 at 10 34 17 AM" src="https://user-images.githubusercontent.com/7429891/85885471-3bd64980-b799-11ea-8cda-8d82d29a5b61.png">

_**Will add PR to docs once review on the naming and approach is approved._

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: https://github.com/microsoftgraph/microsoft-graph-docs/pull/8906
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes

### Other information

