### PR TITLE
Fix: PeoplePicker removePerson input check

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -1247,7 +1247,9 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     this.selectedPeople = filteredPersonArr;
     this.loadState();
     this.fireCustomEvent('selectionChanged', this.selectedPeople);
-    this.input.focus();
+    if (this.input) {
+      this.input.focus();
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #1997 
https://github.com/microsoftgraph/microsoft-graph-toolkit/issues/1997
### PR Type

### BugFix

### Description of the changes

PeoplePicker Component
Safety checks this.input in the removePerson function. This.input can become null when selectionMode="single" and the a person is selected.
