### PR TITLE
exporting mgt-element from mgt

### DIFF
--- a/packages/mgt/src/index.ts
+++ b/packages/mgt/src/index.ts
@@ -12,3 +12,4 @@ export * from './graph/types';
 export { TeamsHelper } from './utils/TeamsHelper';
 export { prepScopes } from './utils/GraphHelpers';
 export * from './utils/Cache';
+export * from '@microsoft/mgt-element';


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #651 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
The mgt packages should re-export the factored out packages to ensure the bundle remains compatible with 1.x and work the same way. This PR exports `@microsoft/mgt-element` from `@microsoft/mgt` so the Providers namespace is still available. 

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
