### PR TITLE
polyfills and config necessary for SPFx ie11 support

### DIFF
--- a/samples/sp-webpart/gulpfile.js
+++ b/samples/sp-webpart/gulpfile.js
@@ -4,4 +4,28 @@ const gulp = require('gulp');
 const build = require('@microsoft/sp-build-web');
 build.addSuppression(`Warning - [sass] The local CSS class 'ms-Grid' is not camelCase and will not be type-safe.`);
 
+build.configureWebpack.mergeConfig({
+    additionalConfiguration: (generatedConfiguration) => {
+      generatedConfiguration.module.rules.push(
+        {
+          test: /\.m?js$/, use:
+          {
+            loader: "babel-loader",
+            options:
+            {
+              presets: [["@babel/preset-env",
+                {
+                  targets: {
+                    "ie": "11"
+                  }
+                }]]
+            }
+          }
+        }
+      );
+  
+      return generatedConfiguration;
+    }
+  });
+
 build.initialize(gulp);

--- a/samples/sp-webpart/package.json
+++ b/samples/sp-webpart/package.json
@@ -30,6 +30,8 @@
     "@types/react": "16.8.8"
   },
   "devDependencies": {
+    "@babel/core": "^7.10.3",
+    "@babel/preset-env": "^7.10.3",
     "@microsoft/rush-stack-compiler-3.7": "0.2.9",
     "@microsoft/sp-build-web": "1.10.0",
     "@microsoft/sp-module-interfaces": "1.10.0",
@@ -38,7 +40,10 @@
     "@types/chai": "3.4.34",
     "@types/mocha": "2.2.38",
     "ajv": "~5.2.2",
+    "babel-loader": "^8.1.0",
     "gulp": "~3.9.1",
-    "typescript": "^3.4.3"
+    "regenerator-runtime": "^0.13.5",
+    "typescript": "^3.4.3",
+    "webpack": "^4.43.0"
   }
 }

--- a/samples/sp-webpart/src/webparts/mgtDemo/MgtDemoWebPart.ts
+++ b/samples/sp-webpart/src/webparts/mgtDemo/MgtDemoWebPart.ts
@@ -2,17 +2,21 @@ import * as React from 'react';
 import * as ReactDom from 'react-dom';
 import { Version } from '@microsoft/sp-core-library';
 import { BaseClientSideWebPart } from '@microsoft/sp-webpart-base';
-import {
-  IPropertyPaneConfiguration,
-  PropertyPaneTextField
-} from '@microsoft/sp-property-pane';
+import { IPropertyPaneConfiguration, PropertyPaneTextField } from '@microsoft/sp-property-pane';
+
+// import web component polyfills for browsers that need them
+import 'regenerator-runtime/runtime';
+import 'core-js/es/number';
+import 'core-js/es/math';
+import 'core-js/es/string';
+import 'core-js/es/date';
+import 'core-js/es/array';
+import 'core-js/es/regexp';
+import '@webcomponents/webcomponentsjs/webcomponents-bundle.js';
 
 import * as strings from 'MgtDemoWebPartStrings';
 import MgtDemo from './components/MgtDemo';
 import { IMgtDemoProps } from './components/IMgtDemoProps';
-
-// import web component polyfills for browsers that need them
-import '@webcomponents/webcomponentsjs/webcomponents-bundle.js';
 
 // import the providers at the top of the page
 import { Providers, SharePointProvider } from '@microsoft/mgt';


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #276 
### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Updates our SPFx sample to support use of ie11. Uses a new `gulpfile.ts` config and additional polyfills. 

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: https://github.com/microsoftgraph/microsoft-graph-docs/pull/8884
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
