### PR TITLE
Fixed people picker search

### DIFF
--- a/packages/mgt/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -668,7 +668,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
         this.fireCustomEvent('selectionChanged', this.selectedPeople);
       }
 
-      if (input) {
+      if (input && !this.groupId) {
         people = [];
         if (this.type === PersonType.person || this.type === PersonType.any) {
           try {
@@ -703,6 +703,8 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
             // nop
           }
         }
+      } else if (input && this.groupId) {
+        people = this._groupPeople;
       }
     }
 
@@ -843,6 +845,8 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
         highlight = displayName.slice(highlightLocation, highlightLocation + userInputLength);
         last = displayName.slice(highlightLocation + userInputLength, displayName.length);
       }
+    } else {
+      first = displayName;
     }
 
     return html`


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #614 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This fix ensures that the people picker search only searches within members of the group even when there is an input search query in the text box. I have also modified the renderHighlightText() function to display the name in the case where the search query is not present in the name (It could be in the email ID). 

### PR checklist
- [ ] Project builds (`yarn build`) and changes have been tested in supported browsers
- [ ] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
