### PR TITLE
Add className and id property to typescript react props

### DIFF
--- a/packages/mgt-react/scripts/generate.js
+++ b/packages/mgt-react/scripts/generate.js
@@ -41,7 +41,8 @@ for (const tag of wc.tags) {
   });
 
   const props = {
-    className: 'string'
+    className: 'string',
+    id: 'string'
   };
 
   for (const prop of tag.properties) {

--- a/packages/mgt-react/scripts/generate.js
+++ b/packages/mgt-react/scripts/generate.js
@@ -40,7 +40,9 @@ for (const tag of wc.tags) {
     className: className
   });
 
-  const props = {};
+  const props = {
+    className: 'string'
+  };
 
   for (const prop of tag.properties) {
     if (prop.type) {

--- a/packages/mgt-react/src/generated/react.ts
+++ b/packages/mgt-react/src/generated/react.ts
@@ -5,6 +5,7 @@ import * as MicrosoftGraphBeta from '@microsoft/microsoft-graph-types-beta';
 import {wrapMgt} from '../Mgt';
 
 export type AgendaProps = {
+	className?: string;
 	date?: string;
 	groupId?: string;
 	days?: number;
@@ -19,6 +20,7 @@ export type AgendaProps = {
 }
 
 export type GetProps = {
+	className?: string;
 	resource?: string;
 	scopes?: string[];
 	version?: string;
@@ -33,6 +35,7 @@ export type GetProps = {
 }
 
 export type LoginProps = {
+	className?: string;
 	userDetails?: IDynamicPerson;
 	templateContext?: TemplateContext;
 	mediaQuery?: ComponentMediaQuery;
@@ -44,6 +47,7 @@ export type LoginProps = {
 }
 
 export type PeoplePickerProps = {
+	className?: string;
 	groupId?: string;
 	type?: PersonType;
 	groupType?: GroupType;
@@ -60,6 +64,7 @@ export type PeoplePickerProps = {
 }
 
 export type PeopleProps = {
+	className?: string;
 	groupId?: string;
 	userIds?: string[];
 	people?: IDynamicPerson[];
@@ -72,6 +77,7 @@ export type PeopleProps = {
 }
 
 export type PersonCardProps = {
+	className?: string;
 	personDetails?: IDynamicPerson;
 	personQuery?: string;
 	userId?: string;
@@ -86,6 +92,7 @@ export type PersonCardProps = {
 }
 
 export type PersonProps = {
+	className?: string;
 	config?: MgtPersonConfig;
 	personQuery?: string;
 	userId?: string;
@@ -105,6 +112,7 @@ export type PersonProps = {
 }
 
 export type TasksProps = {
+	className?: string;
 	res?: TasksStringResource;
 	isNewTaskVisible?: boolean;
 	readOnly?: boolean;
@@ -126,6 +134,7 @@ export type TasksProps = {
 }
 
 export type TeamsChannelPickerProps = {
+	className?: string;
 	selectedItem?: SelectedChannel;
 	templateContext?: TemplateContext;
 	mediaQuery?: ComponentMediaQuery;
@@ -133,6 +142,7 @@ export type TeamsChannelPickerProps = {
 }
 
 export type TodoProps = {
+	className?: string;
 	taskFilter?: TodoFilter;
 	readOnly?: boolean;
 	hideHeader?: boolean;

--- a/packages/mgt-react/src/generated/react.ts
+++ b/packages/mgt-react/src/generated/react.ts
@@ -6,6 +6,7 @@ import {wrapMgt} from '../Mgt';
 
 export type AgendaProps = {
 	className?: string;
+	id?: string;
 	date?: string;
 	groupId?: string;
 	days?: number;
@@ -21,6 +22,7 @@ export type AgendaProps = {
 
 export type GetProps = {
 	className?: string;
+	id?: string;
 	resource?: string;
 	scopes?: string[];
 	version?: string;
@@ -36,6 +38,7 @@ export type GetProps = {
 
 export type LoginProps = {
 	className?: string;
+	id?: string;
 	userDetails?: IDynamicPerson;
 	templateContext?: TemplateContext;
 	mediaQuery?: ComponentMediaQuery;
@@ -48,6 +51,7 @@ export type LoginProps = {
 
 export type PeoplePickerProps = {
 	className?: string;
+	id?: string;
 	groupId?: string;
 	type?: PersonType;
 	groupType?: GroupType;
@@ -65,6 +69,7 @@ export type PeoplePickerProps = {
 
 export type PeopleProps = {
 	className?: string;
+	id?: string;
 	groupId?: string;
 	userIds?: string[];
 	people?: IDynamicPerson[];
@@ -78,6 +83,7 @@ export type PeopleProps = {
 
 export type PersonCardProps = {
 	className?: string;
+	id?: string;
 	personDetails?: IDynamicPerson;
 	personQuery?: string;
 	userId?: string;
@@ -93,6 +99,7 @@ export type PersonCardProps = {
 
 export type PersonProps = {
 	className?: string;
+	id?: string;
 	config?: MgtPersonConfig;
 	personQuery?: string;
 	userId?: string;
@@ -113,6 +120,7 @@ export type PersonProps = {
 
 export type TasksProps = {
 	className?: string;
+	id?: string;
 	res?: TasksStringResource;
 	isNewTaskVisible?: boolean;
 	readOnly?: boolean;
@@ -135,6 +143,7 @@ export type TasksProps = {
 
 export type TeamsChannelPickerProps = {
 	className?: string;
+	id?: string;
 	selectedItem?: SelectedChannel;
 	templateContext?: TemplateContext;
 	mediaQuery?: ComponentMediaQuery;
@@ -143,6 +152,7 @@ export type TeamsChannelPickerProps = {
 
 export type TodoProps = {
 	className?: string;
+	id?: string;
 	taskFilter?: TodoFilter;
 	readOnly?: boolean;
 	hideHeader?: boolean;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #760 

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Adds the className and id property to the mgt-react package allowing typescript users of the package to use the property
### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
