### PR TITLE
Fixed flyout position when used in a parent with css transform

### DIFF
--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -1103,7 +1103,7 @@ export class MgtPerson extends MgtTemplatedComponent {
   private hidePersonCard() {
     const flyout = this.flyout;
     if (flyout) {
-      flyout.isOpen = false;
+      flyout.close();
     }
 
     const personCard = (this.querySelector('mgt-person-card') ||
@@ -1121,7 +1121,7 @@ export class MgtPerson extends MgtTemplatedComponent {
 
     const flyout = this.flyout;
     if (flyout) {
-      flyout.isOpen = true;
+      flyout.open();
     }
   }
 }

--- a/packages/mgt-components/src/components/sub-components/mgt-flyout/mgt-flyout.scss
+++ b/packages/mgt-components/src/components/sub-components/mgt-flyout/mgt-flyout.scss
@@ -9,22 +9,41 @@
 @import '../../../styles/shared-sass-variables.scss';
 
 .root {
+  .scout-top {
+    position: fixed;
+    top: 0;
+    left: 0;
+  }
+
+  .scout-bottom {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+  }
+
   .flyout {
-    display: none;
     position: fixed;
     z-index: 9999999;
-    opacity: 0;
-    box-shadow: set-var(box-shadow, $theme-default, $common);
+
+    slot {
+      box-shadow: set-var(box-shadow, $theme-default, $common);
+      opacity: 0;
+      z-index: 9999999;
+      display: none;
+    }
   }
 
   &.visible {
     .flyout {
-      display: inline-block;
-      animation-name: fadeIn;
-      animation-duration: 0.3s;
-      animation-timing-function: cubic-bezier(0.1, 0.9, 0.2, 1);
-      animation-fill-mode: both;
       transition: top 0.3s ease, bottom 0.3s ease, left 0.3s ease;
+
+      slot {
+        display: inline-block;
+        animation-name: fadeIn;
+        animation-duration: 0.3s;
+        animation-timing-function: cubic-bezier(0.1, 0.9, 0.2, 1);
+        animation-fill-mode: both;
+      }
     }
   }
 }

--- a/packages/mgt-components/src/components/sub-components/mgt-flyout/mgt-flyout.scss
+++ b/packages/mgt-components/src/components/sub-components/mgt-flyout/mgt-flyout.scss
@@ -22,28 +22,21 @@
   }
 
   .flyout {
+    display: none;
     position: fixed;
     z-index: 9999999;
-
-    slot {
-      box-shadow: set-var(box-shadow, $theme-default, $common);
-      opacity: 0;
-      z-index: 9999999;
-      display: none;
-    }
+    opacity: 0;
+    box-shadow: set-var(box-shadow, $theme-default, $common);
   }
 
   &.visible {
     .flyout {
+      display: inline-block;
+      animation-name: fadeIn;
+      animation-duration: 0.3s;
+      animation-timing-function: cubic-bezier(0.1, 0.9, 0.2, 1);
+      animation-fill-mode: both;
       transition: top 0.3s ease, bottom 0.3s ease, left 0.3s ease;
-
-      slot {
-        display: inline-block;
-        animation-name: fadeIn;
-        animation-duration: 0.3s;
-        animation-timing-function: cubic-bezier(0.1, 0.9, 0.2, 1);
-        animation-fill-mode: both;
-      }
     }
   }
 }

--- a/packages/mgt-components/src/components/sub-components/mgt-flyout/mgt-flyout.ts
+++ b/packages/mgt-components/src/components/sub-components/mgt-flyout/mgt-flyout.ts
@@ -102,8 +102,17 @@ export class MgtFlyout extends MgtBaseComponent {
   private get _flyout(): HTMLElement {
     return this.renderRoot.querySelector('.flyout');
   }
+
   private get _anchor(): HTMLElement {
     return this.renderRoot.querySelector('.anchor');
+  }
+
+  private get _topScout(): HTMLElement {
+    return this.renderRoot.querySelector('.scout-top');
+  }
+
+  private get _bottomScout(): HTMLElement {
+    return this.renderRoot.querySelector('.scout-bottom');
   }
 
   private _isOpen: boolean;
@@ -195,6 +204,8 @@ export class MgtFlyout extends MgtBaseComponent {
         <div class="anchor">
           ${anchorTemplate}
         </div>
+        <div class="scout-top"></div>
+        <div class="scout-bottom"></div>
         ${flyoutTemplate}
       </div>
     `;
@@ -249,6 +260,8 @@ export class MgtFlyout extends MgtBaseComponent {
 
       const flyoutRect = flyout.getBoundingClientRect();
       const anchorRect = anchor.getBoundingClientRect();
+      const topScoutRect = this._topScout.getBoundingClientRect();
+      const bottomScoutRect = this._bottomScout.getBoundingClientRect();
 
       const windowRect: IWindowSegment = {
         height: windowHeight,
@@ -341,6 +354,21 @@ export class MgtFlyout extends MgtBaseComponent {
           } else {
             top = Math.max(anchorRect.top + anchorRect.height, this._edgePadding);
           }
+        }
+      }
+
+      // check the scout is positioned where it is supposed to be
+      // if it's not, then we are no longer fixed position and should assume
+      // absolute positioning
+      // this is a workaround when a transform is applied to a parent
+      // https://stackoverflow.com/questions/42660332/css-transform-parent-and-fixed-child
+      if (topScoutRect.top !== 0 || topScoutRect.left !== 0) {
+        left -= topScoutRect.left;
+
+        if (typeof bottom !== 'undefined') {
+          bottom += bottomScoutRect.top - windowHeight;
+        } else {
+          top -= topScoutRect.top;
         }
       }
 


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #877  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This PR adds a workaround by using two `scout` divs to detect when the flyout will not be positioned correctly before it is positioned, and uses the offset of those `scouts` to account for the new stacking context and apply the right position coordinates. 

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in supported browsers
- [x] All public classes and methods have been documented
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
