### PR TITLE
Fix regex to avoid Polynomial time and fix security alert

### DIFF
--- a/packages/mgt-element/src/utils/TemplateHelper.ts
+++ b/packages/mgt-element/src/utils/TemplateHelper.ts
@@ -241,7 +241,7 @@ export class TemplateHelper {
       const childElement = loopChildren[i] as HTMLElement;
 
       const loopExpression = childElement.dataset.for;
-      const loopTokens = this.trimExpression(loopExpression).split(/\s+?(in|of)\s+?/i);
+      const loopTokens = this.trimExpression(loopExpression).split(/\s?(in|of)\s?/i);
 
       if (loopTokens.length === 3) {
         // don't really care what's in the middle at this point

--- a/packages/mgt-element/src/utils/TemplateHelper.ts
+++ b/packages/mgt-element/src/utils/TemplateHelper.ts
@@ -241,7 +241,7 @@ export class TemplateHelper {
       const childElement = loopChildren[i] as HTMLElement;
 
       const loopExpression = childElement.dataset.for;
-      const loopTokens = this.trimExpression(loopExpression).split(/\s+(in|of)\s+/i);
+      const loopTokens = this.trimExpression(loopExpression).split(/\s+?(in|of)\s+?/i);
 
       if (loopTokens.length === 3) {
         // don't really care what's in the middle at this point

--- a/packages/mgt-element/src/utils/TemplateHelper.ts
+++ b/packages/mgt-element/src/utils/TemplateHelper.ts
@@ -241,12 +241,12 @@ export class TemplateHelper {
       const childElement = loopChildren[i] as HTMLElement;
 
       const loopExpression = childElement.dataset.for;
-      const loopTokens = this.trimExpression(loopExpression).split(/\s?(in|of)\s?/i);
+      const loopTokens = this.trimExpression(loopExpression).split(/\s(in|of)\s/i);
 
       if (loopTokens.length === 3) {
         // don't really care what's in the middle at this point
-        const itemName = loopTokens[0];
-        const listKey = loopTokens[2];
+        const itemName = loopTokens[0].trim();
+        const listKey = loopTokens[2].trim();
 
         const list = this.evalInContext(listKey, context);
         if (Array.isArray(list)) {


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1588

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Change the regex to use a non-greedy quantifier. This should prevent matching of white spaces from taking a long time in some _long_ strings. Should also quell the security alert https://github.com/microsoftgraph/microsoft-graph-toolkit/security/code-scanning/30

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
