### PR TITLE
[people-picker] Search users only set in the user-ids when user-ids are set

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -1040,7 +1040,12 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
                   people = await findUsers(graph, input, this.showMax, this._userFilters);
                 }
               } else {
-                people = (await findPeople(graph, input, this.showMax, this.userType, this._peopleFilters)) || [];
+                if (this.userIds && this.userIds.length) {
+                  // has the user-ids proerty set
+                  people = await getUsersForUserIds(graph, this.userIds, input, this._userFilters);
+                } else {
+                  people = (await findPeople(graph, input, this.showMax, this.userType, this._peopleFilters)) || [];
+                }
               }
             } catch (e) {
               // nop
@@ -1676,6 +1681,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     // ensuring people list is displayed
     // find ids from selected people
     if (people && people.length > 0) {
+      people = people.filter(person => person);
       const idFilter = this.selectedPeople.map(el => {
         return el.id ? el.id : el.displayName;
       });

--- a/packages/mgt-components/src/graph/graph.user.ts
+++ b/packages/mgt-components/src/graph/graph.user.ts
@@ -197,9 +197,13 @@ export async function getUsersForUserIds(
     if (user && getUserInvalidationTime() > Date.now() - user.timeCached) {
       user = JSON.parse(user?.user);
       const displayName = user.displayName;
-      const searchMatches = displayName && displayName.toLowerCase().includes(searchInput) ? true : false;
-      if (searchInput && searchMatches) {
-        peopleSearchMatches[id] = user ? user : null;
+
+      if (searchInput) {
+        const match = displayName && displayName.toLowerCase().includes(searchInput);
+        const searchMatches = match ? true : false;
+        if (searchMatches) {
+          peopleSearchMatches[id] = user ? user : null;
+        }
       } else {
         peopleDict[id] = user ? user : null;
       }


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1662  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Searching in the `people-picker` with `user-ids` set gave results that are not part of the `user-ids` listed. This fix ensures that the displayed users and the search results are from the `user-ids` only.
### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
