### PR TITLE
chore: adjust storybook pr triggers

### DIFF
--- a/.github/workflows/pr-storybook.yml
+++ b/.github/workflows/pr-storybook.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   storybook:
     # runs when there is a 'Build: Storybook' label, except if the run was triggered by a labeled event and the added label is not 'Build: Storybook'
-    if: 'contains(github.event.pull_request.labels.*.name, ''Build: Storybook'') && (github.event.action.name != labeled || (github.event.action == labeled && github.event.label.name == ''Build: Storybook''))'
+    if: 'contains(github.event.pull_request.labels.*.name, ''Build: Storybook'') && (github.event.action.name != ''labeled'' || (github.event.action == ''labeled'' && github.event.label.name == ''Build: Storybook''))'
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/pr-storybook.yml
+++ b/.github/workflows/pr-storybook.yml
@@ -10,7 +10,8 @@ on:
 
 jobs:
   storybook:
-    if: "contains(github.event.pull_request.labels.*.name, 'Build: Storybook')"
+    # runs when there is a 'Build: Storybook' label, except if the run was triggered by a labeled event and the added label is not 'Build: Storybook'
+    if: "contains(github.event.pull_request.labels.*.name, 'Build: Storybook') && (github.event.action.name != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'Build: Storybook'))"
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/pr-storybook.yml
+++ b/.github/workflows/pr-storybook.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   storybook:
     # runs when there is a 'Build: Storybook' label, except if the run was triggered by a labeled event and the added label is not 'Build: Storybook'
-    if: "contains(github.event.pull_request.labels.*.name, 'Build: Storybook') && (github.event.action.name != 'labeled' || (github.event.action == 'labeled' && github.event.label.name == 'Build: Storybook'))"
+    if: 'contains(github.event.pull_request.labels.*.name, ''Build: Storybook'') && (github.event.action.name != labeled || (github.event.action == labeled && github.event.label.name == ''Build: Storybook''))'
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Closes # <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
 - Build or CI related changes 
 
### Description of the changes
Update Storybook PR deployment triggers to reduce runs that are not needed.

### PR checklist
N/A

### Other information
This PR should stop the Storybook PR workflow from triggering when adding labels to a PR that already has the 'Build: Storybook' label applied
