### PR TITLE
mgt-person-card callUser, emailUser, chatUser button fix

### DIFF
--- a/src/components/mgt-person-card/mgt-person-card.scss
+++ b/src/components/mgt-person-card/mgt-person-card.scss
@@ -52,6 +52,7 @@ $person-card-background-color: var(--person-card-background-color, #ffffff);
         font-size: $person-card-display-name-font-size;
         color: $person-card-display-name-color;
         &::after {
+          pointer-events: none;
           content: '';
           position: absolute;
           width: 100%;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #518 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

The linear gradient of the overflow for `display-name` and `job-title` properties with the `::after` selector caused the space it inherits to overflow into the entire `class=details` area. This renders the buttons, chatUser, callUser, and emailUser unusable. 

This fix will return the area back to its intended space and allow the buttons to be usable. '

**Sidenote:** I experimented with adding a story to test this, but the person-card looks to render differently in the context of a storybook window and I cannot emulate this. Open to any ideas.

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
