### PR TITLE
Update graph.userWithPhoto.ts

### DIFF
--- a/packages/mgt-components/src/graph/graph.userWithPhoto.ts
+++ b/packages/mgt-components/src/graph/graph.userWithPhoto.ts
@@ -61,7 +61,7 @@ export async function getUserWithPhoto(
   }
   if (getIsPhotosCacheEnabled()) {
     cachedPhoto = await getPhotoFromCache(userId || 'me', schemas.photos.stores.users);
-    if (cachedPhoto !== undefined && cachedPhoto !== null && getPhotoInvalidationTime() > Date.now() - cachedPhoto.timeCached) {
+    if (cachedPhoto && getPhotoInvalidationTime() > Date.now() - cachedPhoto.timeCached) {
       photo = cachedPhoto.photo;
     } else if (cachedPhoto) {
       try {

--- a/packages/mgt-components/src/graph/graph.userWithPhoto.ts
+++ b/packages/mgt-components/src/graph/graph.userWithPhoto.ts
@@ -46,7 +46,7 @@ export async function getUserWithPhoto(
   if (getIsUsersCacheEnabled()) {
     const cache = CacheService.getCache<CacheUser>(schemas.users, schemas.users.stores.users);
     cachedUser = await cache.getValue(userId || 'me');
-    if (cachedUser !== undefined && cachedPhoto !== null && getUserInvalidationTime() > Date.now() - cachedUser.timeCached) {
+    if (cachedUser !== undefined && getUserInvalidationTime() > Date.now() - cachedUser.timeCached) {
       user = cachedUser.user ? JSON.parse(cachedUser.user) : null;
       if (user !== null && requestedProps) {
         const uniqueProps = requestedProps.filter(prop => !Object.keys(user).includes(prop));
@@ -61,7 +61,7 @@ export async function getUserWithPhoto(
   }
   if (getIsPhotosCacheEnabled()) {
     cachedPhoto = await getPhotoFromCache(userId || 'me', schemas.photos.stores.users);
-    if (cachedPhoto !== undefined && getPhotoInvalidationTime() > Date.now() - cachedPhoto.timeCached) {
+    if (cachedPhoto !== undefined && cachedPhoto !== null && getPhotoInvalidationTime() > Date.now() - cachedPhoto.timeCached) {
       photo = cachedPhoto.photo;
     } else if (cachedPhoto) {
       try {

--- a/packages/mgt-components/src/graph/graph.userWithPhoto.ts
+++ b/packages/mgt-components/src/graph/graph.userWithPhoto.ts
@@ -46,7 +46,7 @@ export async function getUserWithPhoto(
   if (getIsUsersCacheEnabled()) {
     const cache = CacheService.getCache<CacheUser>(schemas.users, schemas.users.stores.users);
     cachedUser = await cache.getValue(userId || 'me');
-    if (cachedUser !== undefined && getUserInvalidationTime() > Date.now() - cachedUser.timeCached) {
+    if (cachedUser !== undefined && cachedPhoto !== null && getUserInvalidationTime() > Date.now() - cachedUser.timeCached) {
       user = cachedUser.user ? JSON.parse(cachedUser.user) : null;
       if (user !== null && requestedProps) {
         const uniqueProps = requestedProps.filter(prop => !Object.keys(user).includes(prop));


### PR DESCRIPTION
cache.getValue() for targeting cached photos of type CachePhoto (getPhotoFromCache() in *graph.photos*) returns null instead of undefined (which is the case for CacheUser) when nothing is found.

<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1936  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
