### PR TITLE
Mgt-Person: Added fallback method to search /users endpoint

### DIFF
--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -12,6 +12,7 @@ import { findPeople, getEmailFromGraphEntity } from '../../graph/graph.people';
 import { getPersonImage } from '../../graph/graph.photos';
 import { getUserPresence } from '../../graph/graph.presence';
 import { getUserWithPhoto } from '../../graph/graph.userWithPhoto';
+import { findUsers } from '../../graph/graph.user';
 import { AvatarSize, IDynamicPerson } from '../../graph/types';
 import { Providers, ProviderState, MgtTemplatedComponent } from '@microsoft/mgt-element';
 import '../../styles/style-helper';
@@ -785,7 +786,11 @@ export class MgtPerson extends MgtTemplatedComponent {
       this._fetchedImage = this.getImage();
     } else if (this.personQuery) {
       // Use the personQuery to find our person.
-      const people = await findPeople(graph, this.personQuery, 1);
+      let people = await findPeople(graph, this.personQuery, 1);
+
+      if (!people || people.length === 0) {
+        people = (await findUsers(graph, this.personQuery, 1)) || [];
+      }
 
       if (people && people.length) {
         this.personDetails = people[0];


### PR DESCRIPTION
Closes #755 

### PR Type

Feature

### Description of the changes

Added the fallback method `findUsers` in `mgt-person` component to search _/users_ endpoint when the requested person is not returned using the _/people_ endpoint

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

