### PR TITLE
Fix for people picker selected people close button a11y

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -754,7 +754,8 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
                  <div class="selected-list__person-wrapper__overflow__gradient"></div>
                  <div
                    tabindex="0"
-                   aria-label="close-icon"
+                   role="button"
+                   aria-label="${this.strings.removeSelectedItem} ${person.displayName}"
                    class="selected-list__person-wrapper__overflow__close-icon"
                    @click="${e => this.removePerson(person, e)}"
                    @keydown="${e => this.handleRemovePersonKeyDown(person, e)}"

--- a/packages/mgt-components/src/components/mgt-people-picker/strings.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/strings.ts
@@ -11,5 +11,6 @@ export const strings = {
   loadingMessage: 'Loading...',
   suggestedContact: 'suggested contact',
   suggestedContacts: 'suggested contacts',
-  selected: 'selected'
+  selected: 'selected',
+  removeSelectedItem: 'remove selected item'
 };


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1898 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
Refactoring (no functional changes, no api changes)
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This PR updates the People Picker selected people close button for better a11y support.
-  `role="button"` added to element
-  `removeSelectedItem: 'remove selected item'` added to `strings.ts`
-  `aria-label` updated to include `removeSelectedItem` string and `person.displayName`

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
<!-- - [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax -->
<!-- - [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested -->
<!-- - [] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). -->
<!--Docs PR: --> <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
<!-- - [] License header has been added to all new source files (`yarn setLicense`)-->
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
