### PR TITLE
Fixed people picker flyout layout

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.scss
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.scss
@@ -141,7 +141,7 @@ mgt-people-picker .root {
         text-align: left;
         list-style-type: none;
         background-color: $dropdown__background-color;
-
+        max-height: var(--mgt-flyout-set-height, unset);
         li {
           cursor: pointer;
         }

--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -485,7 +485,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     return html`
       <mgt-flyout light-dismiss class="flyout">
         ${anchor}
-        <div slot="flyout" class="flyout-root">
+        <div slot="flyout" class="flyout-root" @wheel=${(e: WheelEvent) => this.handleSectionScroll(e)}>
           ${this.renderFlyoutContent()}
         </div>
       </mgt-flyout>
@@ -980,38 +980,31 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
    * @param event - tracks user key selection
    */
   private handleArrowSelection(event: KeyboardEvent): void {
-    if (this._foundPeople.length) {
+    const peopleList = this.renderRoot.querySelector('.people-list');
+    if (peopleList && peopleList.children.length) {
       // update arrow count
       if (event.keyCode === 38) {
         // up arrow
-        if (this._arrowSelectionCount > 0) {
-          this._arrowSelectionCount--;
-        } else {
-          this._arrowSelectionCount = 0;
-        }
+        this._arrowSelectionCount =
+          (this._arrowSelectionCount - 1 + peopleList.children.length) % peopleList.children.length;
       }
       if (event.keyCode === 40) {
         // down arrow
-        if (
-          this._arrowSelectionCount + 1 !== this._foundPeople.length &&
-          this._arrowSelectionCount + 1 < this.showMax
-        ) {
-          this._arrowSelectionCount++;
-        } else {
-          this._arrowSelectionCount = 0;
-        }
+        this._arrowSelectionCount = (this._arrowSelectionCount + 1) % peopleList.children.length;
       }
 
-      const peopleList = this.renderRoot.querySelector('.people-list');
       // reset background color
-      if (peopleList) {
-        // tslint:disable-next-line: prefer-for-of
-        for (let i = 0; i < peopleList.children.length; i++) {
-          peopleList.children[i].classList.remove('focused');
-        }
+      // tslint:disable-next-line: prefer-for-of
+      for (let i = 0; i < peopleList.children.length; i++) {
+        peopleList.children[i].classList.remove('focused');
       }
+
       // set selected background
-      peopleList.children[this._arrowSelectionCount].classList.add('focused');
+      const focusedItem = peopleList.children[this._arrowSelectionCount];
+      if (focusedItem) {
+        focusedItem.classList.add('focused');
+        focusedItem.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start' });
+      }
     }
   }
 
@@ -1038,6 +1031,19 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       });
 
       return filtered;
+    }
+  }
+
+  // stop propagating wheel event to flyout so mouse scrolling works
+  private handleSectionScroll(e: WheelEvent) {
+    const target = this.renderRoot.querySelector('.flyout-root') as HTMLElement;
+    if (target) {
+      if (
+        !(e.deltaY < 0 && target.scrollTop === 0) &&
+        !(e.deltaY > 0 && target.clientHeight + target.scrollTop >= target.scrollHeight - 1)
+      ) {
+        e.stopPropagation();
+      }
     }
   }
 }


### PR DESCRIPTION


<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #792  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This PR fixes the people picker flyout rendering on top of the people picker by:
1. Updating the flyout layout logic to avoid hiding the anchor when open
2. Adding an internal css property for setting the max-height of the flyout contents when needed
2. Updating the people picker component to leverage the max-height css property
3. Updating the logic of the people picker dropdown to scroll and bring items to view when focused

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
