### PR TITLE
fix: make people-picker aria-label work in firefox

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -684,6 +684,8 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       return html``;
     }
 
+    // aria-label needs to provide a falsy default to avoid setting the attribute to "undefined" or "null"
+    // direct used of the ariaLabel property on the input element only works in Chromium browsers
     return html`
        <div class="${classMap(inputClasses)}">
          <input
@@ -693,7 +695,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
            role="combobox"
            placeholder=${placeholder}
            autocomplete="off"
-           .ariaLabel=${this.ariaLabel}
+           aria-label=${this.ariaLabel || ''}
            aria-controls="suggestions-list"
            aria-haspopup="listbox"
            aria-autocomplete="list"


### PR DESCRIPTION
Closes #1962 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
- Bugfix

### Description of the changes
Fixed rendering of aria-label in the people picker component

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes
