### PR TITLE
Render person/people as "default" if irretrievable from graph

### DIFF
--- a/packages/mgt-components/src/components/mgt-people/mgt-people.ts
+++ b/packages/mgt-components/src/components/mgt-people/mgt-people.ts
@@ -422,6 +422,7 @@ export class MgtPeople extends MgtTemplatedComponent {
           this._peoplePresence = null;
         }
       }
+      this.people = this.people.filter(Boolean);
     }
   }
 }

--- a/packages/mgt-components/src/components/mgt-people/mgt-people.ts
+++ b/packages/mgt-components/src/components/mgt-people/mgt-people.ts
@@ -422,7 +422,6 @@ export class MgtPeople extends MgtTemplatedComponent {
           this._peoplePresence = null;
         }
       }
-      this.people = this.people.filter(Boolean);
     }
   }
 }

--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -809,7 +809,7 @@ export class MgtPerson extends MgtTemplatedComponent {
     }
 
     let person: IDynamicPerson & { presenceActivity?: string; presenceAvailability?: string } = personProps;
-    if (presence) {
+    if (presence && person.id) {
       person.presenceActivity = presence?.activity;
       person.presenceAvailability = presence?.availability;
     }
@@ -981,7 +981,11 @@ export class MgtPerson extends MgtTemplatedComponent {
           person = await getUser(graph, this.userId, personProps);
         }
       }
-      this.personDetails = person;
+      if (person === null) {
+        this.personDetails = { id: this.userId };
+      } else {
+        this.personDetails = person;
+      }
       this._fetchedImage = this.getImage();
     } else if (this.personQuery) {
       // Use the personQuery to find our person.

--- a/packages/mgt-components/src/graph/graph.photos.ts
+++ b/packages/mgt-components/src/graph/graph.photos.ts
@@ -180,6 +180,9 @@ export async function myPhoto(graph: IGraph): Promise<string> {
  * @export
  */
 export async function getPersonImage(graph: IGraph, person: IDynamicPerson, useContactsApis: boolean = true) {
+  if (!person.id) {
+    return null;
+  }
   // handle if person but not user
   if ('personType' in person && (person as any).personType.subclass !== 'OrganizationUser') {
     if ((person as any).personType.subclass === 'PersonalContact' && useContactsApis) {

--- a/packages/mgt-components/src/graph/graph.user.ts
+++ b/packages/mgt-components/src/graph/graph.user.ts
@@ -169,6 +169,11 @@ export async function getUsersForUserIds(graph: IGraph, userIds: string[]): Prom
         if (getIsUsersCacheEnabled()) {
           cache.putValue(id, { user: JSON.stringify(response.content) });
         }
+      } else {
+        if (peopleDict[id] === null) {
+          peopleDict[id] = id;
+          cache.putValue(id, { user: JSON.stringify(id) });
+        }
       }
     }
     return Promise.all(Object.values(peopleDict));

--- a/packages/mgt-components/src/graph/graph.userWithPhoto.ts
+++ b/packages/mgt-components/src/graph/graph.userWithPhoto.ts
@@ -48,15 +48,13 @@ export async function getUserWithPhoto(
     cachedUser = await cache.getValue(userId || 'me');
     if (cachedUser && getUserInvalidationTime() > Date.now() - cachedUser.timeCached) {
       user = cachedUser.user ? JSON.parse(cachedUser.user) : null;
-      if (requestedProps) {
+      if (requestedProps && user !== null) {
         const uniqueProps = requestedProps.filter(prop => !Object.keys(user).includes(prop));
         if (uniqueProps.length >= 1) {
           user = null;
           cachedUser = null;
         }
       }
-    } else {
-      cachedUser = null;
     }
   }
   if (getIsPhotosCacheEnabled()) {


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1339 

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

 Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

If a person or people component is provided a user-id that is ether no longer retrievable from the graph, this will render a default user in its place. 

Stores the userid or email given as the object instead, and is handled on render. Currently we expect the user to retemplate with the information they may have for the personcard, will wait feedback on this from @yyiinnggzz 

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
