### PR TITLE
rtl for mgt-file-list and mgt-file

### DIFF
--- a/packages/mgt-components/src/components/mgt-file-list/mgt-file-list.ts
+++ b/packages/mgt-components/src/components/mgt-file-list/mgt-file-list.ts
@@ -435,7 +435,7 @@ export class MgtFileList extends MgtTemplatedComponent {
    */
   protected renderFiles(): TemplateResult {
     return html`
-      <div id="file-list-wrapper" class="file-list-wrapper">
+      <div id="file-list-wrapper" class="file-list-wrapper" dir=${this.direction}>
         <ul id="file-list" class="file-list">
           ${repeat(
             this.files,

--- a/packages/mgt-components/src/components/mgt-file/mgt-file.scss
+++ b/packages/mgt-components/src/components/mgt-file/mgt-file.scss
@@ -81,3 +81,11 @@ mgt-file .item {
     }
   }
 }
+
+[dir='rtl'] {
+  .item {
+    &__details {
+      direction: ltr;
+    }
+  }
+}

--- a/packages/mgt-components/src/components/mgt-file/mgt-file.ts
+++ b/packages/mgt-components/src/components/mgt-file/mgt-file.ts
@@ -424,7 +424,9 @@ export class MgtFile extends MgtTemplatedComponent {
     }
 
     return html`
-      ${fileTemplate}
+      <span dir=${this.direction}>
+        ${fileTemplate}
+      </span>
     `;
   }
 


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #984 #983

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

<!-- - Bugfix -->
 Feature 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Adds rtl for the two components:
`mgt-file-list`
`mgt-file` 


There wasn't much to add due to @beth-panx 's excellent css, just a fix for the number labels "01." 

I tested scenarios in the stories and some templating. 



### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
