### PR TITLE
Added provider name to SdkVersion header

### DIFF
--- a/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.ts
+++ b/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.ts
@@ -600,7 +600,7 @@ export class MgtTeamsChannelPicker extends MgtTemplatedComponent {
       teams = await getAllMyTeams(graph);
       teams = teams.filter(t => !t.isArchived);
 
-      const batch = provider.graph.createBatch();
+      const batch = graph.createBatch();
 
       for (const team of teams) {
         batch.get(team.id, `teams/${team.id}/channels`, ['Channel.ReadBasic.All']);

--- a/packages/mgt-element/src/Graph.ts
+++ b/packages/mgt-element/src/Graph.ts
@@ -151,7 +151,7 @@ export function createFromProvider(provider: IProvider, version?: string, compon
     new AuthenticationHandler(provider),
     new RetryHandler(new RetryHandlerOptions()),
     new TelemetryHandler(),
-    new SdkVersionMiddleware(PACKAGE_VERSION),
+    new SdkVersionMiddleware(PACKAGE_VERSION, provider.name),
     new HTTPMessageHandler()
   ];
 

--- a/packages/mgt-element/src/mock/MockProvider.ts
+++ b/packages/mgt-element/src/mock/MockProvider.ts
@@ -45,6 +45,7 @@ export class MockProvider extends IProvider {
     await new Promise(resolve => setTimeout(resolve, 3000));
     this.setState(ProviderState.SignedIn);
   }
+
   /**
    * sets Provider state to signed out
    *
@@ -56,6 +57,7 @@ export class MockProvider extends IProvider {
     await new Promise(resolve => setTimeout(resolve, 3000));
     this.setState(ProviderState.SignedOut);
   }
+
   /**
    * Promise returning token from graph.microsoft.com
    *
@@ -64,5 +66,15 @@ export class MockProvider extends IProvider {
    */
   public getAccessToken(): Promise<string> {
     return Promise.resolve('{token:https://graph.microsoft.com/}');
+  }
+
+  /**
+   * Name used for analytics
+   *
+   * @readonly
+   * @memberof IProvider
+   */
+  public get name() {
+    return 'MgtMockProvider';
   }
 }

--- a/packages/mgt-element/src/providers/IProvider.ts
+++ b/packages/mgt-element/src/providers/IProvider.ts
@@ -39,6 +39,16 @@ export abstract class IProvider implements AuthenticationProvider {
     return this._state;
   }
 
+  /**
+   * Name used for analytics
+   *
+   * @readonly
+   * @memberof IProvider
+   */
+  public get name() {
+    return 'MgtIProvider';
+  }
+
   constructor() {
     this._state = ProviderState.Loading;
   }
@@ -92,7 +102,7 @@ export abstract class IProvider implements AuthenticationProvider {
   public logout?(): Promise<void>;
 
   /**
-   * uses scopes to recieve access token
+   * uses scopes to receive access token
    *
    * @param {...string[]} scopes
    * @returns {Promise<string>}

--- a/packages/mgt-element/src/providers/SimpleProvider.ts
+++ b/packages/mgt-element/src/providers/SimpleProvider.ts
@@ -21,6 +21,16 @@ export class SimpleProvider extends IProvider {
   private _loginHandler: () => Promise<void>;
   private _logoutHandler: () => Promise<void>;
 
+  /**
+   * Name used for analytics
+   *
+   * @readonly
+   * @memberof IProvider
+   */
+  public get name() {
+    return 'MgtSimpleProvider';
+  }
+
   constructor(
     getAccessTokenHandler: (scopes: string[]) => Promise<string>,
     loginHandler?: () => Promise<void>,

--- a/packages/mgt-element/src/utils/SdkVersionMiddleware.ts
+++ b/packages/mgt-element/src/utils/SdkVersionMiddleware.ts
@@ -23,9 +23,11 @@ export class SdkVersionMiddleware implements Middleware {
    */
   private _nextMiddleware: Middleware;
   private _packageVersion: string;
+  private _providerName: string;
 
-  constructor(packageVersion: string) {
+  constructor(packageVersion: string, providerName?: string) {
     this._packageVersion = packageVersion;
+    this._providerName = providerName;
   }
 
   // tslint:disable-next-line: completed-docs
@@ -41,6 +43,11 @@ export class SdkVersionMiddleware implements Middleware {
       if (componentOptions) {
         const componentVersion: string = `${componentOptions.componentName}/${this._packageVersion}`;
         headerParts.push(componentVersion);
+      }
+
+      if (this._providerName) {
+        const providerVersion: string = `${this._providerName}/${this._packageVersion}`;
+        headerParts.push(providerVersion);
       }
 
       // Package version

--- a/packages/providers/mgt-electron-provider/src/Provider/ElectronProvider.ts
+++ b/packages/providers/mgt-electron-provider/src/Provider/ElectronProvider.ts
@@ -18,6 +18,16 @@ import { ipcRenderer } from 'electron';
  * @extends {IProvider}
  */
 export class ElectronProvider extends IProvider {
+  /**
+   * Name used for analytics
+   *
+   * @readonly
+   * @memberof IProvider
+   */
+  public get name() {
+    return 'MgtElectronProvider';
+  }
+
   constructor() {
     super();
     this.graph = createFromProvider(this);

--- a/packages/providers/mgt-msal-provider/src/MsalProvider.ts
+++ b/packages/providers/mgt-msal-provider/src/MsalProvider.ts
@@ -129,6 +129,16 @@ export class MsalProvider extends IProvider {
   }
 
   /**
+   * Name used for analytics
+   *
+   * @readonly
+   * @memberof IProvider
+   */
+  public get name() {
+    return 'MgtMsalProvider';
+  }
+
+  /**
    * client-id authentication
    *
    * @protected

--- a/packages/providers/mgt-proxy-provider/src/ProxyProvider.ts
+++ b/packages/providers/mgt-proxy-provider/src/ProxyProvider.ts
@@ -22,6 +22,17 @@ export class ProxyProvider extends IProvider {
    * @memberof ProxyProvider
    */
   public graph: Graph;
+
+  /**
+   * Name used for analytics
+   *
+   * @readonly
+   * @memberof IProvider
+   */
+  public get name() {
+    return 'MgtProxyProvider';
+  }
+
   constructor(graphProxyUrl: string, getCustomHeaders: () => Promise<object> = null) {
     super();
     this.graph = new ProxyGraph(graphProxyUrl, getCustomHeaders);

--- a/packages/providers/mgt-sharepoint-provider/src/SharePointProvider.ts
+++ b/packages/providers/mgt-sharepoint-provider/src/SharePointProvider.ts
@@ -63,7 +63,17 @@ export class SharePointProvider extends IProvider {
   }
 
   /**
-   * privilege level for authenication
+   * Name used for analytics
+   *
+   * @readonly
+   * @memberof IProvider
+   */
+  public get name() {
+    return 'MgtSharePointProvider';
+  }
+
+  /**
+   * privilege level for authentication
    *
    * @type {string[]}
    * @memberof SharePointProvider

--- a/packages/providers/mgt-teams-provider/src/TeamsProvider.ts
+++ b/packages/providers/mgt-teams-provider/src/TeamsProvider.ts
@@ -135,6 +135,16 @@ export class TeamsProvider extends MsalProvider {
   }
 
   /**
+   * Name used for analytics
+   *
+   * @readonly
+   * @memberof IProvider
+   */
+  public get name() {
+    return 'MgtTeamsProvider';
+  }
+
+  /**
    * Handle all authentication redirects in the authentication page and authenticates the user
    *
    * @static


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #728 

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
- Other... 

### Description of the changes
This PR adds the provider name to the SdkVersion header for analytics

Example request:
![image](https://user-images.githubusercontent.com/711864/112422117-9af7c900-8ced-11eb-8aaf-45baae796831.png)

```
SdkVersion: MGT-TEAMS-CHANNEL-PICKER/2.2.0, MgtMsalProvider/2.2.0, mgt/2.2.0, graph-js/2.2.1 (featureUsage=6)
```

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] Contains **NO** breaking changes

