### PR TITLE
Fixed rendering of user-avatar and initials in person/person-card

### DIFF
--- a/packages/mgt/src/components/mgt-person-card/sections/mgt-person-card-organization/mgt-person-card-organization.ts
+++ b/packages/mgt/src/components/mgt-person-card/sections/mgt-person-card-organization/mgt-person-card-organization.ts
@@ -192,7 +192,7 @@ export class MgtPersonCardOrganization extends BasePersonCardSection {
     return html`
       <div class="coworker" @click=${() => this.navigateCard(coworker)}>
         <div class="coworker__image">
-          <mgt-person .userId=${coworker.id} avatar-size="large"></mgt-person>
+          <mgt-person .personDetails=${coworker} avatar-size="large" fetch-image></mgt-person>
         </div>
         <div class="coworker__details">
           <div class="coworker__name">${coworker.displayName}</div>

--- a/packages/mgt/src/components/mgt-person/mgt-person.scss
+++ b/packages/mgt/src/components/mgt-person/mgt-person.scss
@@ -77,7 +77,7 @@ mgt-person .person-root {
       position: absolute;
       left: calc(#{$avatar-size} * 0.72 - 4px);
       top: calc(#{$avatar-size} * 0.72 - 4px);
-      width: calc(v#{$avatar-size} * 0.28);
+      width: calc(#{$avatar-size} * 0.28);
       height: calc(#{$avatar-size} * 0.28);
       border: 2px solid $presence-background-color;
       border-radius: 50%;
@@ -378,10 +378,12 @@ mgt-person .person-root {
 
 :host .avatar-icon,
 mgt-person .avatar-icon {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   line-height: 1;
   margin: 0;
-  font-size: $avatar-size;
+  font-size: calc(#{$avatar-size} * 0.5);
   width: $avatar-size;
   height: $avatar-size;
   overflow: hidden;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #632 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
The user-avatar icon was previously rendering to fill the available space, and it looked odd (pics in issue #632). To make it look a bit better, I shrunk the font-size of the person icon to be 50% of whatever the avatar-size is.
![image](https://user-images.githubusercontent.com/25832310/95898694-4a467200-0d44-11eb-8b3c-d405c7730782.png)

I also updated the person-card organization section to pass the proper data to mgt-person. This fixes the bug where the avatar -icon was showing up even when initials should have worked. 
![image](https://user-images.githubusercontent.com/25832310/95898896-9a253900-0d44-11eb-97d1-b54d775bc47c.png)

A great way to test this is to check out the sample page for person card: 
`http://localhost:3000/samples/examples/person-card.html`

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
