### PR TITLE
People picker - Remove indefinite caching of flyout menu contents

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -651,6 +651,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       this._groupPeople = null;
       this._foundPeople = null;
       this.selectedPeople = [];
+      this.defaultPeople = null;
     }
 
     return super.requestStateUpdate(force);


### PR DESCRIPTION
Closes #1796

### PR Type
Bugfix

### Description of the changes
The `defaultPeople` property, if set, is used when rendering the flyout menu. This property is set once and never updated, even if the underlying properties that filled that list are changed. This resulted in the issue described in #1796.

This PR adds a change that clears the `defaultProperty` in the `requestStateUpdate` function, if it is called with `force=true`. The `requestStateUpdate` function is called by almost all of the properties in the people picker, when their value has changed, and therefore this PR fixes the caching issue for those properties as well.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] Contains **NO** breaking changes