### PR TITLE
fix: restore provided msal public client behavior

### DIFF
--- a/packages/mgt-element/src/providers/IProvider.ts
+++ b/packages/mgt-element/src/providers/IProvider.ts
@@ -27,13 +27,21 @@ export abstract class IProvider implements AuthenticationProvider {
   public graph: IGraph;
 
   /**
+   * Specifies if the provider has enabled support for multiple accounts
+   *
+   * @protected
+   * @type {boolean}
+   * @memberof IProvider
+   */
+  protected isMultipleAccountDisabled: boolean = true;
+
+  /**
    * Specifies if Multi account functionality is supported by the provider and enabled.
    *
    * @readonly
    * @type {boolean}
    * @memberof IProvider
    */
-  protected isMultipleAccountDisabled: boolean = true;
   public get isMultiAccountSupportedAndEnabled(): boolean {
     return false;
   }


### PR DESCRIPTION
Closes #1930

### PR Type
- Bugfix 

### Description of the changes
A regression removed the functionality to correctly use an explicitly provided Msal PublicClientApplication originally delivered in #1181.
This fixes the regression, cleans up repeated code, and adds missing doc comments

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes
