### PR TITLE
Add ac11y support for the people-picker to narrate selected people

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.scss
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.scss
@@ -53,6 +53,10 @@ mgt-people-picker .root {
     font-weight: normal;
     overflow: hidden;
 
+    &__options {
+      display: contents;
+    }
+
     &__person-wrapper {
       display: flex;
       margin: 0 5px 6px 0;

--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -623,6 +623,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
        <div
         tabindex="0"
         aria-label="selected-people"
+        aria-orientation="vertical"
         role="listbox"
         class="selected-list__options">${selectedPeople.slice(0, selectedPeople.length).map(
           person =>

--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -620,10 +620,18 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       return null;
     }
     return html`
-       ${selectedPeople.slice(0, selectedPeople.length).map(
-         person =>
-           html`
-             <div class="selected-list__person-wrapper">
+       <div
+        tabindex="0"
+        aria-label="selected-people"
+        role="listbox"
+        class="selected-list__options">${selectedPeople.slice(0, selectedPeople.length).map(
+          person =>
+            html`
+             <div
+             role="option"
+             tabindex="0"
+             aria-label=${person.displayName}
+             class="selected-list__person-wrapper">
                ${
                  this.renderTemplate(
                    'selected-person',
@@ -635,6 +643,8 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
                <div class="selected-list__person-wrapper__overflow">
                  <div class="selected-list__person-wrapper__overflow__gradient"></div>
                  <div
+                   tabindex="0"
+                   aria-label="close-icon"
                    class="selected-list__person-wrapper__overflow__close-icon"
                    @click="${e => this.removePerson(person, e)}"
                  >
@@ -643,7 +653,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
                </div>
              </div>
            `
-       )}
+        )}</div>
      `;
   }
   /**


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1117  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

 - Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Added support for the names of the selected people to be narrated by the screen reader.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->

Use the steps in the video of #1117 to test.
