### PR TITLE
Fixed issue where me call was cached in Proxy Graph

### DIFF
--- a/packages/mgt/src/providers/ProxyProvider.ts
+++ b/packages/mgt/src/providers/ProxyProvider.ts
@@ -6,7 +6,6 @@
  */
 
 import { Graph } from '../Graph';
-import { getMe } from '../graph/graph.user';
 import { IProvider, ProviderState } from '@microsoft/mgt-element';
 import { ProxyGraph } from '../ProxyGraph';
 
@@ -27,18 +26,22 @@ export class ProxyProvider extends IProvider {
   constructor(graphProxyUrl: string, getCustomHeaders: () => Promise<object> = null) {
     super();
     this.graph = new ProxyGraph(graphProxyUrl, getCustomHeaders);
-    getMe(this.graph).then(
-      user => {
-        if (user != null) {
-          this.setState(ProviderState.SignedIn);
-        } else {
+
+    this.graph
+      .api('me')
+      .get()
+      .then(
+        user => {
+          if (user != null) {
+            this.setState(ProviderState.SignedIn);
+          } else {
+            this.setState(ProviderState.SignedOut);
+          }
+        },
+        err => {
           this.setState(ProviderState.SignedOut);
         }
-      },
-      err => {
-        this.setState(ProviderState.SignedOut);
-      }
-    );
+      );
   }
 
   /**


### PR DESCRIPTION

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->
- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Proxy provider makes a call to `me` to check whether the service is signed in or not. However, because it was using the `getMe` method, the call was being cached. This PR makes sure the call does not get cached and is always made.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] Contains **NO** breaking changes
