### PR TITLE
Revert move of getUsers, fixes #1795

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -1040,11 +1040,11 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
             } else {
               const isUserOrContactType = this.userType === UserType.user || this.userType === UserType.contact;
               if (this._userFilters && isUserOrContactType) {
+                people = await getUsers(graph, this._userFilters, this.showMax);
               } else {
                 people = await getPeople(graph, this.userType, this._peopleFilters);
               }
             }
-            people = await getUsers(graph, this._userFilters, this.showMax);
           } else if (this.type === PersonType.group) {
             if (this.groupIds) {
               try {


### PR DESCRIPTION
Closes #1795

### PR Type
Bugfix

### Description of the changes
Reverts a, probably accidental, change in #1652 that moved a call to `getUsers`. This change led to an empty `if`-statement and the `user-ids` and `people-filters` properties not working properly.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] Contains **NO** breaking changes
