### PR TITLE
fix: email resolution on paste for people picker

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -1395,10 +1395,11 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
    * Adds debounce method for set delay on user input
    */
   private onUserKeyUp(event: KeyboardEvent): void {
+    const isPaste = (event.ctrlKey || event.metaKey) && event.key === 'v';
     const isCmdOrCtrlKey = ['ControlLeft', 'ControlRight'].includes(event.code) || event.ctrlKey || event.metaKey;
     const isArrowKey = ['ArrowDown', 'ArrowRight', 'ArrowUp', 'ArrowLeft'].includes(event.code);
 
-    if (isCmdOrCtrlKey || isArrowKey) {
+    if ((!isPaste && isCmdOrCtrlKey) || isArrowKey) {
       if (isCmdOrCtrlKey || ['ArrowLeft', 'ArrowRight'].includes(event.code)) {
         // Only hide the flyout when you're doing selections with Left/Right Arrow key
         this.hideFlyout();
@@ -1439,7 +1440,9 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     } else {
       this.userInput = input.value;
       const validEmail = isValidEmail(this.userInput);
-      if (!validEmail) {
+      if (validEmail && this.allowAnyEmail) {
+        this.handleAnyEmail();
+      } else {
         this.handleUserSearch();
       }
     }


### PR DESCRIPTION
Closes #1763

### PR Type
Bugfix 

### Description of the changes
Adds special handling for keyUp when pasting to resolve email addresses

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information

