### PR TITLE
Added two new workflows to automate storybook and npm publishing

### DIFF
--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -25,8 +25,7 @@ jobs:
 
       - name: Get latest version from npm
         id: latest-version
-        shell: bash
-        run: echo "##[set-output name=version;]npm show @microsoft/mgt version"
+        run: echo ::set-output name=version::$(npm show @microsoft/mgt version)
 
       - name: Get current package version
         id: package-version
@@ -36,19 +35,11 @@ jobs:
         if: steps.latest-version.outputs.version != steps.package-version.outputs.current-version
         run: echo "latest-version ${{steps.latest-version.outputs.version}}  package version ${{steps.package-version.outputs.current-version}}"
 
-      - run: npm install -g yarn lerna
-      - run: yarn
-      - run: yarn build
-      - run: yarn storybook:build
-
-      - name: Deploy mgt.dev 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.1
-        with:
-          branch: gh-pages
-          folder: storybook-static
-          target-folder: .
-          clean-exclude: next
-        if: github.repository == 'microsoftgraph/microsoft-graph-toolkit'
+      # - name: Build 🛠
+      #   run: |
+      #         npm install -g yarn lerna
+      #         yarn
+      #         yarn build
 
       # - run: node scripts/setVersion.js
       # - run: lerna exec --scope @microsoft/* -- "npm publish --access=public"
@@ -60,3 +51,15 @@ jobs:
       #   with:
       #     name: mgt-spfx solution
       #     path: packages/mgt-spfx/sharepoint/*
+
+      # - name: Build storybook
+      #   run: yarn storybook:build
+
+      # - name: Deploy mgt.dev 🚀
+      #   uses: JamesIves/github-pages-deploy-action@4.1.1
+      #   with:
+      #     branch: gh-pages
+      #     folder: storybook-static
+      #     target-folder: .
+      #     clean-exclude: next
+      #   if: github.repository == 'microsoftgraph/microsoft-graph-toolkit'

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -8,15 +8,19 @@ on:
     branches: [release/latest, nmetulev/storybook-next]
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         node-version: [12.x]
 
+    environment:
+      name: release
+
     steps:
       - uses: actions/checkout@v2
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -31,35 +35,57 @@ jobs:
         id: package-version
         uses: martinbeentjes/npm-get-version-action@master
 
-      - name: test conditional
+      - name: Build 🛠
         if: steps.latest-version.outputs.version != steps.package-version.outputs.current-version
-        run: echo "latest-version ${{steps.latest-version.outputs.version}}  package version ${{steps.package-version.outputs.current-version}}"
+        run: |
+          npm install -g yarn lerna
+          yarn
+          yarn build
 
-      # - name: Build 🛠
-      #   run: |
-      #         npm install -g yarn lerna
-      #         yarn
-      #         yarn build
+      # commenting out for now until we can properly test this during a release
+      # - name: Update package version
+      #   if: steps.latest-version.outputs.version != steps.package-version.outputs.current-version
+      #   run: node scripts/setVersion.js
 
-      # - run: node scripts/setVersion.js
-      # - run: lerna exec --scope @microsoft/* -- "npm publish --access=public"
-      #   if: github.repository == 'microsoftgraph/microsoft-graph-toolkit' && package.json version != npm version
+      # - name: Publish npm packages
+      #   if: steps.latest-version.outputs.version != steps.package-version.outputs.current-version
+      #   run: lerna exec --scope @microsoft/* -- "npm publish --access=public"
       #   env:
       #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       # - name: Upload a Build Artifact - mgt-spfx Solution
+      #   if: steps.latest-version.outputs.version != steps.package-version.outputs.current-version
       #   uses: actions/upload-artifact@v2
       #   with:
       #     name: mgt-spfx solution
       #     path: packages/mgt-spfx/sharepoint/*
 
-      # - name: Build storybook
-      #   run: yarn storybook:build
+  storybook:
+    runs-on: ubuntu-latest
 
-      # - name: Deploy mgt.dev 🚀
-      #   uses: JamesIves/github-pages-deploy-action@4.1.1
-      #   with:
-      #     branch: gh-pages
-      #     folder: storybook-static
-      #     target-folder: .
-      #     clean-exclude: next
-      #   if: github.repository == 'microsoftgraph/microsoft-graph-toolkit'
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Build 🛠
+        run: |
+          npm install -g yarn lerna
+          yarn
+          yarn build
+          yarn storybook:build
+
+      - name: Deploy mgt.dev 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        with:
+          branch: gh-pages
+          folder: storybook-static
+          target-folder: .
+          clean-exclude: next

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -8,9 +8,38 @@ on:
     branches: [release/latest, nmetulev/storybook-next]
 
 jobs:
-  release:
+  version:
     runs-on: ubuntu-latest
 
+    outputs:
+      latest-version: ${{steps.latest-version.outputs.version}}
+      package-version: ${{steps.package-version.outputs.current-version}}
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Get latest version from npm
+        id: latest-version
+        run: echo ::set-output name=version::$(npm show @microsoft/mgt version)
+
+      - name: Get current package version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@master
+
+  release:
+    runs-on: ubuntu-latest
+    needs: version
+    if: needs.version.outputs.latest-version != needs.version.outputs.package-version
     strategy:
       matrix:
         node-version: [12.x]
@@ -36,7 +65,6 @@ jobs:
         uses: martinbeentjes/npm-get-version-action@master
 
       - name: Build 🛠
-        if: steps.latest-version.outputs.version != steps.package-version.outputs.current-version
         run: |
           npm install -g yarn lerna
           yarn
@@ -44,17 +72,14 @@ jobs:
 
       # commenting out for now until we can properly test this during a release
       # - name: Update package version
-      #   if: steps.latest-version.outputs.version != steps.package-version.outputs.current-version
       #   run: node scripts/setVersion.js
 
       # - name: Publish npm packages
-      #   if: steps.latest-version.outputs.version != steps.package-version.outputs.current-version
       #   run: lerna exec --scope @microsoft/* -- "npm publish --access=public"
       #   env:
       #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # - name: Upload a Build Artifact - mgt-spfx Solution
-      #   if: steps.latest-version.outputs.version != steps.package-version.outputs.current-version
       #   uses: actions/upload-artifact@v2
       #   with:
       #     name: mgt-spfx solution

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -5,7 +5,7 @@ name: Build CI
 
 on:
   push:
-    branches: [release/latest, nmetulev/storybook-next]
+    branches: [release/latest]
 
 jobs:
   version:

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -1,0 +1,62 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Build CI
+
+on:
+  push:
+    branches: [release/latest, nmetulev/storybook-next]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Get latest version from npm
+        id: latest-version
+        shell: bash
+        run: echo "##[set-output name=version;]npm show @microsoft/mgt version"
+
+      - name: Get current package version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@master
+
+      - name: test conditional
+        if: steps.latest-version.outputs.version != steps.package-version.outputs.current-version
+        run: echo "latest-version ${{steps.latest-version.outputs.version}}  package version ${{steps.package-version.outputs.current-version}}"
+
+      - run: npm install -g yarn lerna
+      - run: yarn
+      - run: yarn build
+      - run: yarn storybook:build
+
+      - name: Deploy mgt.dev 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        with:
+          branch: gh-pages
+          folder: storybook-static
+          target-folder: .
+          clean-exclude: next
+        if: github.repository == 'microsoftgraph/microsoft-graph-toolkit'
+
+      # - run: node scripts/setVersion.js
+      # - run: lerna exec --scope @microsoft/* -- "npm publish --access=public"
+      #   if: github.repository == 'microsoftgraph/microsoft-graph-toolkit' && package.json version != npm version
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # - name: Upload a Build Artifact - mgt-spfx Solution
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: mgt-spfx solution
+      #     path: packages/mgt-spfx/sharepoint/*

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    if: github.repository == 'microsoftgraph/microsoft-graph-toolkit'
     strategy:
       matrix:
         node-version: [12.x]
@@ -24,14 +24,21 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install -g yarn lerna
-      - run: yarn
-      - run: yarn build
-      - run: node scripts/setVersion.js --next
-      - run: lerna exec --scope @microsoft/* -- "npm publish --tag next --access=public"
-        if: github.repository == 'microsoftgraph/microsoft-graph-toolkit'
+
+      - name: Build 🛠
+        run: |
+          npm install -g yarn lerna
+          yarn
+          yarn build
+
+      - name: Set Preview Version
+        run: node scripts/setVersion.js --next
+
+      - name: Publish preview packages 🚀
+        run: lerna exec --scope @microsoft/* -- "npm publish --tag next --access=public"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Upload a Build Artifact - mgt-spfx Solution
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -32,5 +32,4 @@ jobs:
           branch: gh-pages
           folder: storybook-static
           target-folder: next
-          clean: false
         if: github.repository == 'microsoftgraph/microsoft-graph-toolkit'

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -6,8 +6,6 @@ name: Build CI
 on:
   push:
     branches: [main, nmetulev/storybook-next]
-    paths:
-      - 'packages/**'
 
 jobs:
   build:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -5,7 +5,7 @@ name: Build CI
 
 on:
   push:
-    branches: [main, nmetulev/storybook-next]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,38 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Build CI
+
+on:
+  push:
+    branches: [main, nmetulev/storybook-next]
+    paths:
+      - 'packages/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install -g yarn lerna
+      - run: yarn
+      - run: yarn build
+      - run: yarn storybook:build
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        with:
+          BRANCH: gh-pages
+          FOLDER: storybook-static
+          TARGET_FOLDER: next
+          CLEAN: false
+        if: github.repository == 'microsoftgraph/microsoft-graph-toolkit'

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.1
         with:
-          BRANCH: gh-pages
-          FOLDER: storybook-static
-          TARGET_FOLDER: next
-          CLEAN: false
+          branch: gh-pages
+          folder: storybook-static
+          target-folder: next
+          clean: false
         if: github.repository == 'microsoftgraph/microsoft-graph-toolkit'

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'microsoftgraph/microsoft-graph-toolkit'
 
     strategy:
       matrix:
@@ -22,14 +23,17 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install -g yarn lerna
-      - run: yarn
-      - run: yarn build
-      - run: yarn storybook:build
-      - name: Deploy 🚀
+
+      - name: Build 🛠
+        run: |
+          npm install -g yarn lerna
+          yarn
+          yarn build
+          yarn storybook:build
+
+      - name: Deploy mgt.dev/next 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.1
         with:
           branch: gh-pages
           folder: storybook-static
           target-folder: next
-        if: github.repository == 'microsoftgraph/microsoft-graph-toolkit'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.2.0",
   "workspaces": [
     "packages/*",
     "packages/providers/*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.1.0",
   "workspaces": [
     "packages/*",
     "packages/providers/*",


### PR DESCRIPTION
### PR Type
<!-- Please uncomment one or more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
- Build or CI related changes
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

This PR adds two new workflows 

1. storybook.yml - whenever changes are pushed to the `main` branch, a new version of mgt.dev will be automatically published to mgt.dev/next for testing and demo purposes. 
2. push-release - whenever changes are pushed to the `release/latest` branch, this workflow will 
    - auto publish mgt.dev
    - publish a new release to npm if the version of package.json is different to what is already published - before publishing, an administrator will have to approve the workflow from running (this is currently commented out until we can test it out during next release)


### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
