### PR TITLE
Cursor to pointer when person-card is clickable

### DIFF
--- a/packages/mgt-components/src/components/mgt-person/mgt-person.scss
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.scss
@@ -13,7 +13,7 @@ $avatar-size-s: var(--avatar-size-s, var(--avatar-size, 24px));
 $avatar-size: var(--avatar-size, var(--avatar-size-s, 48px));
 $avatar-border: var(--avatar-border, 0);
 $avatar-border-radius: var(--avatar-border-radius, 50%);
-$avatar-cursor: var(--avatar-cursor, default);
+$avatar-cursor: var(--avatar-cursor, inherit);
 
 $initials-color: var(--initials-color, white);
 $initials-background-color: --initials-background-color;
@@ -65,6 +65,10 @@ mgt-person .person-root {
   display: flex;
   align-items: center;
   color: $color;
+
+  &.clickable {
+    cursor: pointer;
+  }
 
   .user-avatar {
     position: relative;

--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -524,8 +524,13 @@ export class MgtPerson extends MgtTemplatedComponent {
       const detailsTemplate: TemplateResult = this.renderDetails(person, presence);
       const imageWithPresenceTemplate: TemplateResult = this.renderAvatar(person, image, presence);
 
+      const rootClasses = {
+        'person-root': true,
+        clickable: this.personCardInteraction === PersonCardInteraction.click
+      };
+
       personTemplate = html`
-        <div class="person-root">
+        <div class=${classMap(rootClasses)}>
           ${imageWithPresenceTemplate} ${detailsTemplate}
         </div>
       `;


### PR DESCRIPTION
When the person-card attribute of the mgt-person component is set to value "click", the cursor is changed to a pointer when hovering over the card.

The PR also changes the default value of avatar-cursor to inherit so it respects the pointer cursor.

Tested with Chrome and Firefox by changing the person-card attribute in the mgt-person to "click" in index.html. Also tested that changing the avatar-cursor with styles still works.

Closes #1236 

### PR Type

- Bugfix

### Description of the changes

### PR checklist
- [ X ] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ N/A ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ N/A ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ N/A ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
- [ N/A ] License header has been added to all new source files (`yarn setLicense`)
- [ X ] Contains **NO** breaking changes

### Other information
