### PR TITLE
docs: adds version information to storybook

### DIFF
--- a/.github/workflows/pr-storybook.yml
+++ b/.github/workflows/pr-storybook.yml
@@ -29,14 +29,10 @@ jobs:
         run: |
           npm install -g yarn lerna
           yarn
-      - env:
-          EVENT_CONTEXT: ${{ toJSON(github.event) }}
-        run: |
-          echo $EVENT_CONTEXT
       - name: Extract tag name
         shell: bash
         run: |
-          tag=$(branch=${GITHUB_REF#refs/heads/}; echo ${branch/\//.})
+          tag=$(branch=${{ github.event.pull_request.head.ref }}; echo ${branch/\//.})
           if [[ $tag == next.* ]];
           then
             echo "##[set-output name=tag;]$tag"

--- a/.github/workflows/pr-storybook.yml
+++ b/.github/workflows/pr-storybook.yml
@@ -25,10 +25,27 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Build 🛠
+      - name: Install deps 🛠
         run: |
           npm install -g yarn lerna
           yarn
+
+      - name: Extract tag name
+        shell: bash
+        run: |
+          tag=$(branch=${GITHUB_REF#refs/heads/}; echo ${branch/\//.})
+          if [[ $tag == next.* ]];
+          then
+            echo "##[set-output name=tag;]$tag"
+          else
+            echo "##[set-output name=tag;]pr.${{ github.event.pull_request.number }}"
+          fi
+          echo "##[set-output name=tag;]$(branch=${GITHUB_REF#refs/heads/}; echo ${branch/\//.})"
+        id: extract_tag
+      - run: node scripts/setVersion.js --tag ${{ steps.extract_tag.outputs.tag }}
+
+      - name: Build 🛠
+        run: |
           yarn build
           yarn storybook:build
 

--- a/.github/workflows/pr-storybook.yml
+++ b/.github/workflows/pr-storybook.yml
@@ -29,7 +29,10 @@ jobs:
         run: |
           npm install -g yarn lerna
           yarn
-
+      - env:
+          EVENT_CONTEXT: ${{ toJSON(github.event) }}
+        run: |
+          echo $EVENT_CONTEXT
       - name: Extract tag name
         shell: bash
         run: |
@@ -40,7 +43,6 @@ jobs:
           else
             echo "##[set-output name=tag;]pr.${{ github.event.pull_request.number }}"
           fi
-          echo "##[set-output name=tag;]$(branch=${GITHUB_REF#refs/heads/}; echo ${branch/\//.})"
         id: extract_tag
       - run: node scripts/setVersion.js --tag ${{ steps.extract_tag.outputs.tag }}
 

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -18,6 +18,7 @@ module.exports = {
   ],
   stories: ['../stories/overview.stories.mdx', '../stories/**/*.@(js|mdx)'],
   addons: [
+    'storybook-version',
     '@storybook/addon-docs'
     // '@storybook/addon-a11y/register',
     // '@storybook/addon-actions/register',

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -9,7 +9,12 @@
   Microsoft Graph Toolkit Playground was founded by Microsoft as a community guided, open source project.
   <a tabindex="-1" href="https://privacy.microsoft.com/en-us/privacystatement">Privacy & cookies</a>
   <a tabindex="-1" href="https://www.microsoft.com/en-us/legal/intellectualproperty/copyright/default">Term of use</a>
+  Documentation for version <span id="mgt-version"></span>
 </footer>
+<script type="module">
+  import { PACKAGE_VERSION } from './mgt.storybook.js'
+  document.getElementById('mgt-version').innerText = PACKAGE_VERSION;
+</script>
 
 <script src="https://consentdeliveryfd.azurefd.net/mscc/lib/v2/wcp-consent.js"></script>
 <script src="https://az725175.vo.msecnd.net/scripts/jsll-4.js" type="text/javascript"></script>
@@ -309,11 +314,26 @@
 </style>
 
 <style>
-  /* this keeps the storybook body area above footer */
-  #root>div:first-of-type {
-    height: calc(100% - 40px);
+
+  /* don't show the footer on mobile */
+  @media (max-width: 599px) {
+    .storybook-footer {
+        display: none !important;
+    }
   }
 
+  /* this keeps the storybook body area above footer */
+  @media (max-width: 768px) {
+    #root>div:first-of-type {
+      height: calc(100% - 50px);
+    }
+  }
+
+  @media (min-width: 769px) {
+    #root>div:first-of-type {
+      height: calc(100% - 40px);
+    }
+  }
   .sidebar-header button {
     display: none !important;
   }
@@ -339,12 +359,6 @@
 
   .sidebar-subheading.css-ulso1l {
     color: #717171 !important;
-  }
-
-  @media (max-width: 768px) {
-    #root>div:first-of-type {
-      height: calc(100% - 50px);
-    }
   }
 
   .sidebar-header h1 {

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -6,10 +6,10 @@
 </script>
 
 <footer class="storybook-footer">
-  Microsoft Graph Toolkit Playground was founded by Microsoft as a community guided, open source project.
+  Microsoft Graph Toolkit (v<span id="mgt-version"></span>) Playground was founded by Microsoft as a community guided,
+  open source project.
   <a tabindex="-1" href="https://privacy.microsoft.com/en-us/privacystatement">Privacy & cookies</a>
   <a tabindex="-1" href="https://www.microsoft.com/en-us/legal/intellectualproperty/copyright/default">Term of use</a>
-  Documentation for version <span id="mgt-version"></span>
 </footer>
 <script type="module">
   import { PACKAGE_VERSION } from './mgt.storybook.js'

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "sass": "^1.29.0",
     "shx": "^0.3.3",
     "storybook-addon-web-components-knobs": "^0.3.20",
+    "storybook-version": "^0.1.1",
     "ts-jest": "^26.5.5",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",

--- a/packages/mgt-element/src/index.ts
+++ b/packages/mgt-element/src/index.ts
@@ -27,6 +27,7 @@ export * from './utils/TemplateContext';
 export * from './utils/TemplateHelper';
 export * from './utils/GraphPageIterator';
 export * from './utils/LocalizationHelper';
+export { PACKAGE_VERSION } from './utils/version';
 
 export * from './mock/MockProvider';
 export * from './mock/mgt-mock-provider';

--- a/scripts/setVersion.js
+++ b/scripts/setVersion.js
@@ -1,9 +1,9 @@
-var child_process = require('child_process')
+var child_process = require('child_process');
 var path = require('path');
 var fs = require('fs');
 var project = require('../package.json');
 
-const ignoreDirs = ['node_modules'];
+const ignoreDirs = ['node_modules', 'samples'];
 
 const getFiles = (filter, startPath = 'packages') => {
   let results = [];
@@ -25,11 +25,11 @@ const getFiles = (filter, startPath = 'packages') => {
   }
 
   return results;
-}
+};
 
 const updateMgtDependencyVersion = (packages, version) => {
   for (let package of packages) {
-    console.log(`updating package ${package} with version ${version}`)
+    console.log(`updating package ${package} with version ${version}`);
     const data = fs.readFileSync(package, 'utf8');
 
     var result = data.replace(/"(@microsoft\/mgt.*)": "(\*)"/g, `"$1": "${version}"`);
@@ -37,18 +37,18 @@ const updateMgtDependencyVersion = (packages, version) => {
 
     fs.writeFileSync(package, result, 'utf8');
   }
-}
+};
 
 const updateSpfxSolutionVersion = (solutions, version) => {
   for (let solution of solutions) {
-    console.log(`updating spfx solution ${solution} with version ${version}`)
+    console.log(`updating spfx solution ${solution} with version ${version}`);
     const data = fs.readFileSync(solution, 'utf8');
 
     var result = data.replace(/"version": "(.*)"/g, `"version": "${version}.0"`);
 
     fs.writeFileSync(solution, result, 'utf8');
   }
-}
+};
 
 let version = project.version;
 
@@ -83,8 +83,8 @@ if (process.argv.length > 2) {
       return;
   }
 }
-
-const packages = getFiles('package.json');
+// include update to the root package.json
+const packages = getFiles('package.json', '.');
 updateMgtDependencyVersion(packages, version);
 
 const spfxSolutions = getFiles('package-solution.json');

--- a/stories/components/agenda/agenda.a.js
+++ b/stories/components/agenda/agenda.a.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-agenda',
   component: 'mgt-agenda',
   decorators: [withCodeEditor]

--- a/stories/components/agenda/agenda.properties.js
+++ b/stories/components/agenda/agenda.properties.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-agenda / Properties',
   component: 'mgt-agenda',
   decorators: [withCodeEditor]
@@ -37,4 +41,3 @@ export const getEventsForNextWeek = () => html`
 export const preferredTimezone = () => html`
   <mgt-agenda preferred-timezone="Europe/Paris"></mgt-agenda>
 `;
-

--- a/stories/components/agenda/agenda.style.js
+++ b/stories/components/agenda/agenda.style.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-agenda / Style',
   component: 'mgt-agenda',
   decorators: [withCodeEditor]

--- a/stories/components/agenda/agenda.templating.js
+++ b/stories/components/agenda/agenda.templating.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-agenda / Templating',
   component: 'mgt-agenda',
   decorators: [withCodeEditor]
@@ -261,4 +265,3 @@ export const header = () => html`
 	</template>
 </mgt-agenda>
 `;
-

--- a/stories/components/file/file.a.js
+++ b/stories/components/file/file.a.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-file',
   component: 'mgt-file',
   decorators: [withCodeEditor]

--- a/stories/components/file/file.properties.js
+++ b/stories/components/file/file.properties.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-file / Properties',
   component: 'mgt-file',
   decorators: [withCodeEditor]

--- a/stories/components/file/file.style.js
+++ b/stories/components/file/file.style.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-file / Style',
   component: 'mgt-file',
   decorators: [withCodeEditor]
@@ -33,7 +37,7 @@ export const customCSSProperties = () => html`
     --line2-font-size: 11px;
     --line2-font-weight	: 3px;
     --line2-color: #e50000;
-    --line2-text-transform: capitalize;	
+    --line2-text-transform: capitalize;
     --line3-font-size: 12px;
     --line3-font-weight: 3px;
     --line3-color: purple;

--- a/stories/components/file/file.templating.js
+++ b/stories/components/file/file.templating.js
@@ -1,7 +1,11 @@
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-file / Templating',
   component: 'mgt-file',
   decorators: [withCodeEditor]

--- a/stories/components/fileList/fileList.a.js
+++ b/stories/components/fileList/fileList.a.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-file-list',
   component: 'mgt-file-list',
   decorators: [withCodeEditor]

--- a/stories/components/fileList/fileList.properties.js
+++ b/stories/components/fileList/fileList.properties.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-file-list / Properties',
   component: 'mgt-file-list',
   decorators: [withCodeEditor]

--- a/stories/components/fileList/fileList.style.js
+++ b/stories/components/fileList/fileList.style.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-file-list / Style',
   component: 'mgt-file-list',
   decorators: [withCodeEditor]

--- a/stories/components/fileList/fileList.templating.js
+++ b/stories/components/fileList/fileList.templating.js
@@ -6,8 +6,12 @@
  */
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-file-list / Templating',
   component: 'mgt-file',
   decorators: [withCodeEditor]

--- a/stories/components/get.stories.js
+++ b/stories/components/get.stories.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-get',
   component: 'mgt-get',
   decorators: [withCodeEditor]

--- a/stories/components/login/login.stories.js
+++ b/stories/components/login/login.stories.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-login',
   component: 'mgt-login',
   decorators: [withCodeEditor]

--- a/stories/components/login/login.styles.js
+++ b/stories/components/login/login.styles.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-login / Styles',
   component: 'mgt-login',
   decorators: [withCodeEditor]

--- a/stories/components/people/people.a.js
+++ b/stories/components/people/people.a.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-people',
   component: 'mgt-people',
   decorators: [withCodeEditor]

--- a/stories/components/people/people.properties.js
+++ b/stories/components/people/people.properties.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-people / Properties',
   component: 'mgt-people',
   decorators: [withCodeEditor]

--- a/stories/components/people/people.styles.js
+++ b/stories/components/people/people.styles.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-people / Styles',
   component: 'mgt-people',
   decorators: [withCodeEditor]

--- a/stories/components/people/people.templating.js
+++ b/stories/components/people/people.templating.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-people / Templating',
   component: 'mgt-people',
   decorators: [withCodeEditor]

--- a/stories/components/peoplePicker/peoplePicker.a.js
+++ b/stories/components/peoplePicker/peoplePicker.a.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-people-picker',
   component: 'mgt-people-picker',
   decorators: [withCodeEditor]

--- a/stories/components/peoplePicker/peoplePicker.properties.js
+++ b/stories/components/peoplePicker/peoplePicker.properties.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-people-picker / Properties',
   component: 'mgt-people-picker',
   decorators: [withCodeEditor]

--- a/stories/components/peoplePicker/peoplePicker.style.js
+++ b/stories/components/peoplePicker/peoplePicker.style.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-people-picker / Styles',
   component: 'mgt-people-picker',
   decorators: [withCodeEditor]

--- a/stories/components/peoplePicker/peoplePicker.templating.js
+++ b/stories/components/peoplePicker/peoplePicker.templating.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-people-picker / Templating',
   component: 'mgt-people-picker',
   decorators: [withCodeEditor]
@@ -43,4 +47,3 @@ export const DefaultTemplates = () => html`
 	</template>
 </mgt-people-picker>
 `;
-

--- a/stories/components/person/person.js
+++ b/stories/components/person/person.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components | mgt-person',
   component: 'mgt-person',
   decorators: [withCodeEditor]

--- a/stories/components/person/person.properties.js
+++ b/stories/components/person/person.properties.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-person / Properties',
   component: 'mgt-person',
   decorators: [withCodeEditor]

--- a/stories/components/person/person.style.js
+++ b/stories/components/person/person.style.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-person / Style',
   component: 'mgt-person',
   decorators: [withCodeEditor]

--- a/stories/components/person/person.templating.js
+++ b/stories/components/person/person.templating.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-person / Templating',
   component: 'mgt-person',
   decorators: [withCodeEditor]

--- a/stories/components/personCard/personCard.a.js
+++ b/stories/components/personCard/personCard.a.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-person-card',
   component: 'mgt-person-card',
   decorators: [withCodeEditor]

--- a/stories/components/personCard/personCard.properties.js
+++ b/stories/components/personCard/personCard.properties.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-person-card / Properties',
   component: 'mgt-person-card',
   decorators: [withCodeEditor]

--- a/stories/components/personCard/personCard.style.js
+++ b/stories/components/personCard/personCard.style.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-person-card / Style',
   component: 'mgt-person-card',
   decorators: [withCodeEditor]

--- a/stories/components/personCard/personCard.templating.js
+++ b/stories/components/personCard/personCard.templating.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-person-card / Templating',
   component: 'mgt-person-card',
   decorators: [withCodeEditor]

--- a/stories/components/tasks.stories.js
+++ b/stories/components/tasks.stories.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-tasks',
   component: 'mgt-tasks',
   decorators: [withCodeEditor]

--- a/stories/components/teamsChannelPicker/teamsChannelPicker.a.js
+++ b/stories/components/teamsChannelPicker/teamsChannelPicker.a.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-teams-channel-picker',
   component: 'mgt-teams-channel-picker',
   decorators: [withCodeEditor]

--- a/stories/components/teamsChannelPicker/teamsChannelPicker.style.js
+++ b/stories/components/teamsChannelPicker/teamsChannelPicker.style.js
@@ -1,7 +1,11 @@
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-teams-channel-picker / Style',
   component: 'mgt-teams-channel-picker',
   decorators: [withCodeEditor]
@@ -21,18 +25,18 @@ export const customCSSProperties = () => html`
     mgt-teams-channel-picker {
       --input-border: 2px rgb(255, 0, 0) solid;
 
-      --input-background-color: #fcc0e5; 
-      --input-border-color--hover: #008394; 
-      --input-border-color--focus: #0f78d4; 
+      --input-background-color: #fcc0e5;
+      --input-border-color--hover: #008394;
+      --input-border-color--focus: #0f78d4;
 
-      --dropdown-background-color: #FF69B4; 
-      --dropdown-item-hover-background: #ff92e6; 
-      --dropdown-item-selected-background: #a10980; 
+      --dropdown-background-color: #FF69B4;
+      --dropdown-item-hover-background: #ff92e6;
+      --dropdown-item-selected-background: #a10980;
 
-      --color: blue; 
+      --color: blue;
       --arrow-fill: #ffffff;
-      --placeholder-color: blue; 
-      --placeholder-color--focus: rgba(255, 255, 255, 0.8); 
+      --placeholder-color: blue;
+      --placeholder-color--focus: rgba(255, 255, 255, 0.8);
     }
   </style>
   <mgt-teams-channel-picker person-query="me"></mgt-teams-channel-picker>

--- a/stories/components/teamsChannelPicker/teamsChannelPicker.templating.js
+++ b/stories/components/teamsChannelPicker/teamsChannelPicker.templating.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-teams-channel-picker / Templating',
   component: 'mgt-teams-channel-picker',
   decorators: [withCodeEditor]

--- a/stories/components/todo.stories.js
+++ b/stories/components/todo.stories.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Components / mgt-todo',
   component: 'mgt-todo',
   decorators: [withCodeEditor]

--- a/stories/overview.stories.mdx
+++ b/stories/overview.stories.mdx
@@ -1,4 +1,6 @@
-import { Meta } from '@storybook/addon-docs';
+import { Meta, Source } from '@storybook/addon-docs';
+import { PACKAGE_VERSION } from '@microsoft/mgt';
+import { versionInfo } from './versionInfo';
 
 <Meta title="Overview" />
 
@@ -10,21 +12,25 @@ The Microsoft Graph Toolkit is a collection of reusable, framework-agnostic comp
 
 The Microsoft Graph Toolkit makes it easy to use Microsoft Graph in your application. In the following example, a signed in user and their calendar events are displayed with just two lines of code by using the [Login](?path=/story/components-mgt-login--login) and [Agenda](?path=/story/components-mgt-agenda--simple) components.
 
+<p>This site is providing documentation for version {PACKAGE_VERSION} of the Microsoft Graph Toolkit.</p>
+
 ### Installing the Microsoft Graph Toolkit
 
 It's easy to get started! Add the Toolkit via our `mgt-loader` or via npm and you are ready to go!
 
 #### Via the mgt-loader
 
-```html
-<script src="https://unpkg.com/@microsoft/mgt@2/dist/bundle/mgt-loader.js"></script>
-```
+<Source
+ language="html"
+ code={`<script src="https://unpkg.com/@microsoft/mgt@${versionInfo.major}/dist/bundle/mgt-loader.js"></script>`}
+/>
 
 #### Via npm
 
-```shell
-npm i @microsoft/mgt
-```
+<Source
+ language="shell"
+ code={`npm install @microsoft/mgt@${PACKAGE_VERSION}`}
+/>
 
 ### What's in the Microsoft Graph Toolkit?
 

--- a/stories/samples/editor.stories.js
+++ b/stories/samples/editor.stories.js
@@ -7,15 +7,19 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Editor',
   decorators: [withCodeEditor]
 };
 
 export const Editor = () => html`
   <!-- Add your own HTML code here -->
-  
+
   <script>
     // Add your own JavaScript code here
   </script>

--- a/stories/samples/general.stories.js
+++ b/stories/samples/general.stories.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Samples / General',
   component: 'mgt-combo',
   decorators: [withCodeEditor]

--- a/stories/samples/templating.stories.js
+++ b/stories/samples/templating.stories.js
@@ -7,8 +7,12 @@
 
 import { html } from 'lit-element';
 import { withCodeEditor } from '../../.storybook/addons/codeEditorAddon/codeAddon';
+import { versionInfo } from '../versionInfo';
 
 export default {
+  parameters: {
+    version: versionInfo
+  },
   title: 'Samples / Templating',
   component: 'mgt-get',
   decorators: [withCodeEditor]
@@ -115,7 +119,7 @@ export const AgendaEventTemplate = () => html`
             let ampm = hours >= 12 ? 'PM' : 'AM';
             hours = hours % 12;
             hours = hours ? hours : 12;
-            
+
             timeString = hours + ':' + minutesStr + ' ' + ampm;
           }
 

--- a/stories/versionInfo.js
+++ b/stories/versionInfo.js
@@ -1,0 +1,16 @@
+import { PACKAGE_VERSION } from '@microsoft/mgt-element';
+
+const postfixSplit = PACKAGE_VERSION.indexOf('-');
+let version = PACKAGE_VERSION;
+let postfix;
+if (postfixSplit > 0) {
+  version = PACKAGE_VERSION.substring(0, postfixSplit);
+  postfix = PACKAGE_VERSION.substring(postfixSplit + 1);
+}
+const [major, minor, patch] = version.split('.');
+export const versionInfo = {
+  major,
+  minor,
+  patch,
+  postfix
+};

--- a/stories/versionInfo.js
+++ b/stories/versionInfo.js
@@ -1,3 +1,9 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
 import { PACKAGE_VERSION } from '@microsoft/mgt-element';
 
 const postfixSplit = PACKAGE_VERSION.indexOf('-');


### PR DESCRIPTION
Closes #1413

### PR Type
- Documentation content changes 

### Description of the changes
Adds version info into the storybook site. 
This uses 'storybook-version' to pull the version info into the header bar on a per-story basis. This is driven by the existing version.ts file in mgt-element which is now explicitly exported for use.
The overview mdx based story exposes the version information in the npm install step and in the opening section.
The injected footer now also contains version information. This PR also resolves an unreported issue where the canvas and sidebar buttons were obscured at mobile breakpoints.
This is achieved by having the setVersion script be able to update the root package.json version number as well as all package.json files not in the samples directory.
With the root version set version.ts is updated with gulp 
The storybook-pr workflow will set the version of the built packages based on either the branch name if the branch starts with next and would be published to npm as a preview version or by pr number.
### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
