### PR TITLE
fix: prevent unsafe access to dom nodes in getDocumentDirection

### DIFF
--- a/packages/mgt-element/src/utils/LocalizationHelper.ts
+++ b/packages/mgt-element/src/utils/LocalizationHelper.ts
@@ -46,7 +46,7 @@ export class LocalizationHelper {
    * @memberof LocalizationHelper
    */
   public static getDocumentDirection() {
-    return document.body.getAttribute('dir') || document.documentElement.getAttribute('dir');
+    return document.body?.getAttribute('dir') || document.documentElement?.getAttribute('dir');
   }
 
   /**


### PR DESCRIPTION
Closes #1785 

### PR Type
Bugfix

### Description of the changes
If a provider is in the head using mgt-loader the synchronous loading of mgt scripts causes LocaliztionHelper to attempt to access the body DOM node of the document before the browser has parsed the entire document causing body to be null. Using optional chaining avoids trying to call a method on a null object.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc have been documented following the jsdoc syntax **N/A**
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested **N/A**
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR:  **N/A**
- [x] License header has been added to all new source files (`yarn setLicense`) **N/A**
- [x] Contains **NO** breaking changes

