### PR TITLE
storybook code editor auto indent

### DIFF
--- a/.storybook/addons/codeEditorAddon/editor.js
+++ b/.storybook/addons/codeEditorAddon/editor.js
@@ -3,10 +3,10 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
 let debounce = (func, wait, immediate) => {
   var timeout;
-  return function () {
+  return function() {
     var context = this,
       args = arguments;
-    var later = function () {
+    var later = function() {
       timeout = null;
       if (!immediate) func.apply(context, args);
     };
@@ -32,16 +32,14 @@ export class EditorElement extends LitElement {
         background-color: rgb(243, 243, 243);
       }
 
-      
-
       .editor-root {
         flex-basis: 100%;
       }
 
       .tab {
-        background-color: rgb(236,236,236);
+        background-color: rgb(236, 236, 236);
         color: #616161;
-        font-family: -apple-system,BlinkMacSystemFont,sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, sans-serif;
         font-size: 11px;
         padding: 8px 18px;
         display: inline-block;
@@ -181,17 +179,21 @@ export class EditorElement extends LitElement {
       this.editor.setModel(this.currentEditorState.model);
       this.editor.restoreViewState(this.currentEditorState.state);
     }
+
+    this.editor.getAction('editor.action.formatDocument').run();
   }
 
   render() {
     return html`
       <div class="root">
         <div class="tab-root">
-          ${this.fileTypes.map(type => html`
-            <div @click="${_ => this.showTab(type)}"
-                class="tab ${type === this.currentType ? 'selected' : ''}">
-              ${type}
-            </div>`)}
+          ${this.fileTypes.map(
+            type => html`
+              <div @click="${_ => this.showTab(type)}" class="tab ${type === this.currentType ? 'selected' : ''}">
+                ${type}
+              </div>
+            `
+          )}
         </div>
         <div class="editor-root">
           <slot name="editor"></slot>


### PR DESCRIPTION
Closes #307 

### PR Type
 - Bugfix 

### Description of the changes
Storybook code editor settings add auto indentation.

** Please note the only meaningful change is line 183. Some auto format from linter.

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes

