### PR TITLE
mgt-people fallback-details feature

### DIFF
--- a/packages/mgt-components/src/components/mgt-people/mgt-people.ts
+++ b/packages/mgt-components/src/components/mgt-people/mgt-people.ts
@@ -211,6 +211,27 @@ export class MgtPeople extends MgtTemplatedComponent {
   public scopes: string[] = [];
 
   /**
+   * Fallback when no user is found
+   * @type {IDynamicPerson[]}
+   */
+  @property({
+    attribute: 'fallback-details',
+    type: Int8Array
+  })
+  public get fallbackDetails(): IDynamicPerson[] {
+    return this._fallbackDetails;
+  }
+  public set fallbackDetails(value: IDynamicPerson[]) {
+    if (value === this._fallbackDetails) {
+      return;
+    }
+
+    this._fallbackDetails = value;
+
+    this.requestStateUpdate();
+  }
+
+  /**
    * Get the scopes required for people
    *
    * @static
@@ -236,6 +257,7 @@ export class MgtPeople extends MgtTemplatedComponent {
   private _peoplePresence: {};
   private _resource: string;
   private _version: string = 'v1.0';
+  private _fallbackDetails: IDynamicPerson[];
 
   constructor() {
     super();
@@ -303,8 +325,13 @@ export class MgtPeople extends MgtTemplatedComponent {
    * @memberof MgtPeople
    */
   protected renderPeople(): TemplateResult {
-    const maxPeople = this.people.slice(0, this.showMax);
+    if (this.fallbackDetails) {
+      for (let i = 0; i < this._fallbackDetails.length; i++) {
+        this.people.push(this.fallbackDetails[i]);
+      }
+    }
 
+    const maxPeople = this.people.slice(0, this.showMax);
     return html`
       <ul class="people-list">
         ${repeat(

--- a/stories/components/people/people.properties.js
+++ b/stories/components/people/people.properties.js
@@ -50,3 +50,10 @@ export const PersonCard = () => html`
   <div style="margin-bottom:10px">Person card Click</div>
   <mgt-people show-max="5" person-card="click"></mgt-people>
 `;
+
+export const FallbackDetails = () => html`
+  <mgt-people
+    show-max="12"
+    fallback-details='[{"mail":"validButNotFound@email.in.ad"},{"mail": "test@test.com"}]'>
+  </mgt-people>
+`;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1339

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

 Bugfix 
 Feature 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Adds "fallback-details" feature to the `mgt-people` component. The user can define as many persons as they want, it'll will be added to the rest of the requested "people".

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: https://github.com/microsoftgraph/microsoft-graph-docs/pull/14454
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
