### PR TITLE
Fix regex for safari

### DIFF
--- a/packages/mgt-components/src/graph/graph.files.ts
+++ b/packages/mgt-components/src/graph/graph.files.ts
@@ -1069,8 +1069,11 @@ export async function fetchNextAndCacheForFilesPageIterator(filesPageIterator) {
   if (getIsFileListsCacheEnabled()) {
     let cache: CacheStore<CacheFileList>;
     cache = CacheService.getCache<CacheFileList>(schemas.fileLists, schemas.fileLists.stores.fileLists);
-    const reg = /(?<=graph.microsoft.com\/(v1.0|beta))(.*?)(?=\?)/gi; // match only the endpoint (after version number and before OData query params) e.g. /me/drive/root/children
-    const key = reg.exec(nextLink);
+
+    // match only the endpoint (after version number and before OData query params) e.g. /me/drive/root/children
+    const reg = /(graph.microsoft.com\/(v1.0|beta))(.*?)(?=\?)/gi;
+    const matches = reg.exec(nextLink);
+    const key = matches[3];
 
     cache.putValue(key[0], { files: filesPageIterator.value, nextLink: filesPageIterator._nextLink });
   }

--- a/packages/mgt-components/src/graph/graph.files.ts
+++ b/packages/mgt-components/src/graph/graph.files.ts
@@ -1075,6 +1075,6 @@ export async function fetchNextAndCacheForFilesPageIterator(filesPageIterator) {
     const matches = reg.exec(nextLink);
     const key = matches[3];
 
-    cache.putValue(key[0], { files: filesPageIterator.value, nextLink: filesPageIterator._nextLink });
+    cache.putValue(key, { files: filesPageIterator.value, nextLink: filesPageIterator._nextLink });
   }
 }


### PR DESCRIPTION
Closes #1130 

### PR Type
 - Bugfix

### Description of the changes
A regex expression in file graph.file breaks build for Safari 

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium 
