### PR TITLE
Add selectGroupsById method to People-Picker component

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -9,7 +9,7 @@ import { User } from '@microsoft/microsoft-graph-types';
 import { customElement, html, internalProperty, property, TemplateResult } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map';
 import { repeat } from 'lit-html/directives/repeat';
-import { findGroups, findGroupsFromGroup, getGroupsForGroupIds, GroupType } from '../../graph/graph.groups';
+import { findGroups, findGroupsFromGroup, getGroupsForGroupIds, GroupType, getGroup } from '../../graph/graph.groups';
 import { findPeople, getPeople, PersonType, UserType } from '../../graph/graph.people';
 import { findUsers, findGroupMembers, getUser, getUsersForUserIds } from '../../graph/graph.user';
 import { IDynamicPerson, ViewType } from '../../graph/types';
@@ -429,6 +429,21 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     }
   }
 
+  public async selectGroupsById(groupIds: readonly string[]): Promise<void> {
+    const provider = Providers.globalProvider;
+    const graph = Providers.globalProvider.graph;
+    if (provider && provider.state === ProviderState.SignedIn) {
+      // tslint:disable-next-line: forin
+      for (const id in groupIds) {
+        try {
+          const groupDetails = await getGroup(graph, groupIds[id]);
+          this.addPerson(groupDetails);
+          // tslint:disable-next-line: no-empty
+        } catch (e) {}
+      }
+    }
+  }
+
   /**
    * Invoked on each update to perform rendering tasks. This method must return a lit-html TemplateResult.
    * Setting properties inside this method will not trigger the element to update.
@@ -452,12 +467,12 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     };
 
     return html`
-      <div dir=${this.direction} class=${classMap(inputClasses)} @click=${e => this.focus(e)}>
-        <div class="selected-list">
-          ${selectedPeopleTemplate} ${flyoutTemplate}
-        </div>
-      </div>
-    `;
+       <div dir=${this.direction} class=${classMap(inputClasses)} @click=${e => this.focus(e)}>
+         <div class="selected-list">
+           ${selectedPeopleTemplate} ${flyoutTemplate}
+         </div>
+       </div>
+     `;
   }
 
   /**
@@ -518,23 +533,23 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     }
 
     return html`
-      <div class="${classMap(inputClasses)}">
-        <input
-          id="people-picker-input"
-          class="search-box__input"
-          type="text"
-          placeholder=${placeholder}
-          label="people-picker-input"
-          aria-label="people-picker-input"
-          role="input"
-          @keydown="${this.onUserKeyDown}"
-          @keyup="${this.onUserKeyUp}"
-          @blur=${this.lostFocus}
-          @click=${this.handleFlyout}
-          ?disabled=${this.disabled}
-        />
-      </div>
-    `;
+       <div class="${classMap(inputClasses)}">
+         <input
+           id="people-picker-input"
+           class="search-box__input"
+           type="text"
+           placeholder=${placeholder}
+           label="people-picker-input"
+           aria-label="people-picker-input"
+           role="input"
+           @keydown="${this.onUserKeyDown}"
+           @keyup="${this.onUserKeyUp}"
+           @blur=${this.lostFocus}
+           @click=${this.handleFlyout}
+           ?disabled=${this.disabled}
+         />
+       </div>
+     `;
   }
 
   /**
@@ -550,31 +565,31 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       return null;
     }
     return html`
-      ${selectedPeople.slice(0, selectedPeople.length).map(
-        person =>
-          html`
-            <div class="selected-list__person-wrapper">
-              ${
-                this.renderTemplate(
-                  'selected-person',
-                  { person },
-                  `selected-${person.id ? person.id : person.displayName}`
-                ) || this.renderSelectedPerson(person)
-              }
+       ${selectedPeople.slice(0, selectedPeople.length).map(
+         person =>
+           html`
+             <div class="selected-list__person-wrapper">
+               ${
+                 this.renderTemplate(
+                   'selected-person',
+                   { person },
+                   `selected-${person.id ? person.id : person.displayName}`
+                 ) || this.renderSelectedPerson(person)
+               }
 
-              <div class="selected-list__person-wrapper__overflow">
-                <div class="selected-list__person-wrapper__overflow__gradient"></div>
-                <div
-                  class="selected-list__person-wrapper__overflow__close-icon"
-                  @click="${e => this.removePerson(person, e)}"
-                >
-                  \uE711
-                </div>
-              </div>
-            </div>
-          `
-      )}
-    `;
+               <div class="selected-list__person-wrapper__overflow">
+                 <div class="selected-list__person-wrapper__overflow__gradient"></div>
+                 <div
+                   class="selected-list__person-wrapper__overflow__close-icon"
+                   @click="${e => this.removePerson(person, e)}"
+                 >
+                   \uE711
+                 </div>
+               </div>
+             </div>
+           `
+       )}
+     `;
   }
   /**
    * Render the flyout chrome.
@@ -585,13 +600,13 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
    */
   protected renderFlyout(anchor: TemplateResult): TemplateResult {
     return html`
-      <mgt-flyout light-dismiss class="flyout">
-        ${anchor}
-        <div slot="flyout" class="flyout-root" @wheel=${(e: WheelEvent) => this.handleSectionScroll(e)}>
-          ${this.renderFlyoutContent()}
-        </div>
-      </mgt-flyout>
-    `;
+       <mgt-flyout light-dismiss class="flyout">
+         ${anchor}
+         <div slot="flyout" class="flyout-root" @wheel=${(e: WheelEvent) => this.handleSectionScroll(e)}>
+           ${this.renderFlyoutContent()}
+         </div>
+       </mgt-flyout>
+     `;
   }
 
   /**
@@ -634,13 +649,13 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     return (
       this.renderTemplate('loading', null) ||
       html`
-        <div class="message-parent">
-          <mgt-spinner></mgt-spinner>
-          <div label="loading-text" aria-label="loading" class="loading-text">
-            ${this.strings.loadingMessage}
-          </div>
-        </div>
-      `
+         <div class="message-parent">
+           <mgt-spinner></mgt-spinner>
+           <div label="loading-text" aria-label="loading" class="loading-text">
+             ${this.strings.loadingMessage}
+           </div>
+         </div>
+       `
     );
   }
 
@@ -659,12 +674,12 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       this.renderTemplate('error', null) ||
       this.renderTemplate('no-data', null) ||
       html`
-        <div class="message-parent">
-          <div label="search-error-text" aria-label="We didn't find any matches." class="search-error-text">
-            ${this.strings.noResultsFound}
-          </div>
-        </div>
-      `
+         <div class="message-parent">
+           <div label="search-error-text" aria-label="We didn't find any matches." class="search-error-text">
+             ${this.strings.noResultsFound}
+           </div>
+         </div>
+       `
     );
   }
 
@@ -680,24 +695,24 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     people = people || this._foundPeople;
 
     return html`
-      <div class="people-list">
-        ${repeat(
-          people,
-          person => person.id,
-          person => {
-            const listPersonClasses = {
-              focused: (person as IFocusable).isFocused,
-              'list-person': true
-            };
-            return html`
-              <li class="${classMap(listPersonClasses)}" @click="${e => this.onPersonClick(person)}">
-                ${this.renderPersonResult(person)}
-              </li>
-            `;
-          }
-        )}
-      </div>
-    `;
+       <div class="people-list">
+         ${repeat(
+           people,
+           person => person.id,
+           person => {
+             const listPersonClasses = {
+               focused: (person as IFocusable).isFocused,
+               'list-person': true
+             };
+             return html`
+               <li class="${classMap(listPersonClasses)}" @click="${e => this.onPersonClick(person)}">
+                 ${this.renderPersonResult(person)}
+               </li>
+             `;
+           }
+         )}
+       </div>
+     `;
   }
 
   /**
@@ -720,12 +735,12 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     return (
       this.renderTemplate('person', { person }, person.id) ||
       html`
-        <mgt-person .personDetails=${person} .fetchImage=${true}></mgt-person>
-        <div class="people-person-text-area" id="${person.displayName}">
-          ${this.renderHighlightText(person)}
-          <span class="${classMap(classes)}">${subTitle}</span>
-        </div>
-      `
+         <mgt-person .personDetails=${person} .fetchImage=${true}></mgt-person>
+         <div class="people-person-text-area" id="${person.displayName}">
+           ${this.renderHighlightText(person)}
+           <span class="${classMap(classes)}">${subTitle}</span>
+         </div>
+       `
     );
   }
 
@@ -739,14 +754,14 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
    */
   protected renderSelectedPerson(person: IDynamicPerson): TemplateResult {
     return html`
-      <mgt-person
-        class="selected-list__person-wrapper__person"
-        .personDetails=${person}
-        .fetchImage=${true}
-        .view=${ViewType.oneline}
-        .personCardInteraction=${PersonCardInteraction.click}
-      ></mgt-person>
-    `;
+       <mgt-person
+         class="selected-list__person-wrapper__person"
+         .personDetails=${person}
+         .fetchImage=${true}
+         .view=${ViewType.oneline}
+         .personCardInteraction=${PersonCardInteraction.click}
+       ></mgt-person>
+     `;
   }
 
   /**
@@ -987,12 +1002,12 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     }
 
     return html`
-      <div>
-        <span class="people-person-text">${first}</span
-        ><span class="people-person-text highlight-search-text">${highlight}</span
-        ><span class="people-person-text">${last}</span>
-      </div>
-    `;
+       <div>
+         <span class="people-person-text">${first}</span
+         ><span class="people-person-text highlight-search-text">${highlight}</span
+         ><span class="people-person-text">${last}</span>
+       </div>
+     `;
   }
 
   /**

--- a/stories/components/peoplePicker/peoplePicker.a.js
+++ b/stories/components/peoplePicker/peoplePicker.a.js
@@ -15,37 +15,53 @@ export default {
 };
 
 export const peoplePicker = () => html`
-  <mgt-people-picker></mgt-people-picker>
-`;
+   <mgt-people-picker></mgt-people-picker>
+ `;
 
 export const RTL = () => html`
-  <body dir="rtl">
-    <mgt-people-picker></mgt-people-picker>
-  </body>
-`;
+   <body dir="rtl">
+     <mgt-people-picker></mgt-people-picker>
+   </body>
+ `;
 
 export const selectionChangedEvent = () => html`
-  <mgt-people-picker></mgt-people-picker>
-  <!-- Check the console tab for results -->
-  <script>
-  document.querySelector('mgt-people-picker').addEventListener('selectionChanged', e => {
-    console.log(e.detail)
-  });
-  </script>
-`;
+   <mgt-people-picker></mgt-people-picker>
+   <!-- Check the console tab for results -->
+   <script>
+   document.querySelector('mgt-people-picker').addEventListener('selectionChanged', e => {
+     console.log(e.detail)
+   });
+   </script>
+ `;
+
+export const selectGroupsById = () => html`
+   <mgt-people-picker></mgt-people-picker>
+   <!-- Check the js tab for example -->
+   <script>
+   document.querySelector('mgt-people-picker').selectGroupsById(["94cb7dd0-cb3b-49e0-ad15-4efeb3c7d3e9", "f2861ed7-abca-4556-bf0c-39ddc717ad81"]);
+   </script>
+ `;
+
+export const selectUsersById = () => html`
+   <mgt-people-picker></mgt-people-picker>
+   <!-- Check the js tab for example -->
+   <script>
+   document.querySelector('mgt-people-picker').selectUsersById(["e3d0513b-449e-4198-ba6f-bd97ae7cae85", "40079818-3808-4585-903b-02605f061225"]);
+   </script>
+ `;
 
 export const localization = () => html`
-  <mgt-people-picker></mgt-people-picker>
-  <script>
-  import { LocalizationHelper } from '@microsoft/mgt';
-  LocalizationHelper.strings = {
-    _components: {
-      'people-picker': {
-        inputPlaceholderText: 'Search for 🤼',
-        noResultsFound: '🤷‍♀️',
-        loadingMessage: '🦔'
-      }
-    }
-  }
-  </script>
-`;
+   <mgt-people-picker></mgt-people-picker>
+   <script>
+   import { LocalizationHelper } from '@microsoft/mgt';
+   LocalizationHelper.strings = {
+     _components: {
+       'people-picker': {
+         inputPlaceholderText: 'Search for 🤼',
+         noResultsFound: '🤷‍♀️',
+         loadingMessage: '🦔'
+       }
+     }
+   }
+   </script>
+ `;


### PR DESCRIPTION
Closes #1169 

### PR Type
Feature

### Description of the changes

The added selectGroupsById complements the existing selectUsersById. It allows prepopulating the People Picker component with groups using their group IDs. Use case is, on an edit page that loads user IDs and group IDs from a database the end-user can edit the selection of users and groups already populating the People Picker component.
### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Contains **NO** breaking changes
