### PR TITLE
Added templates for metadata lines in person

### DIFF
--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -12,7 +12,7 @@ import { findPeople, getEmailFromGraphEntity } from '../../graph/graph.people';
 import { getPersonImage } from '../../graph/graph.photos';
 import { getUserPresence } from '../../graph/graph.presence';
 import { getUserWithPhoto } from '../../graph/graph.userWithPhoto';
-import { findUsers } from '../../graph/graph.user';
+import { findUsers, getMe, getUser } from '../../graph/graph.user';
 import { AvatarSize, IDynamicPerson } from '../../graph/types';
 import { Providers, ProviderState, MgtTemplatedComponent } from '@microsoft/mgt-element';
 import '../../styles/style-helper';
@@ -52,6 +52,18 @@ export enum PersonViewType {
    * Render the avatar and three lines of text
    */
   threelines = 5
+}
+
+export enum avatarType {
+  /**
+   * Renders avatar photo if available, falls back to initials
+   */
+  photo = 'photo',
+
+  /**
+   * Forces render avatar initials
+   */
+  initials = 'initials'
 }
 
 /**
@@ -255,6 +267,37 @@ export class MgtPerson extends MgtTemplatedComponent {
   public fetchImage: boolean;
 
   /**
+   * Determines and sets person avatar
+   *
+   *
+   * @type {string}
+   * @memberof MgtPerson
+   */
+  @property({
+    attribute: 'avatar-type',
+    converter: value => {
+      value = value.toLowerCase();
+
+      if (value === 'initials') {
+        return avatarType.initials;
+      } else {
+        return avatarType.photo;
+      }
+    }
+  })
+  public get avatarType(): string {
+    return this._avatarType;
+  }
+  public set avatarType(value: string) {
+    if (value === this._avatarType) {
+      return;
+    }
+
+    this._avatarType = value;
+    this.requestStateUpdate();
+  }
+
+  /**
    * Gets or sets presence of person
    *
    * @type {MicrosoftGraphBeta.Presence}
@@ -370,6 +413,7 @@ export class MgtPerson extends MgtTemplatedComponent {
   private _personPresence: Presence;
   private _personQuery: string;
   private _userId: string;
+  private _avatarType: string;
 
   private _mouseLeaveTimeout;
   private _mouseEnterTimeout;
@@ -385,6 +429,7 @@ export class MgtPerson extends MgtTemplatedComponent {
     this.view = PersonViewType.avatar;
     this.avatarSize = 'auto';
     this._isInvalidImageSrc = false;
+    this._avatarType = 'photo';
   }
 
   /**
@@ -489,8 +534,7 @@ export class MgtPerson extends MgtTemplatedComponent {
       personDetails && this.personCardInteraction === PersonCardInteraction.none
         ? personDetails.displayName || getEmailFromGraphEntity(personDetails) || ''
         : '';
-
-    if (imageSrc && !this._isInvalidImageSrc) {
+    if (imageSrc && !this._isInvalidImageSrc && this._avatarType === 'photo') {
       return html`
         <div class="img-wrapper">
           <img alt=${title} src=${imageSrc} @error=${() => (this._isInvalidImageSrc = true)} />
@@ -630,12 +674,12 @@ export class MgtPerson extends MgtTemplatedComponent {
         : '';
 
     const imageClasses = {
-      initials: !image || this._isInvalidImageSrc,
+      initials: !image || this._isInvalidImageSrc || this._avatarType === 'initials',
       small: !this.isLargeAvatar(),
       'user-avatar': true
     };
 
-    if ((!image || this._isInvalidImageSrc) && this.personDetails) {
+    if ((!image || this._isInvalidImageSrc || this._avatarType === 'initials') && this.personDetails) {
       // add avatar background color
       imageClasses[this._personAvatarBg] = true;
     }
@@ -682,7 +726,7 @@ export class MgtPerson extends MgtTemplatedComponent {
       const text = this.getTextFromProperty(person, this.line1Property);
       if (text) {
         details.push(html`
-          <div class="line1" aria-label="${text}" @click=${() => this.handleLine1Clicked()}>${text}</div>
+          <div class="line1" @click=${() => this.handleLine1Clicked()} aria-label="${text}">${text}</div>
         `);
       }
     }
@@ -691,7 +735,7 @@ export class MgtPerson extends MgtTemplatedComponent {
       const text = this.getTextFromProperty(person, this.line2Property);
       if (text) {
         details.push(html`
-          <div class="line2" aria-label="${text}" @click=${() => this.handleLine2Clicked()}>${text}</div>
+          <div class="line2" @click=${() => this.handleLine2Clicked()} aria-label="${text}">${text}</div>
         `);
       }
     }
@@ -700,7 +744,7 @@ export class MgtPerson extends MgtTemplatedComponent {
       const text = this.getTextFromProperty(person, this.line3Property);
       if (text) {
         details.push(html`
-          <div class="line3" aria-label="${text}" @click=${() => this.handleLine3Clicked()}>${text}</div>
+          <div class="line3" @click=${() => this.handleLine3Clicked()} aria-label="${text}">${text}</div>
         `);
       }
     }
@@ -787,7 +831,10 @@ export class MgtPerson extends MgtTemplatedComponent {
     const graph = provider.graph.forComponent(this);
 
     if (this.personDetails) {
-      if (!this.personDetails.personImage && (this.fetchImage && !this.personImage && !this._fetchedImage)) {
+      if (
+        !this.personDetails.personImage &&
+        (this.fetchImage && this._avatarType === 'photo' && !this.personImage && !this._fetchedImage)
+      ) {
         const image = await getPersonImage(graph, this.personDetails, MgtPerson.config.useContactApis);
         if (image) {
           this.personDetails.personImage = image;
@@ -796,8 +843,16 @@ export class MgtPerson extends MgtTemplatedComponent {
       }
     } else if (this.userId || this.personQuery === 'me') {
       // Use userId or 'me' query to get the person and image
-      const person = await getUserWithPhoto(graph, this.userId);
-
+      let person;
+      if (this._avatarType === 'photo') {
+        person = await getUserWithPhoto(graph, this.userId);
+      } else {
+        if (this.personQuery === 'me') {
+          person = await getMe(graph);
+        } else {
+          person = await getUser(graph, this.userId);
+        }
+      }
       this.personDetails = person;
       this._fetchedImage = this.getImage();
     } else if (this.personQuery) {

--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -723,29 +723,56 @@ export class MgtPerson extends MgtTemplatedComponent {
     const details: TemplateResult[] = [];
 
     if (this.view > PersonViewType.avatar) {
-      const text = this.getTextFromProperty(person, this.line1Property);
-      if (text) {
+      if (this.hasTemplate('line1')) {
+        // Render the line1 template
+        const template = this.renderTemplate('line1', { person });
         details.push(html`
-          <div class="line1" @click=${() => this.handleLine1Clicked()} aria-label="${text}">${text}</div>
+          <div class="line1" @click=${() => this.handleLine1Clicked()}>${template}</div>
         `);
+      } else {
+        // Render the line1 property value
+        const text = this.getTextFromProperty(person, this.line1Property);
+        if (text) {
+          details.push(html`
+            <div class="line1" @click=${() => this.handleLine1Clicked()} aria-label="${text}">${text}</div>
+          `);
+        }
       }
     }
 
     if (this.view > PersonViewType.oneline) {
-      const text = this.getTextFromProperty(person, this.line2Property);
-      if (text) {
+      if (this.hasTemplate('line2')) {
+        // Render the line2 template
+        const template = this.renderTemplate('line2', { person });
         details.push(html`
-          <div class="line2" @click=${() => this.handleLine2Clicked()} aria-label="${text}">${text}</div>
+          <div class="line2" @click=${() => this.handleLine2Clicked()}>${template}</div>
         `);
+      } else {
+        // Render the line2 property value
+        const text = this.getTextFromProperty(person, this.line2Property);
+        if (text) {
+          details.push(html`
+            <div class="line2" @click=${() => this.handleLine2Clicked()} aria-label="${text}">${text}</div>
+          `);
+        }
       }
     }
 
     if (this.view > PersonViewType.twolines) {
-      const text = this.getTextFromProperty(person, this.line3Property);
-      if (text) {
+      if (this.hasTemplate('line3')) {
+        // Render the line3 template
+        const template = this.renderTemplate('line3', { person });
         details.push(html`
-          <div class="line3" @click=${() => this.handleLine3Clicked()} aria-label="${text}">${text}</div>
+          <div class="line3" @click=${() => this.handleLine3Clicked()}>${template}</div>
         `);
+      } else {
+        // Render the line3 property value
+        const text = this.getTextFromProperty(person, this.line3Property);
+        if (text) {
+          details.push(html`
+            <div class="line3" @click=${() => this.handleLine3Clicked()} aria-label="${text}">${text}</div>
+          `);
+        }
       }
     }
 

--- a/packages/mgt-react/src/generated/react.ts
+++ b/packages/mgt-react/src/generated/react.ts
@@ -94,6 +94,7 @@ export type PersonProps = {
 	personDetails?: IDynamicPerson;
 	personImage?: string;
 	fetchImage?: boolean;
+	avatarType?: string;
 	personPresence?: MicrosoftGraphBeta.Presence;
 	personCardInteraction?: PersonCardInteraction;
 	line1Property?: string;

--- a/stories/components/person.stories.js
+++ b/stories/components/person.stories.js
@@ -49,6 +49,11 @@ export const personView = () => html`
   </style>
 `;
 
+export const personAvatarType = () => html`
+  <mgt-person person-query="me" avatar-type="photo"></mgt-person>
+  <mgt-person person-query="me" avatar-type="initials"></mgt-person>
+`;
+
 export const personLineClickEvents = () => html`
   <div class="example">
     <mgt-person person-query="me" view="threelines"></mgt-person>

--- a/stories/components/person.stories.js
+++ b/stories/components/person.stories.js
@@ -295,6 +295,26 @@ export const setPersonDetails = () => html`
   </script>
 `;
 
+export const retemplateMetadata = () => html`
+  <mgt-person person-query="me" view="threeLines">
+    <template data-type="line1">
+      <div>
+        Hello, my name is: {{person.displayName}}
+      </div>
+    </template>
+    <template data-type="line2">
+      <div>
+        {{person.jobTitle}}
+      </div>
+    </template>
+    <template data-type="line3">
+      <div>
+        Loves MGT
+      </div>
+    </template>
+  </mgt-person>
+`;
+
 export const moreExamples = () => html`
   <style>
     .example {


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #790 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
I've added the ability to provide templates to override the lines 1/2/3 portions of the component. Click events should continue to work, even with templates. Also, all templates have the `{{person}}` object available.

With/without templates:
![image](https://user-images.githubusercontent.com/25832310/108419078-ee569300-71e6-11eb-8145-269742352c40.png)

Implement like so:
```
<mgt-person person-query="me" view="threeLines" person-card="hover" show-presence>
  <template data-type="line1">
    <div>
      Hello, my name is: {{person.displayName}}
    </div>
  </template>
  <template data-type="line2">
    <div>
      Super cool
    </div>
  </template>
  <template data-type="line3">
    <div>
      Loves MGT
    </div>
  </template>
</mgt-person>
```

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-docs/tree/master/concepts/toolkit) [target branch `mgt/next` for new features]. Docs PR: https://github.com/microsoftgraph/microsoft-graph-docs/pull/11699
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
I didn't explicitly add the `avatarType` to the react package, but it got generated during build. It should probably be committed.