### PR TITLE
MGT Person - Disable attempt to get user photo when using userId/personQuery and fetchImage=false

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -251,6 +251,19 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
   public showMax: number;
 
   /**
+   * Sets whether the person image should be fetched
+   * from the Microsoft Graph
+   *
+   * @type {boolean}
+   * @memberof MgtPerson
+   */
+  @property({
+    attribute: 'fetch-images',
+    type: Boolean
+  })
+  public fetchImages: boolean;
+
+  /**
    *  array of user picked people.
    * @type {IDynamicPerson[]}
    */
@@ -421,6 +434,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     this.clearState();
     this._showLoading = true;
     this.showMax = 6;
+    this.fetchImages = true;
 
     this.disabled = false;
     this.allowAnyEmail = false;
@@ -846,7 +860,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     return (
       this.renderTemplate('person', { person }, person.id) ||
       html`
-         <mgt-person .personDetails=${person} .fetchImage=${true}></mgt-person>
+         <mgt-person .personDetails=${person} .fetchImage=${this.fetchImages}></mgt-person>
          <div class="people-person-text-area" id="${person.displayName}">
            ${this.renderHighlightText(person)}
            <span class="${classMap(classes)}">${subTitle}</span>
@@ -869,7 +883,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
          tabindex="-1"
          class="selected-list__person-wrapper__person"
          .personDetails=${person}
-         .fetchImage=${true}
+         .fetchImage=${this.fetchImages}
          .view=${ViewType.oneline}
          .personCardInteraction=${PersonCardInteraction.click}
        ></mgt-person>

--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -1019,7 +1019,12 @@ export class MgtPerson extends MgtTemplatedComponent {
     } else if (this.userId || this.personQuery === 'me') {
       // Use userId or 'me' query to get the person and image
       let person;
-      if (this._avatarType === 'photo') {
+      if (
+        this._avatarType === 'photo' &&
+        this.fetchImage &&
+        !this.personImage &&
+        !this._fetchedImage
+      ) {
         person = await getUserWithPhoto(graph, this.userId, personProps);
       } else {
         if (this.personQuery === 'me') {
@@ -1040,7 +1045,12 @@ export class MgtPerson extends MgtTemplatedComponent {
 
       if (people && people.length) {
         this.personDetailsInternal = people[0];
-        if (this._avatarType === 'photo') {
+        if (
+          this._avatarType === 'photo' &&
+          this.fetchImage &&
+          !this.personImage &&
+          !this._fetchedImage
+        ) {
           const image = await getPersonImage(graph, people[0], MgtPerson.config.useContactApis);
 
           if (image) {

--- a/packages/mgt-react/src/generated/react.ts
+++ b/packages/mgt-react/src/generated/react.ts
@@ -112,6 +112,7 @@ export type PeoplePickerProps = {
 	allowAnyEmail?: boolean;
 	templateContext?: TemplateContext;
 	mediaQuery?: ComponentMediaQuery;
+	fetchImages?: boolean;
 	selectionChanged?: (e: Event) => void;
 	templateRendered?: (e: Event) => void;
 }


### PR DESCRIPTION
Closes #1558

### PR Type
Bugfix

### Description of the changes
Fixes bug #1558 by adding additional prop checks (mainly fetchImage prop) prior to running getUserWithPhoto() / getPersonImage() functions. 

### PR checklist
- [ ] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes