### PR TITLE
Adding an aria-label property that can be set on the people picker component to allow a visual label to match the label of the component

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -450,6 +450,16 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
   }
 
   /**
+   * Label that can be set on the people picker input to provide context to
+   * assistive technologies
+   */
+  @property({
+    attribute: 'aria-label',
+    type: String
+  })
+  public ariaLabel: string;
+
+  /**
    * Get the scopes required for people picker
    *
    * @static
@@ -681,6 +691,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
            role="combobox"
            placeholder=${placeholder}
            autocomplete="off"
+           aria-label=${this.ariaLabel}
            aria-controls="suggestions-list"
            aria-haspopup="listbox"
            aria-autocomplete="list"


### PR DESCRIPTION
Adding an aria-label property that can be set on the people picker component to allow a visual label to match the label of the component

<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1899 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Added a property called `aria-label` that can be passed in to the component which sets the aria-label on the people picker input.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: https://github.com/microsoftgraph/microsoft-graph-docs/pull/19218
<!-- Please uncomment if any Accessibility related changes -->
- [x] Accessibility tested and approved
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->

