### PR TITLE
update: Focus on the heading link once in the storybook playground

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -44,7 +44,7 @@
     }
 
     // This is a fix for an accessibility issue: https://github.com/microsoftgraph/microsoft-graph-toolkit/issues/1085
-    sidebarHeader[0].innerHTML = '<h1 tabindex="0" class="css-1su1ft1">' + '<a href="https://aka.ms/mgt" target="_blank" class="css-ixbm00">' + "Microsoft Graph Toolkit Playground</a>" + "</h1>";
+    sidebarHeader[0].innerHTML = '<h1 tabindex="-1" class="css-1su1ft1">' + '<a href="https://aka.ms/mgt" target="_blank" class="css-ixbm00">' + "Microsoft Graph Toolkit Playground</a>" + "</h1>";
 
     const sidebarNode = sidebarHeader[0].parentNode;
 
@@ -416,6 +416,7 @@
   .css-gb1sl5 {
     color: #717171 !important;
   }
+
   .sto-ulso1l,
   .css-1en6m26 {
     color: #616159 !important;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1535  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Allow the tab key to land only once on the heading in the storybook playground.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
- [ ] Accessibility tested and approved
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
