### PR TITLE
[mgt-get] variable "presentational" loading template with refresh 

### DIFF
--- a/packages/mgt-components/src/components/mgt-get/mgt-get.ts
+++ b/packages/mgt-components/src/components/mgt-get/mgt-get.ts
@@ -203,6 +203,7 @@ export class MgtGet extends MgtTemplatedComponent {
 
   private isPolling: boolean = false;
   private isRefreshing: boolean = false;
+  private refreshType: string = 'false';
 
   /**
    * Synchronizes property values when attributes change.
@@ -226,6 +227,8 @@ export class MgtGet extends MgtTemplatedComponent {
    * @memberof MgtGet
    */
   public refresh(hardRefresh = false) {
+    this.refreshType = hardRefresh.toString();
+
     this.isRefreshing = true;
     this.requestStateUpdate(hardRefresh);
     this.isRefreshing = false;
@@ -247,7 +250,7 @@ export class MgtGet extends MgtTemplatedComponent {
    * trigger the element to update.
    */
   protected render() {
-    if (this.isLoadingState && !this.isPolling) {
+    if (this.isLoadingState && !this.isPolling && this.refreshType !== 'false') {
       return this.renderTemplate('loading', null);
     } else if (this.error) {
       return this.renderTemplate('error', this.error);

--- a/packages/mgt-components/src/components/mgt-get/mgt-get.ts
+++ b/packages/mgt-components/src/components/mgt-get/mgt-get.ts
@@ -203,7 +203,6 @@ export class MgtGet extends MgtTemplatedComponent {
 
   private isPolling: boolean = false;
   private isRefreshing: boolean = false;
-  private refreshType: string = 'false';
 
   /**
    * Synchronizes property values when attributes change.
@@ -227,11 +226,11 @@ export class MgtGet extends MgtTemplatedComponent {
    * @memberof MgtGet
    */
   public refresh(hardRefresh = false) {
-    this.refreshType = hardRefresh.toString();
-
     this.isRefreshing = true;
+    if (hardRefresh) {
+      this.clearState();
+    }
     this.requestStateUpdate(hardRefresh);
-    this.isRefreshing = false;
   }
 
   /**
@@ -250,7 +249,7 @@ export class MgtGet extends MgtTemplatedComponent {
    * trigger the element to update.
    */
   protected render() {
-    if (this.isLoadingState && !this.isPolling && this.refreshType !== 'false') {
+    if (this.isLoadingState && !this.response) {
       return this.renderTemplate('loading', null);
     } else if (this.error) {
       return this.renderTemplate('error', this.error);
@@ -419,7 +418,7 @@ export class MgtGet extends MgtTemplatedComponent {
     } else {
       this.response = null;
     }
-
+    this.isRefreshing = false;
     this.fireCustomEvent('dataChange', { response: this.response, error: this.error });
   }
 

--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -824,6 +824,14 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
         this.defaultSelectedUsers = await getUsersForUserIds(graph, this.defaultSelectedUserIds);
         this.defaultSelectedGroups = await getGroupsForGroupIds(graph, this.defaultSelectedGroupIds);
 
+        this.defaultSelectedGroups = this.defaultSelectedGroups.filter(group => {
+          return group !== null;
+        });
+
+        this.defaultSelectedUsers = this.defaultSelectedUsers.filter(user => {
+          return user !== null;
+        });
+
         this.selectedPeople = [...this.defaultSelectedUsers, ...this.defaultSelectedGroups];
         this.requestUpdate();
         this.fireCustomEvent('selectionChanged', this.selectedPeople);

--- a/stories/components/get.stories.js
+++ b/stories/components/get.stories.js
@@ -162,3 +162,31 @@ export const PollingRate = () => html`
     </template>
   </mgt-get>
 `;
+
+export const refresh = () => html`
+    <mgt-get cache-enabled="true" resource="/me/presence" version="beta" scopes="Presence.Read">
+      <template data-type="default"> {{availability}} </template>
+      <template data-type="loading">
+        <h2>Loading...?!?!</h2>
+      </template>
+    </mgt-get>
+
+    <div>
+      <label>get.refresh(false)</label>
+      <button id="false">Soft refresh</button>
+    </div>
+    <label>get.refresh(true)</label>
+    <button id="true">Hard refresh</button>
+
+    
+  <script>
+
+    document.querySelector('#false').addEventListener('click', _ =>{
+          document.querySelector('mgt-get').refresh(false)
+    })
+
+    document.querySelector('#true').addEventListener('click', _ =>{
+      document.querySelector('mgt-get').refresh(true)
+    })
+  </script>
+`;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1183

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

 Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Adds a new private variable `refreshType` to change whether the loading template is displayed during a `refresh()`

Loading templates still display if uninitialized or set to `refresh(true)` 

Example:
```html
    <mgt-get cache-enabled="true" resource="/me/presence" version="beta" scopes="Presence.Read">
      <template data-type="default"> {{availability}} </template>
      <template data-type="loading">
        <h2>Loading...?!?!</h2>
      </template>
    </mgt-get>
```

```js
//console
let get = document.querySelector('mgt-get')

     get.refresh(false)
///will not display loading template

     get.refresh(true)
//displays loading template

```

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
