### PR TITLE
[people-picker][bug] fires blur event on selection of person

### DIFF
--- a/packages/mgt/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -1006,6 +1006,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     if (event.keyCode === 9 || event.keyCode === 13) {
       // keyCodes capture: tab (9) and enter (13)
       if (this._foundPeople.length) {
+        this.fireCustomEvent('blur');
         event.preventDefault();
       }
       this.addPerson(this._foundPeople[this._arrowSelectionCount]);


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #677 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

adds `this.fireCustomEvent('blur')` to mgt-people-picker, person selection functionality so that either selection method (key or mouse) fires blur event. This event was previously escaped by preventDefault() to cancel tab navigation.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
