### PR TITLE
[teams-channel-picker] Added scope config

### DIFF
--- a/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.graph.ts
+++ b/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.graph.ts
@@ -15,10 +15,6 @@ import { Team } from '@microsoft/microsoft-graph-types';
  * @memberof Graph
  */
 export async function getAllMyTeams(graph: IGraph): Promise<Team[]> {
-  const teams = await graph
-    .api('/me/joinedTeams')
-    .middlewareOptions(prepScopes('Team.ReadBasic.All'))
-    .select(['displayName', 'id', 'isArchived'])
-    .get();
+  const teams = await graph.api('/me/joinedTeams').select(['displayName', 'id', 'isArchived']).get();
   return teams ? teams.value : null;
 }


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1074 
### PR Type
<!-- Please uncomment one or more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This PR adds a static config to `MgtTeamsChannelPicker` for the user to globally select which scopes to use in order to avoid a breaking change as part of 2.2.

By default, the component will continue asking for 'user.read.all', 'group.read.all'.

With this line

```ts
MgtTeamsChannelPicker.config.useTeamsBasedScopes = true;
```

The component will ask for 'team.readbasic.all', 'channel.readbasic.all'

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: https://github.com/microsoftgraph/microsoft-graph-docs/pull/12560/commits/f868f639fc67e7fa371fe34e1b93b3b0c4b9ceef
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
As part of this PR, I'm asking for all scopes for that component at the same to minimize the number of popups/redirects a user gets. We can use this as an example for other components in the future.
