### PR TITLE
[bug] [mgt-person-card] userid property fix

### DIFF
--- a/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.ts
+++ b/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.ts
@@ -314,6 +314,7 @@ export class MgtPersonCard extends MgtTemplatedComponent {
       case 'person-query':
       case 'user-id':
         this.personDetails = null;
+        this.state = null;
         this.requestStateUpdate();
         break;
     }

--- a/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.ts
+++ b/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.ts
@@ -189,7 +189,18 @@ export class MgtPersonCard extends MgtTemplatedComponent {
   @property({
     attribute: 'user-id'
   })
-  public userId: string;
+  public get userId(): string {
+    return this._userId;
+  }
+  public set userId(value: string) {
+    if (value === this._userId) {
+      return;
+    }
+    this._userId = value;
+    this.personDetails = null;
+    this.state = null;
+    this.requestStateUpdate();
+  }
 
   /**
    * Set the image of the person
@@ -283,6 +294,8 @@ export class MgtPersonCard extends MgtTemplatedComponent {
   private _personDetails: IDynamicPerson;
   private _me: MicrosoftGraph.User;
 
+  private _userId: string;
+
   private get internalPersonDetails(): IDynamicPerson {
     return (this.state && this.state.person) || this.personDetails;
   }
@@ -312,7 +325,6 @@ export class MgtPersonCard extends MgtTemplatedComponent {
 
     switch (name) {
       case 'person-query':
-      case 'user-id':
         this.personDetails = null;
         this.state = null;
         this.requestStateUpdate();


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #865 
### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Sets person-card state to null for user-id changes so that `loadState()` is called and the card is refreshed with the new user. 

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
