### PR TITLE
Support page-size when insight-type is set on mgt-file-list

### DIFF
--- a/packages/mgt-components/src/components/mgt-file-list/mgt-file-list.ts
+++ b/packages/mgt-components/src/components/mgt-file-list/mgt-file-list.ts
@@ -671,7 +671,7 @@ export class MgtFileList extends MgtTemplatedComponent {
         } else if (this.itemPath) {
           pageIterator = await getFilesByPathIterator(graph, this.itemPath, this.pageSize);
         } else if (this.insightType) {
-          files = await getMyInsightsFiles(graph, this.insightType);
+          files = await getMyInsightsFiles(graph, this.insightType, this.pageSize);
         } else {
           pageIterator = await getFilesIterator(graph, this.pageSize);
         }
@@ -699,7 +699,7 @@ export class MgtFileList extends MgtTemplatedComponent {
         } else if (this.itemPath) {
           pageIterator = await getUserFilesByPathIterator(graph, this.userId, this.itemPath, this.pageSize);
         } else if (this.insightType) {
-          files = await getUserInsightsFiles(graph, this.userId, this.insightType);
+          files = await getUserInsightsFiles(graph, this.userId, this.insightType, this.pageSize);
         }
       }
 


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1210  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

I added support for the `page-size` property to be detected when you also pass the `insight-type` property allowing you to display the number of files you want in the `mgt-file-list` component.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
