### PR TITLE
Add default-selected-group-ids attribute for People-Picker component

### DIFF
--- a/packages/mgt-components/src/graph/cacheStores.ts
+++ b/packages/mgt-components/src/graph/cacheStores.ts
@@ -44,6 +44,7 @@ export const schemas = {
   groups: {
     name: 'groups',
     stores: {
+      groups: 'groups',
       groupsQuery: 'groupsQuery'
     },
     version: 1

--- a/packages/mgt-components/src/graph/cacheStores.ts
+++ b/packages/mgt-components/src/graph/cacheStores.ts
@@ -47,7 +47,7 @@ export const schemas = {
       groups: 'groups',
       groupsQuery: 'groupsQuery'
     },
-    version: 1
+    version: 2
   },
   get: {
     name: 'responses',

--- a/packages/mgt-element/src/utils/Cache.ts
+++ b/packages/mgt-element/src/utils/Cache.ts
@@ -360,7 +360,7 @@ export class CacheStore<T extends CacheItem> {
       upgrade: (db, oldVersion, newVersion, transaction) => {
         for (const storeName in this.schema.stores) {
           if (this.schema.stores.hasOwnProperty(storeName)) {
-            db.createObjectStore(storeName);
+            db.objectStoreNames.contains(storeName) || db.createObjectStore(storeName);
           }
         }
       }

--- a/packages/mgt-react/src/generated/react.ts
+++ b/packages/mgt-react/src/generated/react.ts
@@ -99,6 +99,7 @@ export type PeoplePickerProps = {
 	people?: IDynamicPerson[];
 	selectedPeople?: IDynamicPerson[];
 	defaultSelectedUserIds?: string[];
+	defaultSelectedGroupIds?: string[];
 	placeholder?: string;
 	selectionMode?: string;
 	showMax?: number;

--- a/stories/components/peoplePicker.stories.js
+++ b/stories/components/peoplePicker.stories.js
@@ -160,6 +160,21 @@ export const pickerDefaultSelectedUserIds = () => html`
   </mgt-people-picker>
 `;
 
+export const pickerDefaultSelectedGroupIds = () => html`
+  <mgt-people-picker
+    default-selected-group-ids="94cb7dd0-cb3b-49e0-ad15-4efeb3c7d3e9, f2861ed7-abca-4556-bf0c-39ddc717ad81">
+  </mgt-people-picker>
+  </mgt-people-picker>
+`;
+
+export const pickerDefaultSelectedUserAndGroupIds = () => html`
+  <mgt-people-picker
+    default-selected-user-ids="e3d0513b-449e-4198-ba6f-bd97ae7cae85, 40079818-3808-4585-903b-02605f061225"
+    default-selected-group-ids="94cb7dd0-cb3b-49e0-ad15-4efeb3c7d3e9, f2861ed7-abca-4556-bf0c-39ddc717ad81">
+  </mgt-people-picker>
+  </mgt-people-picker>
+`;
+
 export const darkTheme = () => html`
   <mgt-people-picker class="mgt-dark"></mgt-people-picker>
   <style>

--- a/stories/components/peoplePicker.stories.js
+++ b/stories/components/peoplePicker.stories.js
@@ -171,7 +171,6 @@ export const pickerDefaultSelectedUserAndGroupIds = () => html`
     default-selected-user-ids="e3d0513b-449e-4198-ba6f-bd97ae7cae85, 40079818-3808-4585-903b-02605f061225"
     default-selected-group-ids="94cb7dd0-cb3b-49e0-ad15-4efeb3c7d3e9, f2861ed7-abca-4556-bf0c-39ddc717ad81">
   </mgt-people-picker>
-  </mgt-people-picker>
 `;
 
 export const darkTheme = () => html`

--- a/stories/components/peoplePicker.stories.js
+++ b/stories/components/peoplePicker.stories.js
@@ -164,7 +164,6 @@ export const pickerDefaultSelectedGroupIds = () => html`
   <mgt-people-picker
     default-selected-group-ids="94cb7dd0-cb3b-49e0-ad15-4efeb3c7d3e9, f2861ed7-abca-4556-bf0c-39ddc717ad81">
   </mgt-people-picker>
-  </mgt-people-picker>
 `;
 
 export const pickerDefaultSelectedUserAndGroupIds = () => html`


### PR DESCRIPTION
Closes #1065

### PR Type
Feature

### Description of the changes
The newly added `default-selected-group-ids` complements the already existing `default-selected-user-ids`. It allows initializing the People Picker component with pre-selected groups. A use case for this would be an edit page that loads user IDs and group IDs from a database for the end-user to edit the selection of users and groups.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: https://github.com/microsoftgraph/microsoft-graph-docs/pull/12662
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes