### PR TITLE
Set the aria-label text for the buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "private": true,
-  "version": "2.5.2",
+  "version": "2.5.3",
   "workspaces": [
     "packages/*",
     "packages/providers/*",

--- a/packages/mgt-components/src/components/mgt-login/mgt-login.ts
+++ b/packages/mgt-components/src/components/mgt-login/mgt-login.ts
@@ -209,12 +209,20 @@ export class MgtLogin extends MgtTemplatedComponent {
    * @memberof MgtLogin
    */
   protected renderButton() {
+    const signedIn = Providers.globalProvider.state === ProviderState.SignedIn;
+    const ariaLabel = signedIn
+      ? this.userDetails
+        ? this.userDetails.displayName
+        : this.strings.signInLinkSubtitle
+      : this.strings.signInLinkSubtitle;
     const classes = {
       'login-button': true,
       'no-click': this._isFlyoutOpen
     };
     return html`
-      <button ?disabled="${this.isLoadingState}" @click=${this.onClick} class=${classMap(classes)} role="button">
+      <button aria-label=${ariaLabel} ?disabled="${this.isLoadingState}" @click=${this.onClick} class=${classMap(
+      classes
+    )} role="button">
         ${this.renderButtonContent()}
       </button>
     `;
@@ -362,9 +370,7 @@ export class MgtLogin extends MgtTemplatedComponent {
       template ||
       html`
         <i class="login-icon ms-Icon ms-Icon--Contact"></i>
-        <span aria-label="Sign In">
-          ${this.strings.signInLinkSubtitle}
-        </span>
+        <span>${this.strings.signInLinkSubtitle}</span>
       `
     );
   }

--- a/packages/mgt-components/src/components/mgt-login/mgt-login.ts
+++ b/packages/mgt-components/src/components/mgt-login/mgt-login.ts
@@ -212,12 +212,13 @@ export class MgtLogin extends MgtTemplatedComponent {
     const provider = Providers.globalProvider;
     const signedInState = ProviderState.SignedIn;
 
-    const signedIn = provider && provider.state === signedInState;
-    const ariaLabel = signedIn
-      ? this.userDetails
-        ? this.userDetails.displayName
-        : this.strings.signInLinkSubtitle
-      : this.strings.signInLinkSubtitle;
+    let ariaLabel = this.strings.signInLinkSubtitle;
+    if (provider) {
+      if (provider.state === signedInState) {
+        ariaLabel = this.userDetails ? this.userDetails.displayName : this.strings.signInLinkSubtitle;
+      }
+    }
+
     const classes = {
       'login-button': true,
       'no-click': this._isFlyoutOpen

--- a/packages/mgt-components/src/components/mgt-login/mgt-login.ts
+++ b/packages/mgt-components/src/components/mgt-login/mgt-login.ts
@@ -309,7 +309,7 @@ export class MgtLogin extends MgtTemplatedComponent {
       html`
         <ul>
           <li>
-            <button class="popup-command" @click=${this.logout} aria-label="Sign Out">
+            <button class="popup-command" @click=${this.logout} aria-label=${this.strings.signOutLinkSubtitle}>
               ${this.strings.signOutLinkSubtitle}
             </button>
           </li>

--- a/packages/mgt-components/src/components/mgt-login/mgt-login.ts
+++ b/packages/mgt-components/src/components/mgt-login/mgt-login.ts
@@ -209,7 +209,10 @@ export class MgtLogin extends MgtTemplatedComponent {
    * @memberof MgtLogin
    */
   protected renderButton() {
-    const signedIn = Providers.globalProvider.state === ProviderState.SignedIn;
+    const provider = Providers.globalProvider;
+    const signedInState = ProviderState.SignedIn;
+
+    const signedIn = provider && provider.state === signedInState;
     const ariaLabel = signedIn
       ? this.userDetails
         ? this.userDetails.displayName

--- a/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.ts
+++ b/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.ts
@@ -563,10 +563,12 @@ export class MgtPersonCard extends MgtTemplatedComponent {
    */
   protected renderExpandedDetailsButton(): TemplateResult {
     return html`
-      <div class="expanded-details-button" @click=${() => this.showExpandedDetails()} @keydown=${
-      this.handleKeyDown
-    } @ tabindex=0>
-        ${getSvg(SvgIcon.ExpandDown)}
+      <div 
+        class="expanded-details-button" 
+        @click=${() => this.showExpandedDetails()} 
+        @keydown=${this.handleKeyDown}
+        tabindex=0>
+          ${getSvg(SvgIcon.ExpandDown)}
       </div>
     `;
   }
@@ -623,14 +625,20 @@ export class MgtPersonCard extends MgtTemplatedComponent {
 
     const currentSectionIndex = this._currentSection ? this.sections.indexOf(this._currentSection) : -1;
 
-    const navIcons = this.sections.map((section, i, a) => {
+    const navIcons = this.sections.map((section, i) => {
       const classes = classMap({
         active: i === currentSectionIndex,
         'section-nav__icon': true
       });
+      const tagName = section.tagName;
+      const ariaLabel = tagName.substring(16, tagName.length).toLowerCase();
       return html`
-        <button tabindex=0 class=${classes} @click=${() =>
-        this.updateCurrentSection(section)}>${section.renderIcon()}</button>
+        <button
+          aria-label=${ariaLabel}
+          tabindex=0
+          class=${classes}
+          @click=${() => this.updateCurrentSection(section)}>
+            ${section.renderIcon()}</button>
       `;
     });
 
@@ -639,8 +647,12 @@ export class MgtPersonCard extends MgtTemplatedComponent {
       'section-nav__icon': true
     });
     return html`
-      <button tabindex=0 class=${overviewClasses} @click=${() => this.updateCurrentSection(null)}>
-        ${getSvg(SvgIcon.Overview)}
+      <button 
+        aria-label="overview"
+        tabindex=0 
+        class=${overviewClasses}
+        @click=${() => this.updateCurrentSection(null)}>
+          ${getSvg(SvgIcon.Overview)}
       </button>
       ${navIcons}
     `;
@@ -654,16 +666,21 @@ export class MgtPersonCard extends MgtTemplatedComponent {
    * @memberof MgtPersonCard
    */
   protected renderOverviewSection(): TemplateResult {
+    function handleKeyDown(e: KeyboardEvent, section: BasePersonCardSection) {
+      e.code === 'Enter' ? this.updateCurrentSection(section) : '';
+    }
+
     const compactTemplates = this.sections.map(
-      section => html`
+      (section: BasePersonCardSection) => html`
         <div class="section">
           <div class="section__header">
             <div class="section__title">${section.displayName}</div>
-            <a class="section__show-more" tabindex=0 @keydown=${e =>
-              e.keyCode === 13 ? this.updateCurrentSection(section) : ''} @click=${() =>
-        this.updateCurrentSection(section)}
-              >${this.strings.showMoreSectionButton}</a
-            >
+            <a 
+              class="section__show-more"
+              tabindex=0
+              @keydown=${(e: KeyboardEvent) => handleKeyDown(e, section)}
+              @click=${() => this.updateCurrentSection(section)}>
+                ${this.strings.showMoreSectionButton}</a>
           </div>
           <div class="section__content">${section.asCompactView()}</div>
         </div>


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1715 , closes #1584 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This allows the login component to have an encapsulating button which has an `aria-label` that is set depending on whether a user is signed in (sets the `displayName`) or signed out (sets the 'Sign In' string). The `aria-label` is maintained when you override the various templates.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
