### PR TITLE
Added type attribute to events property on agenda component

### DIFF
--- a/packages/mgt/src/components/mgt-agenda/mgt-agenda.ts
+++ b/packages/mgt/src/components/mgt-agenda/mgt-agenda.ts
@@ -134,7 +134,8 @@ export class MgtAgenda extends MgtTemplatedComponent {
    * @type {MicrosoftGraph.Event[]}
    */
   @property({
-    attribute: 'events'
+    attribute: 'events',
+    type: Array
   })
   public events: MicrosoftGraph.Event[];
 


### PR DESCRIPTION
### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Added the `type` attribute to the `events` property on Agenda. Without this attribute, you cannot set the `events` attribute in HTML and have it map correctly to the `events` property.

In other words, doing something like this:

```
<mgt-agenda events="<JSON array of events>"></mgt-agenda>
```

Would not work, the component would render nothing.

### PR checklist
- [ ] Project builds (`yarn build`) and changes have been tested in supported browsers
- [ ] All public classes and methods have been documented
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
See "Convert from attribute to property" at https://lit-element.polymer-project.org/guide/properties