### PR TITLE
fix: correct css overrides for contrast issues

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -416,7 +416,7 @@
   .css-gb1sl5 {
     color: #717171 !important;
   }
-
+  .sto-ulso1l,
   .css-1en6m26 {
     color: #616159 !important;
   }

--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -76,11 +76,11 @@
   }
 
   .css-19nbuh3,
-  .css-1m7olli * .token.attr-value {
+  .css-zj0253 * .token.attr-value {
     color: #0360B9 !important;
   }
 
-  .css-1m7olli * .token.attr-name{
+  .css-zj0253 * .token.attr-name {
     color: #e50000 !important;
   }
 


### PR DESCRIPTION
Closes #1813 

### PR Type
 - Bugfix
 
### Description of the changes
updates custom css selectors to fix color contrast, changes in the Storybook package resulted in a regression.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax : **N/A**
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested : **N/A**
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: **N/A**
- [x] Accessibility tested and approved
- [x] License header has been added to all new source files (`yarn setLicense`) : **N/A**
- [x] Contains **NO** breaking changes

### Other information
A11y approval is assumed as this addresses a regression and has not wider impact.
