### PR TITLE
Fixed metadata alignment in mgt-todo

### DIFF
--- a/packages/mgt/src/components/mgt-tasks-base/mgt-tasks-base.scss
+++ b/packages/mgt/src/components/mgt-tasks-base/mgt-tasks-base.scss
@@ -166,8 +166,8 @@ $task-icon-color-completed: var(--task-icon-color-completed, white);
         flex: 1;
         display: grid;
         display: -ms-grid;
-        grid-template-columns: 1fr auto;
-        -ms-grid-columns: 1fr auto;
+        grid-template-columns: auto 1fr;
+        -ms-grid-columns: auto 1fr;
         grid-template-rows: auto auto auto auto;
         -ms-grid-rows: auto auto auto auto;
         justify-content: space-between;
@@ -219,18 +219,6 @@ $task-icon-color-completed: var(--task-icon-color-completed, white);
           -ms-grid-column: 2;
         }
 
-        .TaskAssignee {
-          grid-row: 3;
-          -ms-grid-row: 3;
-          grid-column: 1 / 3;
-          -ms-grid-column: 1;
-          -ms-grid-column-span: 2;
-
-          mgt-people {
-            --list-margin: 0;
-          }
-        }
-
         .TaskDue {
           justify-content: flex-end;
           align-items: flex-start;
@@ -243,8 +231,8 @@ $task-icon-color-completed: var(--task-icon-color-completed, white);
         }
 
         &.tablet {
-          grid-template-columns: 1fr auto auto auto;
-          -ms-grid-columns: 1fr auto auto auto;
+          grid-template-columns: 1fr 0.5fr 1fr 0.5fr;
+          -ms-grid-columns: 1fr 0.5fr 1fr 0.5fr;
           grid-template-rows: auto auto;
           -ms-grid-rows: auto auto;
 


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes # <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Somewhere in the creation of mgt-todo, I deviated from the styles in the original mgt-tasks. The effect is that task metadata aligns in odd ways in tablet and mobile view.

To fix it I just copied the good styles from mgt-tasks over into mgt-todo. Tadaa! They should act the same now 👍

mgt-tasks
![image](https://user-images.githubusercontent.com/25832310/92658738-ed225100-f2ab-11ea-90bf-6c1e8ad0c3c7.png)
![image](https://user-images.githubusercontent.com/25832310/92658817-1216c400-f2ac-11ea-93cb-5c5234cd94cc.png)

mgt-todo (old)
![image](https://user-images.githubusercontent.com/25832310/92658767-f9a6a980-f2ab-11ea-9871-43e250d311f6.png)
![image](https://user-images.githubusercontent.com/25832310/92658799-0925f280-f2ac-11ea-8757-5ab464627dcc.png)

mgt-todo (new)
![image](https://user-images.githubusercontent.com/25832310/92659016-6a4dc600-f2ac-11ea-8445-14d74779471f.png)
![image](https://user-images.githubusercontent.com/25832310/92659029-7174d400-f2ac-11ea-85aa-63d4cd26fb31.png)



### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
