### PR TITLE
Assume default template for mgt-react

### DIFF
--- a/packages/mgt-react/src/Mgt.ts
+++ b/packages/mgt-react/src/Mgt.ts
@@ -116,6 +116,8 @@ export class Mgt extends Wc {
       let element = child as ReactElement;
       if (element && element.props && element.props.template) {
         templates[element.props.template] = element;
+      } else {
+        templates['default'] = element;
       }
     });
 

--- a/packages/mgt-react/src/MgtTemplateProps.ts
+++ b/packages/mgt-react/src/MgtTemplateProps.ts
@@ -1,4 +1,4 @@
 export type MgtTemplateProps = {
-  template: string;
+  template?: string;
   dataContext?: any;
 };

--- a/samples/react-app/src/index.js
+++ b/samples/react-app/src/index.js
@@ -14,7 +14,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import { Providers, MsalProvider } from '@microsoft/mgt';
-import { MockProvider } from '@microsoft/mgt/dist/mock/MockProvider';
+import { MockProvider } from '@microsoft/mgt-element/dist/mock/MockProvider';
 
 Providers.globalProvider = new MockProvider(true);
 


### PR DESCRIPTION
Closes #713 

### PR Type

<!-- - Bugfix -->
Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Updated `mgt-react` to assume the template value is `default` if no template value is provided

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes
