### PR TITLE
[mgt-person][bugfix] Return lineprop context name to person

### DIFF
--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -803,15 +803,15 @@ export class MgtPerson extends MgtTemplatedComponent {
    * @returns {TemplateResult}
    * @memberof MgtPerson
    */
-  protected renderDetails(person: IDynamicPerson, presence?: Presence): TemplateResult {
-    if (!person || this.view === ViewType.image || this.view === PersonViewType.avatar) {
+  protected renderDetails(personProps: IDynamicPerson, presence?: Presence): TemplateResult {
+    if (!personProps || this.view === ViewType.image || this.view === PersonViewType.avatar) {
       return html``;
     }
 
-    let personProperties: IDynamicPerson & { presenceActivity?: string; presenceAvailability?: string } = person;
+    let person: IDynamicPerson & { presenceActivity?: string; presenceAvailability?: string } = personProps;
     if (presence) {
-      personProperties.presenceActivity = presence?.activity;
-      personProperties.presenceAvailability = presence?.availability;
+      person.presenceActivity = presence?.activity;
+      person.presenceAvailability = presence?.availability;
     }
 
     const details: TemplateResult[] = [];
@@ -819,13 +819,13 @@ export class MgtPerson extends MgtTemplatedComponent {
     if (this.view > ViewType.image) {
       if (this.hasTemplate('line1')) {
         // Render the line1 template
-        const template = this.renderTemplate('line1', { personProperties });
+        const template = this.renderTemplate('line1', { person });
         details.push(html`
           <div class="line1" @click=${() => this.handleLine1Clicked()}>${template}</div>
         `);
       } else {
         // Render the line1 property value
-        const text = this.getTextFromProperty(personProperties, this.line1Property);
+        const text = this.getTextFromProperty(person, this.line1Property);
         if (text) {
           details.push(html`
             <div class="line1" @click=${() => this.handleLine1Clicked()} aria-label="${text}">${text}</div>
@@ -837,13 +837,13 @@ export class MgtPerson extends MgtTemplatedComponent {
     if (this.view > ViewType.oneline) {
       if (this.hasTemplate('line2')) {
         // Render the line2 template
-        const template = this.renderTemplate('line2', { personProperties });
+        const template = this.renderTemplate('line2', { person });
         details.push(html`
           <div class="line2" @click=${() => this.handleLine2Clicked()}>${template}</div>
         `);
       } else {
         // Render the line2 property value
-        const text = this.getTextFromProperty(personProperties, this.line2Property);
+        const text = this.getTextFromProperty(person, this.line2Property);
         if (text) {
           details.push(html`
             <div class="line2" @click=${() => this.handleLine2Clicked()} aria-label="${text}">${text}</div>
@@ -855,13 +855,13 @@ export class MgtPerson extends MgtTemplatedComponent {
     if (this.view > ViewType.twolines) {
       if (this.hasTemplate('line3')) {
         // Render the line3 template
-        const template = this.renderTemplate('line3', { personProperties });
+        const template = this.renderTemplate('line3', { person });
         details.push(html`
           <div class="line3" @click=${() => this.handleLine3Clicked()}>${template}</div>
         `);
       } else {
         // Render the line3 property value
-        const text = this.getTextFromProperty(personProperties, this.line3Property);
+        const text = this.getTextFromProperty(person, this.line3Property);
         if (text) {
           details.push(html`
             <div class="line3" @click=${() => this.handleLine3Clicked()} aria-label="${text}">${text}</div>


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1328

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Renames the `personProperties` value previously passed to the line1 templates, to `person` to match the documentation for features and our previous.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
