### PR TITLE
feat: add new CSS properties for the people picker

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.scss
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.scss
@@ -214,7 +214,11 @@ mgt-people-picker .root {
               flex: 1 1 0;
               max-height: 40px;
               overflow: hidden;
-              color: $color;
+              color: $dropdown-item__text__color;
+
+              &:hover {
+                color: $dropdown-item__text__color--hover;
+              }
 
               .people-person-text {
                 font-size: 14px;

--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.scss
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.scss
@@ -126,7 +126,15 @@ mgt-people-picker .root {
             flex: 1 1 0;
             max-height: 40px;
             overflow: hidden;
-            color: $color;
+            color: $dropdown-item__text__color;
+
+            &:hover {
+              color: $dropdown-item__text__color--hover;
+            }
+            
+            &.focused {
+              color: $dropdown-item__text__color--hover;
+            }
 
             .people-person-text {
               font-size: 14px;

--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -75,6 +75,8 @@ interface IFocusable {
  *
  * @cssprop --dropdown-background-color - {Color} Background color of dropdown area
  * @cssprop --dropdown-item-hover-background - {Color} Background color of person during hover
+ * @cssprop --dropdown-item-text-color - {Color} Color of person text
+ * @cssprop --dropdown-item-text-hover-color - {Color} Color of person text during hover
  *
  * @cssprop --placeholder-color--focus - {Color} Color of placeholder text during focus state
  * @cssprop --placeholder-color - {Color} Color of placeholder text

--- a/packages/mgt-components/src/styles/shared-sass-variables.scss
+++ b/packages/mgt-components/src/styles/shared-sass-variables.scss
@@ -172,6 +172,12 @@ $link__color--disabled--light: $gray90;
 $depth-shadow--light: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132);
 $depth-shadow--dark: 0 5px 14px 0 rgba(0, 0, 0, 0.8);
 
+/* -----People picker dropdown text----- */
+$dropdown__item__text__color--light: $text__color__main--light;
+$dropdown__item__text__color--dark: $text__color__main--dark;
+$dropdown__item__text__hover__color--light: $text__color__main--light;
+$dropdown__item__text__hover__color--dark: $text__color__main--dark;
+
 $font-family: var(--default-font-family);
 $font-size: var(--default-font-size);
 
@@ -339,7 +345,17 @@ $common: (
     _var: --list-item-background-color--hover,
     dark: $list__item__background-color--hover--dark,
     light: $list__item__background-color--hover--light
-  )
+  ),
+  dropdown__item__text__color: (
+    _var: --dropdown-item-text-color,
+    dark: $dropdown__item__text__color--dark,
+    light: $dropdown__item__text__color--light
+  ),
+  dropdown__item__text__color--hover: (
+    _var: --dropdown-item-text-hover-color,
+    dark:$dropdown__item__text__hover__color--dark,
+    light: $dropdown__item__text__hover__color--light
+  ),
 );
 
 @function set-var($var, $theme, $component) {
@@ -374,6 +390,8 @@ $dropdown-item__background-color--hover: var(
   --dropdown-item-hover-background,
   set-var(input-outlined__background-color--hover, $theme-default, $common)
 );
+$dropdown-item__text__color: set-var(dropdown__item__text__color, $theme-default, $common);
+$dropdown-item__text__color--hover: set-var(dropdown__item__text__color--hover, $theme-default, $common);
 
 @mixin input__border($theme) {
   border-top: $input__border-top;

--- a/stories/components/peoplePicker/peoplePicker.style.js
+++ b/stories/components/peoplePicker/peoplePicker.style.js
@@ -35,6 +35,8 @@ export const customCssProperties = () => html`
 
     --dropdown-background-color: #956970; /* selection area background color */
     --dropdown-item-hover-background: purple; /* person background color on hover */
+    --dropdown-item__text__color: yellow; /* person item text color */
+    --dropdown-item__text__hover__color: blue; /* person item text color on hover */
 
     --selected-person-background-color: black ; /* person item background color */
 

--- a/stories/components/peoplePicker/peoplePicker.style.js
+++ b/stories/components/peoplePicker/peoplePicker.style.js
@@ -33,9 +33,9 @@ export const customCssProperties = () => html`
     --input-border-color--hover: #008394; /* input area border hover color */
     --input-border-color--focus: #0f78d4; /* input area border focus color */
 
-    --dropdown-background-color: #956970; /* selection area background color */
+    --dropdown-background-color: #ca00ca; /* selection area background color */
     --dropdown-item-hover-background: purple; /* person background color on hover */
-    --dropdown-item-text-color: yellow; /* person item text color */
+    --dropdown-item-text-color: white; /* person item text color */
     --dropdown-item-text-hover-color: gold; /* person item text color on hover */
 
     --selected-person-background-color: black ; /* person item background color */

--- a/stories/components/peoplePicker/peoplePicker.style.js
+++ b/stories/components/peoplePicker/peoplePicker.style.js
@@ -35,8 +35,8 @@ export const customCssProperties = () => html`
 
     --dropdown-background-color: #956970; /* selection area background color */
     --dropdown-item-hover-background: purple; /* person background color on hover */
-    --dropdown-item__text__color: yellow; /* person item text color */
-    --dropdown-item__text__hover__color: blue; /* person item text color on hover */
+    --dropdown-item-text-color: yellow; /* person item text color */
+    --dropdown-item-text-hover-color: gold; /* person item text color on hover */
 
     --selected-person-background-color: black ; /* person item background color */
 


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1888  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
- Added two new custom CSS properties for use in the mgt-people-picker:
  - `--dropdown-item-text-color` customizes the text color of the dropdown items.
  - `--dropdown-item-text-hover-color` customizes the text color of the dropdown items during hover
### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: https://github.com/microsoftgraph/microsoft-graph-docs/pull/19067<!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->

In windows, when you enable high contrast themes, the text colors are set to white or black by default. Hence, testing this with issue #1888 is a challenge. Therefore, I'm requesting the issue other to verify if this solution fixes their issue.