### PR TITLE
Adds support for preferred timezone in mgt-agenda.

### DIFF
--- a/packages/mgt/src/components/mgt-agenda/mgt-agenda.graph.ts
+++ b/packages/mgt/src/components/mgt-agenda/mgt-agenda.graph.ts
@@ -16,6 +16,7 @@ import { GraphPageIterator } from '../../utils/GraphPageIterator';
  * @param {Date} startDateTime
  * @param {Date} endDateTime
  * @param {string} [groupId]
+ * @param {string} preferredTimezone
  * @returns {(Promise<Event[]>)}
  * @memberof Graph
  */
@@ -23,7 +24,8 @@ export function getEventsPageIterator(
   graph: IGraph,
   startDateTime: Date,
   endDateTime: Date,
-  groupId?: string
+  groupId?: string,
+  preferredTimezone?: string
 ): Promise<GraphPageIterator<MicrosoftGraph.Event>> {
   const scopes = 'calendars.read';
 
@@ -40,10 +42,14 @@ export function getEventsPageIterator(
 
   uri += `/calendarview?${sdt}&${edt}`;
 
-  const request = graph
+  let request = graph
     .api(uri)
     .middlewareOptions(prepScopes(scopes))
     .orderby('start/dateTime');
+
+  if (preferredTimezone) {
+    request = request.header('Prefer', `outlook.timezone="${preferredTimezone}"`);
+  }
 
   return GraphPageIterator.create<MicrosoftGraph.Event>(graph, request);
 }


### PR DESCRIPTION
Closes #681

<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
 - Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Extends mgt-agenda with a new property named `preferred-timezone` which allows developers to specify the preferred timezone to be used when retrieving events from Graph.

### PR checklist

- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: https://github.com/microsoftgraph/microsoft-graph-docs/pull/10530
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information

n/a
