### PR TITLE
Update mgt-person background color css custom property

### DIFF
--- a/src/components/mgt-people-picker/mgt-people-picker.scss
+++ b/src/components/mgt-people-picker/mgt-people-picker.scss
@@ -269,6 +269,7 @@ mgt-people-picker .person-display-name {
 
 mgt-person {
   --avatar-size-s: 32px;
+  --background-color: var(--selected-person-background-color, #f1f1f1);
   margin-left: 12px;
   cursor: default;
 }
@@ -358,4 +359,21 @@ mgt-people-picker .people-person-text-area {
 
 mgt-flyout {
   flex: 1 0 auto;
+  .list-person {
+    mgt-person {
+      --background-color: var(--dropdown-background-color, white);
+    }
+
+    &:hover {
+      mgt-person {
+        --background-color: var(--dropdown-item-hover-background, rgba(241, 241, 241, 0.87));
+      }
+    }
+
+    &.focused {
+      mgt-person {
+        --background-color: var(--dropdown-item-hover-background, rgba(241, 241, 241, 0.87));
+      }
+    }
+  }
 }

--- a/src/components/mgt-people-picker/mgt-people-picker.scss
+++ b/src/components/mgt-people-picker/mgt-people-picker.scss
@@ -359,21 +359,4 @@ mgt-people-picker .people-person-text-area {
 
 mgt-flyout {
   flex: 1 0 auto;
-  .list-person {
-    mgt-person {
-      --background-color: var(--dropdown-background-color, white);
-    }
-
-    &:hover {
-      mgt-person {
-        --background-color: var(--dropdown-item-hover-background, rgba(241, 241, 241, 0.87));
-      }
-    }
-
-    &.focused {
-      mgt-person {
-        --background-color: var(--dropdown-item-hover-background, rgba(241, 241, 241, 0.87));
-      }
-    }
-  }
 }

--- a/src/components/mgt-people-picker/mgt-people-picker.scss
+++ b/src/components/mgt-people-picker/mgt-people-picker.scss
@@ -269,7 +269,6 @@ mgt-people-picker .person-display-name {
 
 mgt-person {
   --avatar-size-s: 32px;
-  --background-color: var(--selected-person-background-color, #f1f1f1);
   margin-left: 12px;
   cursor: default;
 }

--- a/src/components/mgt-person-card/mgt-person-card.scss
+++ b/src/components/mgt-person-card/mgt-person-card.scss
@@ -31,8 +31,6 @@ $person-card-background-color: var(--person-card-background-color, #ffffff);
     padding: 18px 14px;
 
     mgt-person {
-      --background-color: var(--person-card-background-color, #ffffff);
-
       &.person-image {
         --avatar-size: 75px;
       }

--- a/src/components/mgt-person/mgt-person.scss
+++ b/src/components/mgt-person/mgt-person.scss
@@ -21,7 +21,7 @@ $font-size: var(--font-size, #{$ms-font-size-m});
 $font-weight: var(--font-weight, #{$ms-font-weight-semibold});
 $color: var(--color, #{$ms-color-neutralDark});
 $text-transform: var(text-transform, none);
-$background-color: var(--background-color, #ffffff);
+$presence-background-color: var(--presence-background-color, #ffffff);
 
 $line2-font-size: var(--line2-font-size, var(--email-font-size, #{$ms-font-size-s}));
 $line2-font-weight: var(--line2-font-weight, 400);
@@ -68,7 +68,6 @@ mgt-person .person-root {
   position: relative;
   display: flex;
   align-items: center;
-  background-color: $background-color;
 
   .user-avatar {
     width: $avatar-size;
@@ -85,11 +84,11 @@ mgt-person .person-root {
       top: calc(#{$avatar-size} * 0.72 - 4px);
       width: calc(v#{$avatar-size} * 0.28);
       height: calc(#{$avatar-size} * 0.28);
-      border: 2px solid $background-color;
+      border: 2px solid $presence-background-color;
       border-radius: 50%;
 
       .presence-oof-offline-wrapper {
-        background-color: $background-color;
+        background-color: $presence-background-color;
         border-color: $presence-color-oof;
 
         .presence-oof-offline svg {
@@ -112,7 +111,7 @@ mgt-person .person-root {
         align-items: center;
 
         &.presence-offline {
-          background-color: $background-color;
+          background-color: $presence-background-color;
           border-color: $presence-color-invisible;
         }
 
@@ -122,7 +121,7 @@ mgt-person .person-root {
         }
 
         &.presence-oof-available {
-          background-color: $background-color;
+          background-color: $presence-background-color;
           border-color: $presence-color-online;
         }
 
@@ -137,7 +136,7 @@ mgt-person .person-root {
         }
 
         &.presence-oof-dnd {
-          background-color: $background-color;
+          background-color: $presence-background-color;
           border-color: $presence-color-dnd;
         }
 
@@ -147,7 +146,7 @@ mgt-person .person-root {
         }
 
         &.presence-oof-busy {
-          background-color: $background-color;
+          background-color: $presence-background-color;
           border-color: $presence-color-dnd;
         }
       }
@@ -161,7 +160,7 @@ mgt-person .person-root {
 
       .presence-available::before {
         content: $ms-icon-code-SkypeCheck;
-        color: $background-color;
+        color: $presence-background-color;
         margin-left: calc(#{$avatar-size} * 0.07 - 2px);
       }
 
@@ -173,13 +172,13 @@ mgt-person .person-root {
 
       .presence-away::before {
         content: $ms-icon-code-SkypeClock;
-        color: $background-color;
+        color: $presence-background-color;
         margin-left: calc(#{$avatar-size} * 0.07 - 2px);
       }
 
       .presence-dnd::before {
         content: $ms-icon-code-SkypeMinus;
-        color: $background-color;
+        color: $presence-background-color;
         margin-left: calc(#{$avatar-size} * 0.07 - 2px);
       }
 

--- a/src/components/mgt-person/mgt-person.ts
+++ b/src/components/mgt-person/mgt-person.ts
@@ -66,7 +66,7 @@ export enum PersonViewType {
  * @cssprop --font-size - {Length} Font size
  * @cssprop --font-weight - {Length} Font weight
  * @cssprop --color - {Color} Color
- * @cssprop --background-color - {Color} Background color
+ * @cssprop --presence-background-color - {Color} Presence badge background color
  * @cssprop --text-transform - {String} text transform
  * @cssprop --line2-font-size - {Length} Line 2 font size
  * @cssprop --line2-font-weight - {Length} Line 2 font weight


### PR DESCRIPTION
### PR Type
 - Bugfix 

### Description of the changes
Updated css custom property that originally changes background color of mgt-person to only change the background/icon fill color of the presence badge. Developers will have the flexibility of changing it based on what the background-color they set up in their app.

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: https://github.com/microsoftgraph/microsoft-graph-docs/pull/8924
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes

