### PR TITLE
[mgt-file] Include OneNote Icon when driveItem.package is type 'oneNote'

### DIFF
--- a/packages/mgt-components/src/components/mgt-file/mgt-file.ts
+++ b/packages/mgt-components/src/components/mgt-file/mgt-file.ts
@@ -488,7 +488,13 @@ export class MgtFile extends MgtTemplatedComponent {
     } else {
       // get file type extension from file name
       const re = /(?:\.([^.]+))?$/;
-      const fileType = re.exec(this.driveItem.name)[1] || (this.driveItem.package !== undefined ? (this.driveItem.package.type === 'oneNote' ? 'onetoc' : 'folder') : 'folder');
+      const fileType =
+        re.exec(this.driveItem.name)[1] ||
+        (this.driveItem.package !== undefined
+          ? this.driveItem.package.type === 'oneNote'
+            ? 'onetoc'
+            : 'folder'
+          : 'folder');
       fileIconSrc = getFileTypeIconUriByExtension(fileType, 48, 'svg');
     }
 

--- a/packages/mgt-components/src/components/mgt-file/mgt-file.ts
+++ b/packages/mgt-components/src/components/mgt-file/mgt-file.ts
@@ -488,7 +488,7 @@ export class MgtFile extends MgtTemplatedComponent {
     } else {
       // get file type extension from file name
       const re = /(?:\.([^.]+))?$/;
-      const fileType = re.exec(this.driveItem.name)[1] || 'folder';
+      const fileType = re.exec(this.driveItem.name)[1] || (this.driveItem.package !== undefined ? (this.driveItem.package.type === 'oneNote' ? 'onetoc' : 'folder') : 'folder');
       fileIconSrc = getFileTypeIconUriByExtension(fileType, 48, 'svg');
     }
 


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1026 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Added additional condition to validate if file is "driveItem.package.type === 'oneNote'".
If yes then return associate docicon 'onetoc' else returns 'Folder'
![image](https://user-images.githubusercontent.com/8522348/117275749-a565c080-ae5e-11eb-8cd1-366ea91fc882.png)


### PR checklist
- [ ] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
