### PR TITLE
[mgt-people-picker] tab control 

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -857,6 +857,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
   }
 
   private gainedFocus() {
+    console.log('focus happens');
     this._isFocused = true;
     if (this.input) {
       this.input.focus();
@@ -917,6 +918,10 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     if (event.keyCode === 40 || event.keyCode === 39 || event.keyCode === 38 || event.keyCode === 37) {
       // keyCodes capture: down arrow (40), right arrow (39), up arrow (38) and left arrow (37)
       return;
+    }
+    if (event.keyCode === 9 && !this.flyout.isOpen) {
+      // keyCodes capture: tab (9)
+      this.gainedFocus();
     }
 
     const input = event.target as HTMLInputElement;
@@ -992,12 +997,14 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       }
     }
     if (event.keyCode === 9 || event.keyCode === 13) {
-      // keyCodes capture: tab (9) and enter (13)
-      if (this._foundPeople.length) {
-        this.fireCustomEvent('blur');
-        event.preventDefault();
+      if (!event.shiftKey) {
+        // keyCodes capture: tab (9) and enter (13)
+        if (this._foundPeople.length) {
+          this.fireCustomEvent('blur');
+          event.preventDefault();
+        }
+        this.addPerson(this._foundPeople[this._arrowSelectionCount]);
       }
-      this.addPerson(this._foundPeople[this._arrowSelectionCount]);
       this.hideFlyout();
       (event.target as HTMLInputElement).value = '';
     }

--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -578,6 +578,9 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
    * @memberof MgtPeoplePicker
    */
   protected renderNoData(): TemplateResult {
+    if (!this._isFocused) {
+      return;
+    }
     return (
       this.renderTemplate('error', null) ||
       this.renderTemplate('no-data', null) ||
@@ -857,7 +860,6 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
   }
 
   private gainedFocus() {
-    console.log('focus happens');
     this._isFocused = true;
     if (this.input) {
       this.input.focus();
@@ -921,6 +923,9 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     }
     if (event.keyCode === 9 && !this.flyout.isOpen) {
       // keyCodes capture: tab (9)
+      this.gainedFocus();
+    }
+    if (event.shiftKey) {
       this.gainedFocus();
     }
 
@@ -997,7 +1002,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       }
     }
     if (event.keyCode === 9 || event.keyCode === 13) {
-      if (!event.shiftKey) {
+      if (!event.shiftKey && this._foundPeople) {
         // keyCodes capture: tab (9) and enter (13)
         if (this._foundPeople.length) {
           this.fireCustomEvent('blur');


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1001

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

 Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Fixes a few issues surrounding accessible tab traversal for a `mgt-people-picker` component. 

1) When user taps "tab" 2x (twice) inside the input-box, the flyout will properly hide, and be unfocused. Previously, the flyout would appear and display error message. 
2) "shift + tab" to back out of the input-box to access elements above or below
3) loads people when tabbed (related to #1001) 


This should help alleviate some of the accessible traversal until we redesign or add visible targets. example:

```html
    <h2 tabindex="0">test</h2>
    <mgt-people-picker></mgt-people-picker>
    <h2 tabindex="0">test</h2>
```

Should be easily traversable with tab, or shift+tab


### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
