### PR TITLE
Fix for Intermittent Teams 2 provider failure

### DIFF
--- a/packages/providers/mgt-teams-msal2-provider/src/TeamsMsal2Provider.ts
+++ b/packages/providers/mgt-teams-msal2-provider/src/TeamsMsal2Provider.ts
@@ -256,7 +256,12 @@ export class TeamsMsal2Provider extends Msal2Provider {
 
         // make sure we are calling login only once
         if (!sessionStorage.getItem(this._sessionStorageLoginInProgress)) {
-          sessionStorage.setItem(this._sessionStorageLoginInProgress, 'true');
+          const isInIframe = window.parent !== window;
+          if (!isInIframe) {
+              sessionStorage.setItem(this._sessionStorageLoginInProgress, "true");
+          } else {
+              console.warn("handleProviderState - Is in iframe... will try to login anyway... but will not set session storage variable");
+          }
 
           provider.login();
         }


### PR DESCRIPTION
#1432

<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes # 1432

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

The change prevents the logging in session variable from being set in an iframe. This was preventing the top window from handling the login when msal was trying to run inside a hidden iframe before the parent gets a chance.

### PR checklist
- [ ] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
