### PR TITLE
fix: set the hover and focus color on the dropdown item

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.scss
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.scss
@@ -117,9 +117,15 @@ mgt-people-picker .root {
           border-radius: 4px;
           &:hover {
             background-color: $dropdown-item__background-color--hover;
+            .people-person-text-area {
+              color: $dropdown-item__text__color--hover;
+            }
           }
           &.focused {
             background-color: $dropdown-item__background-color--hover;
+            .people-person-text-area {
+              color: $dropdown-item__text__color--hover;
+            }
           }
           .people-person-text-area {
             margin-left: 13px;
@@ -127,14 +133,6 @@ mgt-people-picker .root {
             max-height: 40px;
             overflow: hidden;
             color: $dropdown-item__text__color;
-
-            &:hover {
-              color: $dropdown-item__text__color--hover;
-            }
-            
-            &.focused {
-              color: $dropdown-item__text__color--hover;
-            }
 
             .people-person-text {
               font-size: 14px;


### PR DESCRIPTION


<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #1950 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
This fix ensures that the color of the text on the dropdown item is set whenever you hover or focus anywhere on the dropdown item.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
