### PR TITLE
Allow undefined photo response in mgt-person for when people don't ha…

### DIFF
--- a/packages/mgt/src/graph/graph.user.ts
+++ b/packages/mgt/src/graph/graph.user.ts
@@ -51,7 +51,7 @@ export async function getUserWithPhoto(graph: IGraph, userId?: string): Promise<
   if (userDetailsResponse.content) {
     person = userDetailsResponse.content;
 
-    person.personImage = photoResponse.content;
+    person.personImage = photoResponse && photoResponse.content;
   }
 
   return person;


### PR DESCRIPTION
Closes #522 

### PR Type

Bugfix

### Description of the changes

It was identified that the `mgt-person` failed to load for users without photos. After some quick debugging, (https://github.com/microsoftgraph/microsoft-graph-toolkit/issues/522#issuecomment-655204439), I found that `Batch` doesn't add failed responses to its map. This fix null-terminates that photo response, thus handling 404 errors from the API.

### PR checklist
- [x] Project builds (`npm run build`) and changes have been tested in supported browsers (including IE11)
- [x] All public classes and methods have been documented (no additions)
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. (no api changes)
- [x] License header has been added to all new source files (`npm run setLicense`)
- [x] Contains **NO** breaking changes

### Other information

I was going to do this with a null-terminator (`photoResponse?.content`), but prettier didn't seem to like that during build.