### PR TITLE
Adds support for loading document thumbnails with mgt-get. Closes #1218

### DIFF
--- a/packages/mgt-components/src/components/mgt-get/mgt-get.ts
+++ b/packages/mgt-components/src/components/mgt-get/mgt-get.ts
@@ -18,6 +18,7 @@ import {
 } from '@microsoft/mgt-element';
 
 import { getPhotoForResource } from '../../graph/graph.photos';
+import { getDocumentThumbnail } from '../../graph/graph.files';
 import { schemas } from '../../graph/cacheStores';
 
 /**
@@ -374,17 +375,28 @@ export class MgtGet extends MgtTemplatedComponent {
               }
             }
           } else {
-            if (this.resource.indexOf('/photo/$value') === -1) {
-              throw new Error('Only /photo/$value endpoints support the image type');
+            if (this.resource.indexOf('/photo/$value') === -1 && this.resource.indexOf('/thumbnails/') === -1) {
+              throw new Error('Only /photo/$value and /thumbnails/ endpoints support the image type');
             }
 
-            // Sanitizing the resource to ensure getPhotoForResource gets the right format
-            const sanitizedResource = this.resource.replace('/photo/$value', '');
-            const photoResponse = await getPhotoForResource(graph, sanitizedResource, this.scopes);
+            let image;
+            if (this.resource.indexOf('/photo/$value') > -1) {
+              // Sanitizing the resource to ensure getPhotoForResource gets the right format
+              const sanitizedResource = this.resource.replace('/photo/$value', '');
+              const photoResponse = await getPhotoForResource(graph, sanitizedResource, this.scopes);
+              if (photoResponse) {
+                image = photoResponse.photo;
+              }
+            } else if (this.resource.indexOf('/thumbnails/') > -1) {
+              const imageResponse = await getDocumentThumbnail(graph, this.resource, this.scopes);
+              if (imageResponse) {
+                image = imageResponse.thumbnail;
+              }
+            }
 
-            if (photoResponse) {
+            if (image) {
               response = {
-                image: photoResponse.photo
+                image: image
               };
             }
           }


### PR DESCRIPTION
Closes #1218

### PR Type

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Adds support for loading document thumbnails with mgt-get

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: TBD
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information

~~While the project builds and the changes seem to be okay, I couldn't fully test them. The storybook proxy doesn't seem to return document thumbnails and there are no instructions how to test the bundle locally. Is there a way for us to see it in action before merging @nmetulev?~~

I found the build:bundle script in the mgt package and was able to test the bundle locally. All seems to be working as intended.