### PR TITLE
Fixed templateContext changes not re-rendering templates

### DIFF
--- a/packages/mgt-element/src/components/templatedComponent.ts
+++ b/packages/mgt-element/src/components/templatedComponent.ts
@@ -112,11 +112,13 @@ export abstract class MgtTemplatedComponent extends MgtBaseComponent {
 
     const template = html`
       <slot name=${slotName}></slot>
-    `;
+      `;
+
+    const dataContext = { ...context, ...this.templateContext };
 
     if (this._renderedTemplates.hasOwnProperty(slotName)) {
       const { context: existingContext, slot } = this._renderedTemplates[slotName];
-      if (equals(existingContext, context)) {
+      if (equals(existingContext, dataContext)) {
         return template;
       }
       this.removeChild(slot);
@@ -126,13 +128,11 @@ export abstract class MgtTemplatedComponent extends MgtBaseComponent {
     div.slot = slotName;
     div.dataset.generated = 'template';
 
-    const dataContext = { ...context, ...this.templateContext };
-
     TemplateHelper.renderTemplate(div, this.templates[templateType], dataContext);
 
     this.appendChild(div);
 
-    this._renderedTemplates[slotName] = { context, slot: div };
+    this._renderedTemplates[slotName] = { context: dataContext, slot: div };
 
     this.fireCustomEvent('templateRendered', { templateType, context: dataContext, element: div });
 

--- a/packages/mgt-element/src/components/templatedComponent.ts
+++ b/packages/mgt-element/src/components/templatedComponent.ts
@@ -112,7 +112,7 @@ export abstract class MgtTemplatedComponent extends MgtBaseComponent {
 
     const template = html`
       <slot name=${slotName}></slot>
-      `;
+    `;
 
     const dataContext = { ...context, ...this.templateContext };
 

--- a/packages/mgt-element/src/components/templatedComponent.ts
+++ b/packages/mgt-element/src/components/templatedComponent.ts
@@ -5,7 +5,7 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { html, PropertyValues } from 'lit-element';
+import { html, property, PropertyValues } from 'lit-element';
 
 import { equals } from '../utils/equals';
 import { MgtBaseComponent } from './baseComponent';
@@ -46,7 +46,7 @@ export abstract class MgtTemplatedComponent extends MgtBaseComponent {
    * @type {MgtElement.TemplateContext}
    * @memberof MgtTemplatedComponent
    */
-  public templateContext: TemplateContext;
+  @property({ attribute: false }) public templateContext: TemplateContext;
 
   /**
    * Holds all templates defined by developer


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1263 

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Fixed issue where templates would not re-render when the template context is changed by making sure the data context equality check also includes the template context

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
