### PR TITLE
chore: update build pipelines to use node v14.x

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pr-clean-storybook.yml
+++ b/.github/workflows/pr-clean-storybook.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pr-storybook.yml
+++ b/.github/workflows/pr-storybook.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
     if: needs.version.outputs.latest-version != needs.version.outputs.package-version
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     environment:
       name: release
@@ -80,7 +80,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository == 'microsoftgraph/microsoft-graph-toolkit'
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
           branch: gh-pages
           folder: storybook-static
           target-folder: next
-          clean-exclude: | 
+          clean-exclude: |
             pr
             fluentui
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #1938 

### PR Type
- Bugfix
- 
### Description of the changes
Updates all pipelines to use node 14.x to build articacts

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser) 
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax **N/A**
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested **N/A**
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->  **N/A**
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)  **N/A**
- [x] Contains **NO** breaking changes  **N/A**

### Other information
Should allow open PRs to build successfully again