### PR TITLE
Fixing h1 and alt on images

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -45,6 +45,7 @@
     // GitHub
     const githubImage = document.createElement('img');
     githubImage.src = './github.png';
+    githubImage.alt = 'GitHub';
     githubImage.style = imageStyle;
 
     const githubText = document.createElement('span');
@@ -64,6 +65,7 @@
     // npm
     const npmImage = document.createElement('img');
     npmImage.src = './npm.png';
+    npmImage.alt = 'npm';
     npmImage.style = imageStyle;
 
     const npmText = document.createElement('span');

--- a/stories/feedback.stories.mdx
+++ b/stories/feedback.stories.mdx
@@ -2,24 +2,24 @@ import { Meta } from '@storybook/addon-docs';
 
 <Meta title="Feedback" />
 
-# Feedback
+## Feedback
 
 In order to improve the Microsoft Graph Toolkit, we need your feedback!
 
 There are various ways for you to provide feedback of your experience and help us make the Toolkit better.
 
-## Contribute to Microsoft Graph Toolkit
+### Contribute to Microsoft Graph Toolkit
 
 If there is a feature or bug you find and you are intersted in contributing directly to our code base please refer to our [contribution guide](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki).
 We encourage developers to feel welcomed into the code base and directly contribute.
 
-## Report Issues
+### Report Issues
 
 File feature requests, bugs or other issues against the [Microsoft Graph Toolkit repo](https://aka.ms/mgt/issues).
 To help us get to your issue faster use the GitHub labels provided.
 A team member will look to help out with outstanding issues and navigate them to the right owner.
 
-## Online Forums
+### Online Forums
 
 For any questions on Microsoft Graph Toolkit or Microsoft Graph, use [Microsoft Q&A](https://docs.microsoft.com/en-us/answers/topics/microsoft-graph-toolkit.html) or [Stack Overflow](https://stackoverflow.com/questions/tagged/microsoft-graph-toolkit).
 There use the tag `microsoft-graph-toolkit` for the question to be funneled to our team.

--- a/stories/overview.stories.mdx
+++ b/stories/overview.stories.mdx
@@ -2,7 +2,7 @@ import { Meta } from '@storybook/addon-docs';
 
 <Meta title="Overview" />
 
-# Microsoft Graph Toolkit: UI Components and Authentication Providers for Microsoft Graph
+## Microsoft Graph Toolkit: UI Components and Authentication Providers for Microsoft Graph
 
 The Microsoft Graph Toolkit is a collection of reusable, framework-agnostic components and authentication providers for accessing and working with Microsoft Graph. The components are fully functional right of out of the box, with built in providers that authenticate with and fetch data from Microsoft Graph.
 
@@ -10,25 +10,25 @@ The Microsoft Graph Toolkit is a collection of reusable, framework-agnostic comp
 
 The Microsoft Graph Toolkit makes it easy to use Microsoft Graph in your application. In the following example, a signed in user and their calendar events are displayed with just two lines of code by using the [Login](?path=/story/components-mgt-login--login) and [Agenda](?path=/story/components-mgt-agenda--simple) components.
 
-## Installing the Microsoft Graph Toolkit
+### Installing the Microsoft Graph Toolkit
 
 It's easy to get started! Add the Toolkit via our `mgt-loader` or via npm and you are ready to go!
 
-### Via the mgt-loader
+#### Via the mgt-loader
 
 ```html
 <script src="https://unpkg.com/@microsoft/mgt/dist/bundle/mgt-loader.js"></script>
 ```
 
-### Via npm
+#### Via npm
 
 ```shell
 npm i @microsoft/mgt
 ```
 
-## What's in the Microsoft Graph Toolkit?
+### What's in the Microsoft Graph Toolkit?
 
-### Components
+#### Components
 
 The Microsoft Graph Toolkit includes a collection of web components for the most commonly built experiences powered by Microsoft Graph APIs.
 
@@ -49,7 +49,7 @@ The components are also available as [React components](https://docs.microsoft.c
 | [To Do](?path=/story/components-mgt-todo--tasks)                                               | Displays and enables adding, removing, completing, or editing of tasks from Microsoft To Do.                                                     |
 | [Tasks](?path=/story/components-mgt-tasks--tasks)                                              | Displays and enables adding, removing, completing, or editing of tasks from Microsoft Planner or Microsoft To Do.                                |
 
-### Providers
+#### Providers
 
 [Providers](https://docs.microsoft.com/graph/toolkit/providers/providers) enable authentication and provide the implementation for acquiring access tokens on various platforms and expose a Microsoft Graph client for calling the Microsoft Graph APIs. The components work best when used with a provider, but the providers can be used on their own.
 
@@ -64,7 +64,7 @@ The components are also available as [React components](https://docs.microsoft.c
 | [Proxy](https://docs.microsoft.com/graph/toolkit/providers/proxy)             | Allows the use of backend authentication by routing all calls to Microsoft Graph through your backend.                                |
 | [Custom](https://docs.microsoft.com/graph/toolkit/providers/custom)           | Create a custom provider to enable authentication and access to Microsoft Graph with your application's existing authentication code. |
 
-## Who should use it?
+### Who should use it?
 
 The Microsoft Graph Toolkit is great for developers of all experience levels looking to develop an app that connects to and accesses data from Microsoft Graph, such as a:
 
@@ -74,7 +74,7 @@ The Microsoft Graph Toolkit is great for developers of all experience levels loo
 - Progressive Web App (PWA)
 - Electron app
 
-## Where can I use it?
+### Where can I use it?
 
 The Microsoft Graph Toolkit is supported in the following browsers.
 
@@ -82,7 +82,7 @@ The Microsoft Graph Toolkit is supported in the following browsers.
 | --------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | **Edge**                                                              | **Firefox**                                                                 | **Chrome**                                                                | **Safari**                                                                | **Opera**                                                               | **Samsung**                                                                                  |
 
-## Next steps
+### Next steps
 
 - Read our [documentation](https://aka.ms/mgt/docs).
 - [Get started](https://docs.microsoft.com/graph/toolkit/get-started/overview) with the Microsoft Graph Toolkit.


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1525

### PR Type

- Bugfix

### Description of the changes
Fixing the fact we had multiple H1 on the same page since we released the Overview + Feedback.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes