### PR TITLE
Fixed issue where person would not update when personQuery and userId properties change

### DIFF
--- a/packages/mgt/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt/src/components/mgt-person/mgt-person.ts
@@ -90,7 +90,18 @@ export class MgtPerson extends MgtTemplatedComponent {
   @property({
     attribute: 'person-query'
   })
-  public personQuery: string;
+  public get personQuery(): string {
+    return this._personQuery;
+  }
+  public set personQuery(value: string) {
+    if (value === this._personQuery) {
+      return;
+    }
+
+    this._personQuery = value;
+    this.personDetails = null;
+    this.requestStateUpdate();
+  }
 
   /**
    * user-id property allows developer to use id value to determine person
@@ -99,7 +110,18 @@ export class MgtPerson extends MgtTemplatedComponent {
   @property({
     attribute: 'user-id'
   })
-  public userId: string;
+  public get userId(): string {
+    return this._userId;
+  }
+  public set userId(value: string) {
+    if (value === this._userId) {
+      return;
+    }
+
+    this._userId = value;
+    this.personDetails = null;
+    this.requestStateUpdate();
+  }
 
   /**
    * determines if person component renders user-name
@@ -317,6 +339,8 @@ export class MgtPerson extends MgtTemplatedComponent {
   private _personAvatarBg: string;
   private _personImage: string;
   private _personPresence: Presence;
+  private _personQuery: string;
+  private _userId: string;
 
   private _mouseLeaveTimeout;
   private _mouseEnterTimeout;
@@ -331,30 +355,6 @@ export class MgtPerson extends MgtTemplatedComponent {
     this.view = PersonViewType.avatar;
     this.avatarSize = 'auto';
     this._isInvalidImageSrc = false;
-  }
-
-  /**
-   * Synchronizes property values when attributes change.
-   *
-   * @param {*} name
-   * @param {*} oldValue
-   * @param {*} newValue
-   * @memberof MgtPerson
-   */
-  public attributeChangedCallback(name, oldval, newval) {
-    super.attributeChangedCallback(name, oldval, newval);
-
-    if (oldval === newval) {
-      return;
-    }
-
-    switch (name) {
-      case 'person-query':
-      case 'user-id':
-        this.personDetails = null;
-        this.requestStateUpdate();
-        break;
-    }
   }
 
   /**


### PR DESCRIPTION


<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #690 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This PR fixes an issue where the component would not update it's data if the `personQuery` or `userId` properties changed. However, it would work if the attributes were changed. The issue was fixed by moving the state update request to the properties setters instead

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Contains **NO** breaking changes
