### PR TITLE
[people-picker] user-ids fix for 'me' request 

### DIFF
--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -965,10 +965,10 @@ export class MgtPerson extends MgtTemplatedComponent {
       ) {
         this.personDetails;
         let image;
-        if ('personType' in this.personDetails) {
-          image = await getPersonImage(graph, this.personDetails, MgtPerson.config.useContactApis);
-        } else {
+        if ('groupTypes' in this.personDetails) {
           image = await getGroupImage(graph, this.personDetails, MgtPerson.config.useContactApis);
+        } else {
+          image = await getPersonImage(graph, this.personDetails, MgtPerson.config.useContactApis);
         }
         if (image) {
           this.personDetails.personImage = image;

--- a/packages/mgt-components/src/graph/graph.user.ts
+++ b/packages/mgt-components/src/graph/graph.user.ts
@@ -164,8 +164,11 @@ export async function getUsersForUserIds(graph: IGraph, userIds: string[], searc
         peopleDict[id] = user ? user : null;
       }
     } else if (id !== '') {
-      batch.get(id, `/users/${id}`, ['user.readbasic.all']);
-      notInCache.push(id);
+      if (id.toString() === 'me') {
+        peopleDict[id] = await getMe(graph);
+      } else {
+        batch.get(id, `/users/${id}`, ['user.readbasic.all']);
+      }
     }
   }
   try {


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1396 

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

1. fixes issue with the people-picker retrieving a "me" value from getUsersFromUserIds. Previously it would only find data for the user from the cache in login. 

2. "me" wasn't producing personType results, so updating the clause for team photo vs person photo
### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
