### PR TITLE
Fixed --input-border-* custom properties

### DIFF
--- a/packages/mgt-components/src/styles/shared-sass-variables.scss
+++ b/packages/mgt-components/src/styles/shared-sass-variables.scss
@@ -302,23 +302,23 @@ $common: (
   ),
   input-outlined__border-top: (
     _var: --input-border-top,
-    dark: 2px solid $input-outlined__border-color--dark,
-    light: 2px solid $input-outlined__border-color--light
+    dark: var(--input-border, 2px solid $input-outlined__border-color--dark),
+    light: var(--input-border, 2px solid $input-outlined__border-color--light)
   ),
   input-outlined__border-right: (
     _var: --input-border-right,
-    dark: 2px solid $input-outlined__border-color--dark,
-    light: 2px solid $input-outlined__border-color--light
+    dark: var(--input-border, 2px solid $input-outlined__border-color--dark),
+    light: var(--input-border, 2px solid $input-outlined__border-color--light)
   ),
   input-outlined__border-bottom: (
     _var: --input-border-bottom,
-    dark: 2px solid $input-outlined__border-color--dark,
-    light: 2px solid $input-outlined__border-color--light
+    dark: var(--input-border, 2px solid $input-outlined__border-color--dark),
+    light: var(--input-border, 2px solid $input-outlined__border-color--light)
   ),
   input-outlined__border-left: (
     _var: --input-border-left,
-    dark: 2px solid $input-outlined__border-color--dark,
-    light: 2px solid $input-outlined__border-color--light
+    dark: var(--input-border, 2px solid $input-outlined__border-color--dark),
+    light: var(--input-border, 2px solid $input-outlined__border-color--light)
   ),
   input-outlined__border-color--hover: (
     _var: --input-border-color--hover,
@@ -380,7 +380,6 @@ $dropdown-item__background-color--hover: var(
   border-right: $input__border-right;
   border-bottom: $input__border-bottom;
   border-left: $input__border-left;
-  border: $input__border;
 }
 
 @include create-themes($common);

--- a/stories/components/peoplePicker/peoplePicker.style.js
+++ b/stories/components/peoplePicker/peoplePicker.style.js
@@ -21,13 +21,13 @@ export const customCssProperties = () => html`
 <mgt-people-picker></mgt-people-picker>
 <style>
   mgt-people-picker {
-    --input-border: 10px 4px 10px 10px; /* sets all input area border */
+    --input-border: 3px dashed green; /* sets all input area border */
 
     /* OR individual input border sides */
-    --input-border-bottom: 2px rgba(255, 255, 255, 0.5) solid;
-    --input-border-right: 2px rgba(255, 255, 255, 0.5) solid;
-    --input-border-left: 2px rgba(255, 255, 255, 0.5) solid;
-    --input-border-top: 2px rgba(255, 255, 255, 0.5) solid;
+    --input-border-bottom: 2px red solid;
+    --input-border-right: 2px green solid;
+    --input-border-left: 2px blue solid;
+    --input-border-top: 2px yellow solid;
 
     --input-background-color: purple; /* input area background color */
     --input-border-color--hover: #008394; /* input area border hover color */


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1113 

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Fixed `--input-border-`* custom properties for people picker and teams channel picker.

Fixed by creating a dependency to the `--input-border` property to all `--input-border-*` properties and only using `border-*` properties in our css. For example, here is how the border properties are now set for the people picker:

```css
border-left: var(--input-border-left, var(--input-border, "default value")) 
border-right: var(--input-border-right, var(--input-border, "default value")) 
border-top: var(--input-border-top, var(--input-border, "default value")) 
border-bottom: var(--input-border-bottom, var(--input-border, "default value")) 
``` 

Notice we are no longer setting a `border` property since the other border properties will cover it.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
