### PR TITLE
teams-channel-picker display property for firefox bug

### DIFF
--- a/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.scss
+++ b/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.scss
@@ -86,7 +86,7 @@
     }
     .team-chosen-input[contenteditable]:empty::after {
       content: attr(data-placeholder);
-      display: inline-block;
+      display: flex;
       color: $placeholder__color;
     }
 

--- a/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.scss
+++ b/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.scss
@@ -61,6 +61,7 @@
     }
 
     .search-wrapper {
+      height: 14px;
       display: flex;
       flex-wrap: nowrap;
       align-items: center;
@@ -68,6 +69,7 @@
     }
 
     .team-chosen-input {
+      // height: 14px;
       display: inline-block;
       border: none;
       line-height: normal;
@@ -86,7 +88,6 @@
     }
     .team-chosen-input[contenteditable]:empty::after {
       content: attr(data-placeholder);
-      display: flex;
       color: $placeholder__color;
     }
 
@@ -94,6 +95,11 @@
       align-self: flex-start;
       font-family: 'FabricMDL2Icons';
       color: var(--accent-color, $commblue_primary);
+      line-height: normal;
+    }
+
+    .input-search {
+      height: 19px;
     }
 
     .input-search-start {

--- a/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.scss
+++ b/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.scss
@@ -69,7 +69,6 @@
     }
 
     .team-chosen-input {
-      // height: 14px;
       display: inline-block;
       border: none;
       line-height: normal;

--- a/samples/examples/simple-provider.html
+++ b/samples/examples/simple-provider.html
@@ -10,7 +10,8 @@
     <div class="container">
       <div class="leftContainer">
         <p id="WelcomeMessage">Welcome to the Microsoft Authentication Library For Javascript Quickstart</p>
-        <button id="SignIn" onclick="signIn()">Sign In</button>
+        <button id="SignIn">Sign In</button>
+        <button id="SignOut" hidden>Sign Out</button>
       </div>
       <div class="rightContainer">
         <pre id="json"></pre>
@@ -50,6 +51,10 @@
       // Register Callbacks for redirect flow
       // myMSALObj.handleRedirectCallbacks(acquireTokenRedirectCallBack, acquireTokenErrorRedirectCallBack);
       myMSALObj.handleRedirectCallback(authRedirectCallBack);
+      //Set login button
+      var loginbutton = document.getElementById('SignIn');
+      loginbutton.removeAttribute('hidden');
+      loginbutton.addEventListener('click', signIn, true);
 
       Providers.globalProvider = new SimpleProvider(async function(scopes) {
         var request = { scopes: scopes };
@@ -126,9 +131,13 @@
 
         var divWelcome = document.getElementById('WelcomeMessage');
         divWelcome.innerHTML = 'Welcome ' + myMSALObj.getAccount().userName + ' to Microsoft Graph API';
+
+        //Toggle login and logout buttons
+        var logoutbutton = document.getElementById('SignOut');
+        logoutbutton.removeAttribute('hidden');
+        logoutbutton.addEventListener('click', signOut, true);
         var loginbutton = document.getElementById('SignIn');
-        loginbutton.innerHTML = 'Sign Out';
-        loginbutton.setAttribute('onclick', 'signOut();');
+        loginbutton.setAttribute('hidden', true);
       }
 
       //This function can be removed if you do not need to support IE


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #816

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Updates the display property to flex, for the selector:
```
.team-chosen-input[contenteditable]:empty::after
```

Browsers (such as firefox) seemed to be handling the input line height differently. So if a user selects a team, and then wishes to change the selection, the cursor will still appear to be on same baseline. 

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information

Testing this seems to be mostly reproducible in storybook. 
