### PR TITLE
Update to use default font family in mgt-arrow-option to fix mgt-tasks font

### DIFF
--- a/packages/mgt/src/components/sub-components/mgt-arrow-options/mgt-arrow-options.scss
+++ b/packages/mgt/src/components/sub-components/mgt-arrow-options/mgt-arrow-options.scss
@@ -5,10 +5,12 @@
  * -------------------------------------------------------------------------------------------
  */
 
+@import '../../../styles/shared-styles.scss';
+
 :host,
 mgt-arrow-options {
   position: relative;
-  font-family: 'Segoe UI';
+  font-family: var(--default-font-family);
 }
 
 :host .ArrowIcon,


### PR DESCRIPTION
Closes #620 

### PR Type
- Bugfix

### Description of the changes
This will fix the font in mgt-tasks and mgt-todo header

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes
