### PR TITLE
fixed agenda header dates for all day events

### DIFF
--- a/packages/mgt-components/src/components/mgt-agenda/mgt-agenda.ts
+++ b/packages/mgt-components/src/components/mgt-agenda/mgt-agenda.ts
@@ -460,7 +460,10 @@ export class MgtAgenda extends MgtTemplatedComponent {
     const grouped = {};
 
     events.forEach(event => {
-      const header = this.getDateHeaderFromDateTimeString(event.start.dateTime);
+      var eventDate = new Date(event.start.dateTime);
+      var dateString = eventDate.toISOString().replace('Z', '');
+
+      const header = this.getDateHeaderFromDateTimeString(dateString);
       grouped[header] = grouped[header] || [];
       grouped[header].push(event);
     });


### PR DESCRIPTION
Closes #1289  

### PR Type
- Bugfix 

### Description of the changes
Fixed the agenda header dates for All day events.  Event times are adjusted for the user's timezone except for All day events.  The fix passes the ISO string with the appropriate time for the user's timezone to the getDateHeaderFromDateTimeString function which subtracts the timezone offset.

### PR checklist
- [ x ] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ x ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
