### PR TITLE
fix: set the person details in all blocks when loading state

### DIFF
--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -1034,8 +1034,7 @@ export class MgtPerson extends MgtTemplatedComponent {
         !this.personImage &&
         !this._fetchedImage
       ) {
-        details;
-        let image;
+        let image: string;
         if ('groupTypes' in details) {
           image = await getGroupImage(graph, details, MgtPerson.config.useContactApis);
         } else {
@@ -1059,6 +1058,7 @@ export class MgtPerson extends MgtTemplatedComponent {
         }
       }
       this.personDetailsInternal = person;
+      this.personDetails = person;
       this._fetchedImage = this.getImage();
     } else if (this.personQuery) {
       // Use the personQuery to find our person.
@@ -1070,11 +1070,13 @@ export class MgtPerson extends MgtTemplatedComponent {
 
       if (people && people.length) {
         this.personDetailsInternal = people[0];
+        this.personDetails = people[0];
         if (this._avatarType === 'photo' && !this.disableImageFetch) {
           const image = await getPersonImage(graph, people[0], MgtPerson.config.useContactApis);
 
           if (image) {
             this.personDetailsInternal.personImage = image;
+            this.personDetails.personImage = image;
             this._fetchedImage = image;
           }
         }
@@ -1082,16 +1084,18 @@ export class MgtPerson extends MgtTemplatedComponent {
     }
 
     // populate presence
-    const defaultPresence = {
+    const defaultPresence: Presence = {
       activity: 'Offline',
       availability: 'Offline',
       id: null
     };
+
     if (this.showPresence && !this.personPresence && !this._fetchedPresence) {
       try {
-        if (this.personDetailsInternal && this.personDetailsInternal.id) {
+        details = this.personDetailsInternal || this.personDetails;
+        if (details) {
           // setting userId to 'me' ensures only the presence.read permission is required
-          const userId = this.personQuery !== 'me' ? this.personDetailsInternal.id : null;
+          const userId = this.personQuery !== 'me' ? details?.id : null;
           this._fetchedPresence = await getUserPresence(graph, userId);
         } else {
           this._fetchedPresence = defaultPresence;


### PR DESCRIPTION

<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1593  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
When you try to check for the id from `this.personDetailsInternal` only, the value will be `undefined` in the event `personDetails` were set on the component. To mitigate getting the default presence value, I update the instances that the `loadState` method updates the person's details. This ensures the final call to get the presence has either a user ID to make the call, it calls the `/me` endpoint or it falls to the default presence value.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
