### PR TITLE
Fixed getUserWithPhoto when photo is already cached

### DIFF
--- a/packages/mgt-components/src/graph/graph.userWithPhoto.ts
+++ b/packages/mgt-components/src/graph/graph.userWithPhoto.ts
@@ -38,7 +38,7 @@ export async function getUserWithPhoto(
   let cachedUser: CacheUser;
 
   const resource = userId ? `users/${userId}` : 'me';
-  let fullResource = requestedProps ? `?$select=${requestedProps.toString()}` : '';
+  let fullResource = resource + (requestedProps ? `?$select=${requestedProps.toString()}` : '');
 
   const scopes = userId ? ['user.readbasic.all'] : ['user.read'];
 


### PR DESCRIPTION
This is a follow up form #1051 

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
I noticed that if a photo is already cached, but a user is not, the call to get the user from the graph is malformed. This PR fixes that issue.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
