### PR TITLE
fix: remove the SdkVersion header when redirected to a non-graph endpoint

### DIFF
--- a/packages/mgt-element/src/IGraph.ts
+++ b/packages/mgt-element/src/IGraph.ts
@@ -66,3 +66,24 @@ export interface IGraph {
    */
   createBatch(): IBatch;
 }
+
+export type GraphEndpoint =
+  | 'https://graph.microsoft.com'
+  | 'https://graph.microsoft.us'
+  | 'https://dod-graph.microsoft.us'
+  | 'https://graph.microsoft.de'
+  | 'https://microsoftgraph.chinacloudapi.cn';
+
+export const MICROSOFT_GRAPH_ENDPOINTS: Set<GraphEndpoint> = new Set<GraphEndpoint>();
+export const MICROSOFT_GRAPH_DEFAULT_ENDPOINT: GraphEndpoint = 'https://graph.microsoft.com';
+
+(() => {
+  const endpoints: GraphEndpoint[] = [
+    MICROSOFT_GRAPH_DEFAULT_ENDPOINT,
+    'https://graph.microsoft.us',
+    'https://dod-graph.microsoft.us',
+    'https://graph.microsoft.de',
+    'https://microsoftgraph.chinacloudapi.cn'
+  ];
+  endpoints.forEach(endpoint => MICROSOFT_GRAPH_ENDPOINTS.add(endpoint));
+})();

--- a/packages/mgt-element/src/utils/GraphHelpers.ts
+++ b/packages/mgt-element/src/utils/GraphHelpers.ts
@@ -6,7 +6,7 @@
  */
 
 import { AuthenticationHandlerOptions, Middleware } from '@microsoft/microsoft-graph-client';
-import { Providers } from '..';
+import { GraphEndpoint, MICROSOFT_GRAPH_ENDPOINTS, Providers } from '..';
 
 /**
  * creates an AuthenticationHandlerOptions from scopes array that
@@ -45,4 +45,21 @@ export function chainMiddleware(...middleware: Middleware[]): Middleware {
     current = next;
   }
   return rootMiddleware;
+}
+
+/**
+ * Helper method to validate a base URL string
+ * @param url a URL string
+ * @returns GraphEndpoint
+ */
+export function validateBaseURL(url: string): GraphEndpoint {
+  try {
+    const urlObj = new URL(url);
+    const originAsEndpoint = urlObj.origin as GraphEndpoint;
+    if (MICROSOFT_GRAPH_ENDPOINTS.has(originAsEndpoint)) {
+      return originAsEndpoint;
+    }
+  } catch (error) {
+    return;
+  }
 }

--- a/packages/mgt-element/src/utils/SdkVersionMiddleware.ts
+++ b/packages/mgt-element/src/utils/SdkVersionMiddleware.ts
@@ -8,6 +8,7 @@
 import { Context, Middleware } from '@microsoft/microsoft-graph-client';
 import { getRequestHeader, setRequestHeader } from '@microsoft/microsoft-graph-client/lib/es/middleware/MiddlewareUtil';
 import { ComponentMiddlewareOptions } from './ComponentMiddlewareOptions';
+import { validateBaseURL } from './GraphHelpers';
 
 /**
  * Implements Middleware for the Graph sdk to inject
@@ -33,33 +34,39 @@ export class SdkVersionMiddleware implements Middleware {
   // tslint:disable-next-line: completed-docs
   public async execute(context: Context): Promise<void> {
     try {
-      // Header parts must follow the format: 'name/version'
-      const headerParts: string[] = [];
+      if (typeof context.request === 'string') {
+        if (validateBaseURL(context.request)) {
+          // Header parts must follow the format: 'name/version'
+          const headerParts: string[] = [];
 
-      const componentOptions = context.middlewareControl.getMiddlewareOptions(
-        ComponentMiddlewareOptions
-      ) as ComponentMiddlewareOptions;
+          const componentOptions = context.middlewareControl.getMiddlewareOptions(
+            ComponentMiddlewareOptions
+          ) as ComponentMiddlewareOptions;
 
-      if (componentOptions) {
-        const componentVersion: string = `${componentOptions.componentName}/${this._packageVersion}`;
-        headerParts.push(componentVersion);
+          if (componentOptions) {
+            const componentVersion: string = `${componentOptions.componentName}/${this._packageVersion}`;
+            headerParts.push(componentVersion);
+          }
+
+          if (this._providerName) {
+            const providerVersion: string = `${this._providerName}/${this._packageVersion}`;
+            headerParts.push(providerVersion);
+          }
+
+          // Package version
+          const packageVersion: string = `mgt/${this._packageVersion}`;
+          headerParts.push(packageVersion);
+
+          // Existing SdkVersion header value
+          headerParts.push(getRequestHeader(context.request, context.options, 'SdkVersion'));
+
+          // Join the header parts together and update the SdkVersion request header value
+          const sdkVersionHeaderValue = headerParts.join(', ');
+          setRequestHeader(context.request, context.options, 'SdkVersion', sdkVersionHeaderValue);
+        } else {
+          delete context?.options?.headers['SdkVersion'];
+        }
       }
-
-      if (this._providerName) {
-        const providerVersion: string = `${this._providerName}/${this._packageVersion}`;
-        headerParts.push(providerVersion);
-      }
-
-      // Package version
-      const packageVersion: string = `mgt/${this._packageVersion}`;
-      headerParts.push(packageVersion);
-
-      // Existing SdkVersion header value
-      headerParts.push(getRequestHeader(context.request, context.options, 'SdkVersion'));
-
-      // Join the header parts together and update the SdkVersion request header value
-      const sdkVersionHeaderValue = headerParts.join(', ');
-      setRequestHeader(context.request, context.options, 'SdkVersion', sdkVersionHeaderValue);
     } catch (error) {
       // ignore error
     }


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1621  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This happens during large file upload as some endpoints throw a CORS error when the SdkVersion header is attached. This change deletes the header from the request object when the request endpoint is a non-graph endpoint.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
