### PR TITLE
Fixed mgt-person to only require 'Presence.Read' for current signed in user 

### DIFF
--- a/packages/mgt/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt/src/components/mgt-person/mgt-person.ts
@@ -775,7 +775,9 @@ export class MgtPerson extends MgtTemplatedComponent {
     if (this.showPresence && !this.personPresence && !this._fetchedPresence) {
       try {
         if (this.personDetails && this.personDetails.id) {
-          this._fetchedPresence = await getUserPresence(graph, this.personDetails.id);
+          // setting userId to 'me' ensures only the presence.read permission is required
+          const userId = this.personQuery !== 'me' ? this.personDetails.id : null;
+          this._fetchedPresence = await getUserPresence(graph, userId);
         } else {
           this._fetchedPresence = defaultPresence;
         }


### PR DESCRIPTION

Closes #695 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

  Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Updated `getUserPresence` to call the `/me/presence` endpoint and use only the `Presence.Read` permission for current signed in user.

Also deleted the `getMyPresence` function since it was never used


### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Contains **NO** breaking changes
