### PR TITLE
Update mgt-agenda.ts

### DIFF
--- a/packages/mgt/src/components/mgt-agenda/mgt-agenda.ts
+++ b/packages/mgt/src/components/mgt-agenda/mgt-agenda.ts
@@ -577,7 +577,15 @@ export class MgtAgenda extends MgtTemplatedComponent {
   }
 
   private prettyPrintTimeFromDateTime(date: Date) {
-    date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
+    // If a preferred time zone was sent in the Graph request
+    // times are already set correctly. Do not adjust
+    if (!this.preferredTimezone) {
+      // If no preferred time zone was specified, the times are in UTC
+      // fall back to old behavior and adjust the times to the browser's
+      // time zone
+      date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
+    }
+
     let hours = date.getHours();
     const minutes = date.getMinutes();
     const ampm = hours >= 12 ? 'PM' : 'AM';


### PR DESCRIPTION
Fixed `prettyPrintTimeFromDateTime` to not do a UTC->Browser shift on times when a preferred time zone is specified.

Closes #745

### PR Type

- Bugfix

### Description of the changes

Fixed `prettyPrintTimeFromDateTime` to not do a UTC->Browser shift on times when a preferred time zone is specified.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes
