### PR TITLE
add react html attributes to the component properties

### DIFF
--- a/packages/mgt-react/src/Mgt.ts
+++ b/packages/mgt-react/src/Mgt.ts
@@ -134,6 +134,7 @@ export class Mgt extends Wc {
  * @returns React component
  */
 export const wrapMgt = <T = WcProps>(tag: string) => {
-  const component: React.FC<T> = (props: T) => React.createElement(Mgt, { type: tag, ...props });
+  const component: React.FC<T & React.HTMLAttributes<any>> = (props: T) =>
+    React.createElement(Mgt, { type: tag, ...props });
   return component;
 };


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #760 (this is an optional PR to the closed issue, but this PR includes all missing html attributes, not just few of them)

### PR Type
Bugfix
Refactoring (no functional changes, no api changes) 

### Description of the changes

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information

build the packages to test 

This screenshot shows intelligence without the properties
![Screenshot 2020-12-22 at 17 32 20](https://user-images.githubusercontent.com/2223355/102905730-3d4caa00-447c-11eb-979f-c076fc0c36f5.png)
This screenshot show intelligence with the properties after this PR
![Screenshot 2020-12-22 at 17 30 44](https://user-images.githubusercontent.com/2223355/102905732-3e7dd700-447c-11eb-8629-272c8ab96951.png)
