### PR TITLE
Mgt-Person: Added fallback method to search /users endpoint and updated findUsers method

### DIFF
--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -12,6 +12,7 @@ import { findPeople, getEmailFromGraphEntity } from '../../graph/graph.people';
 import { getPersonImage } from '../../graph/graph.photos';
 import { getUserPresence } from '../../graph/graph.presence';
 import { getUserWithPhoto } from '../../graph/graph.userWithPhoto';
+import { findUsers } from '../../graph/graph.user';
 import { AvatarSize, IDynamicPerson } from '../../graph/types';
 import { Providers, ProviderState, MgtTemplatedComponent } from '@microsoft/mgt-element';
 import '../../styles/style-helper';
@@ -785,7 +786,11 @@ export class MgtPerson extends MgtTemplatedComponent {
       this._fetchedImage = this.getImage();
     } else if (this.personQuery) {
       // Use the personQuery to find our person.
-      const people = await findPeople(graph, this.personQuery, 1);
+      let people = await findPeople(graph, this.personQuery, 1);
+
+      if (!people || people.length === 0) {
+        people = (await findUsers(graph, this.personQuery, 1)) || [];
+      }
 
       if (people && people.length) {
         this.personDetails = people[0];

--- a/packages/mgt-components/src/graph/graph.user.ts
+++ b/packages/mgt-components/src/graph/graph.user.ts
@@ -268,7 +268,7 @@ export async function findUsers(graph: IGraph, query: string, top: number = 10):
       .api('users')
       .header('ConsistencyLevel', 'eventual')
       .count(true)
-      .search(`"displayName:${query}"`)
+      .search(`"displayName:${query}" OR "mail:${query}"`)
       .top(top)
       .middlewareOptions(prepScopes(scopes))
       .get();


### PR DESCRIPTION
Closes #755 

### PR Type
Feature

### Description of the changes
Updated the `mgt-person` component to use the fallback method `findUsers` to search `/users` endpoint when the requested person is not returned using the `/people` endpoint. Also updated the `findUsers` method to search users by `displayName` and `email` (Ref https://github.com/microsoftgraph/microsoft-graph-toolkit/pull/860#issuecomment-754886369).

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes