### PR TITLE
Fixes bundle by moving back to @fluentui\web-components 0.22

### DIFF
--- a/packages/mgt-components/package.json
+++ b/packages/mgt-components/package.json
@@ -40,7 +40,7 @@
     "@microsoft/microsoft-graph-client": "^2.2.1",
     "@microsoft/microsoft-graph-types": "^2.0.0",
     "@microsoft/microsoft-graph-types-beta": "^0.15.0-preview",
-    "@fluentui/web-components": "^1.3.3",
+    "@fluentui/web-components": "0.22.1",
     "office-ui-fabric-core": "11.0.0"
   },
   "publishConfig": {

--- a/packages/mgt-components/src/components/mgt-file-list/mgt-file-list.ts
+++ b/packages/mgt-components/src/components/mgt-file-list/mgt-file-list.ts
@@ -42,6 +42,7 @@ import { MgtFile } from '../mgt-file/mgt-file';
 import { MgtFileUploadConfig } from './mgt-file-upload/mgt-file-upload';
 
 export { FluentDesignSystemProvider, FluentProgressRing } from '@fluentui/web-components';
+export * from './mgt-file-upload/mgt-file-upload';
 
 // import { fluentProgressRing } from '@fluentui/web-components';
 // import { registerFluentComponents } from '../../utils/FluentComponents';

--- a/packages/mgt-components/src/components/mgt-file-list/mgt-file-list.ts
+++ b/packages/mgt-components/src/components/mgt-file-list/mgt-file-list.ts
@@ -41,10 +41,12 @@ import { strings } from './strings';
 import { MgtFile } from '../mgt-file/mgt-file';
 import { MgtFileUploadConfig } from './mgt-file-upload/mgt-file-upload';
 
-import { fluentProgressRing } from '@fluentui/web-components';
-import { registerFluentComponents } from '../../utils/FluentComponents';
+export { FluentDesignSystemProvider, FluentProgressRing } from '@fluentui/web-components';
 
-registerFluentComponents(fluentProgressRing);
+// import { fluentProgressRing } from '@fluentui/web-components';
+// import { registerFluentComponents } from '../../utils/FluentComponents';
+
+// registerFluentComponents(fluentProgressRing);
 
 /**
  * The File List component displays a list of multiple folders and files by
@@ -573,6 +575,7 @@ export class MgtFileList extends MgtTemplatedComponent {
    */
   protected renderFiles(): TemplateResult {
     return html`
+    <fluent-design-system-provider use-defaults>
       <div id="file-list-wrapper" class="file-list-wrapper" dir=${this.direction}>
         ${this.enableFileUpload ? this.renderFileUpload() : null}
         <ul
@@ -599,6 +602,7 @@ export class MgtFileList extends MgtTemplatedComponent {
             : null
         }
       </div>
+    </fluent-design-system-provider>
     `;
   }
 

--- a/packages/mgt-components/src/components/mgt-file-list/mgt-file-upload/mgt-file-upload.ts
+++ b/packages/mgt-components/src/components/mgt-file-list/mgt-file-upload/mgt-file-upload.ts
@@ -21,10 +21,12 @@ import {
   deleteSessionFile
 } from '../../../graph/graph.files';
 
-import { registerFluentComponents } from '../../../utils/FluentComponents';
-import { fluentButton, fluentCheckbox, fluentProgress } from '@fluentui/web-components';
+export { FluentProgress, FluentButton, FluentCheckbox } from '@fluentui/web-components';
 
-registerFluentComponents(fluentProgress, fluentButton, fluentCheckbox);
+// import { registerFluentComponents } from '../../../utils/FluentComponents';
+// import { fluentButton, fluentCheckbox, fluentProgress } from '@fluentui/web-components';
+
+// registerFluentComponents(fluentProgress, fluentButton, fluentCheckbox);
 
 /**
  * Upload conflict behavior status

--- a/packages/mgt-components/src/utils/FluentComponents.ts
+++ b/packages/mgt-components/src/utils/FluentComponents.ts
@@ -1,23 +1,23 @@
-import { provideFluentDesignSystem } from '@fluentui/web-components';
+// import { provideFluentDesignSystem } from '@fluentui/web-components';
 
-const designSystem = provideFluentDesignSystem();
+// const designSystem = provideFluentDesignSystem();
 
-export const registerFluentComponents = (...fluentComponents) => {
-  if (!fluentComponents || !fluentComponents.length) {
-    return;
-  }
+// export const registerFluentComponents = (...fluentComponents) => {
+//   if (!fluentComponents || !fluentComponents.length) {
+//     return;
+//   }
 
-  const registry = {
-    register(container: any) {
-      if (!container) {
-        return;
-      }
+//   const registry = {
+//     register(container: any) {
+//       if (!container) {
+//         return;
+//       }
 
-      for (const component of fluentComponents) {
-        component().register(container);
-      }
-    }
-  };
+//       for (const component of fluentComponents) {
+//         component().register(container);
+//       }
+//     }
+//   };
 
-  designSystem.register(registry);
-};
+//   designSystem.register(registry);
+// };

--- a/packages/mgt/src/bundle/mgt-loader.js
+++ b/packages/mgt/src/bundle/mgt-loader.js
@@ -5,7 +5,7 @@
  * -------------------------------------------------------------------------------------------
  */
 
-(async function () {
+(function () {
   'use strict';
 
   var rootPath = getScriptPath();
@@ -14,8 +14,6 @@
   if (es6()) {
     window.WebComponents = window.WebComponents || {};
     window.WebComponents.root = rootPath + 'wc/';
-
-    await waitUntilReady();
 
     addScript(rootPath + 'wc/webcomponents-loader.js');
     addScript(rootPath + 'mgt.es6.js');
@@ -50,19 +48,6 @@
     return true;
   }
 
-  function waitUntilReady() {
-
-    return new Promise(function (resolve, reject) {
-      if (document.body) {
-        resolve();
-      }
-
-      document.addEventListener('DOMContentLoaded', function () {
-        resolve();
-      })
-    });
-  };
-
   function addScript(src, onload) {
     // TODO: support async loading
 
@@ -73,7 +58,7 @@
     //   tag.addEventListener("load", onload);
     // }
 
-    // document.write(tag.outerHTML);
-    document.head.appendChild(tag);
+    document.write(tag.outerHTML);
+    // document.head.appendChild(tag);
   }
 })();


### PR DESCRIPTION
### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This PR fixes an exception with our bundle introduced by @fluentui/web-components 1.x. [I tried to resolve](https://github.com/microsoftgraph/microsoft-graph-toolkit/commit/2385e2412e964d33c86fd46f89632a0d69cb00e4) this issue initially by making our loader asynchronous, but that introduced more issues (this PR also undoes that fix).

The issue is caused when the bundle is referenced in the `<head>` of a document. The new [fast design system](https://github.com/microsoft/fast/blob/c4fe4d0706dae02bc2d4c8ea37dafe6c79c03075/packages/web-components/fast-foundation/src/design-token/design-token.ts#L22), introduced in 1.x, leverages `document.body` as the default element for registering design tokens, but it assumes the body is available when the module is loaded. However, when we create our bundle, the code is executed synchronously and the body is not yet available, causing an exception.

This will not be an issue when we move to esm for our bundles since es modules are loaded asynchronously, and will be resolved by #1312 in the next major release.

For our 2.x releases however, this PR downgrades the version of @fluentui/web-components. We will continue to use 1.x in our 3.0 branch.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] Contains **NO** breaking changes
