### PR TITLE
Fixed issue with overflow text on task title

### DIFF
--- a/packages/mgt-components/src/components/mgt-tasks-base/mgt-tasks-base.scss
+++ b/packages/mgt-components/src/components/mgt-tasks-base/mgt-tasks-base.scss
@@ -178,7 +178,7 @@ $task-border-completed: var(--task-complete-border, 2px dotted inherit);
         color: $detail__color;
         font-size: 12px;
         font-weight: 600;
-        white-space: nowrap;
+        white-space: normal;
         margin-bottom: 12px;
 
         .TaskDetail {


### PR DESCRIPTION
Changed the css to address the TaskTitle overflow when the text is long.



Closes  #1274 

### PR Type

Bugfix 

### Description of the changes
Changed the White-Space css property  on the TaskDetailsContainer class from nowrap to normal

