### PR TITLE
update groupIds prop of PeoplePicker to string array

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -134,8 +134,8 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
   }
 
   /**
-   * value determining if search is filtered to multiple groups.
-   * @type {string}
+   * array of groups for search to be filtered by.
+   * @type {string[]}
    */
   @property({
     attribute: 'group-ids',


### PR DESCRIPTION
Closes #1934

### PR Type
Bugfix

### Description of the changes
Update groupIds prop of PeoplePicker component to string[] to fix error. Also moves in line with other similar fields like userIds,  defaultSelectedUserIds and defaultSelectedGroupIds. Documentation probably needs to be updated for all 4 of these fields as they ALL say to provide 'string of comma-separated...' which must be legacy as they are all now string[] rather than comma separated strings.

All 4 of these props also have what looks to be legacy converters to separate the strings by comma separator, which is probably not needed anymore but I haven't touched these... (`return value.split(',').map(v => v.trim());`)

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes