### PR TITLE
docs: add args table to all simple docs pages

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -37,6 +37,9 @@ addParameters({
   previewTabs: {
     'storybook/docs/panel': {
       hidden: true
+    },
+    canvas: {
+      hidden: true
     }
   },
   docs: {

--- a/stories/components/file/file.a.js
+++ b/stories/components/file/file.a.js
@@ -7,11 +7,18 @@
 
 import { html } from 'lit';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { defaultDocsPage } from '../../../.storybook/story-elements/defaultDocsPage';
 
 export default {
   title: 'Components / mgt-file',
   component: 'file',
-  decorators: [withCodeEditor]
+  decorators: [withCodeEditor],
+  parameters: {
+    docs: {
+      page: defaultDocsPage,
+      source: { code: '<mgt-file file-query="/me/drive/items/01BYE5RZZFWGWWVNHHKVHYXE3OUJHGWCT2"></mgt-file>' }
+    }
+  }
 };
 
 export const file = () => html`

--- a/stories/components/fileList/fileList.a.js
+++ b/stories/components/fileList/fileList.a.js
@@ -7,11 +7,18 @@
 
 import { html } from 'lit';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { defaultDocsPage } from '../../../.storybook/story-elements/defaultDocsPage';
 
 export default {
   title: 'Components / mgt-file-list',
   component: 'file-list',
-  decorators: [withCodeEditor]
+  decorators: [withCodeEditor],
+  parameters: {
+    docs: {
+      page: defaultDocsPage,
+      source: { code: '<mgt-file-list></mgt-file-list>' }
+    }
+  }
 };
 
 export const fileList = () => html`

--- a/stories/components/get/get.stories.js
+++ b/stories/components/get/get.stories.js
@@ -6,13 +6,35 @@
  */
 
 import { html } from 'lit';
-import { withCodeEditor } from '../../.storybook/addons/codeEditorAddon/codeAddon';
+import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { defaultDocsPage } from '../../../.storybook/story-elements/defaultDocsPage';
 
 export default {
   title: 'Components / mgt-get',
   component: 'get',
-  decorators: [withCodeEditor]
+  decorators: [withCodeEditor],
+  parameters: {
+    docs: {
+      page: defaultDocsPage,
+      source: {
+        code: `
+<mgt-get resource="/me/messages" scopes="mail.read">
+  <template>
+    <pre>{{ JSON.stringify(value, null, 2) }}</pre>
+  </template>
+</mgt-get>`
+      }
+    }
+  }
 };
+
+export const Get = () => html`
+<mgt-get resource="/me/messages" scopes="mail.read">
+  <template>
+    <pre>{{ JSON.stringify(value, null, 2) }}</pre>
+  </template>
+</mgt-get>
+`;
 
 export const GetEmail = () => html`
   <mgt-get resource="/me/messages" version="beta" scopes="mail.read" max-pages="2">

--- a/stories/components/login/login.stories.js
+++ b/stories/components/login/login.stories.js
@@ -7,11 +7,18 @@
 
 import { html } from 'lit';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { defaultDocsPage } from '../../../.storybook/story-elements/defaultDocsPage';
 
 export default {
   title: 'Components / mgt-login',
   component: 'login',
-  decorators: [withCodeEditor]
+  decorators: [withCodeEditor],
+  parameters: {
+    docs: {
+      page: defaultDocsPage,
+      source: { code: '<mgt-login></mgt-login>' }
+    }
+  }
 };
 
 export const Login = () => html`

--- a/stories/components/people/people.a.js
+++ b/stories/components/people/people.a.js
@@ -7,11 +7,18 @@
 
 import { html } from 'lit';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { defaultDocsPage } from '../../../.storybook/story-elements/defaultDocsPage';
 
 export default {
   title: 'Components / mgt-people',
   component: 'people',
-  decorators: [withCodeEditor]
+  decorators: [withCodeEditor],
+  parameters: {
+    docs: {
+      page: defaultDocsPage,
+      source: { code: '<mgt-people show-max="5"></mgt-people>' }
+    }
+  }
 };
 
 export const People = () => html`

--- a/stories/components/peoplePicker/peoplePicker.a.js
+++ b/stories/components/peoplePicker/peoplePicker.a.js
@@ -7,11 +7,18 @@
 
 import { html } from 'lit';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { defaultDocsPage } from '../../../.storybook/story-elements/defaultDocsPage';
 
 export default {
   title: 'Components / mgt-people-picker',
   component: 'people-picker',
-  decorators: [withCodeEditor]
+  decorators: [withCodeEditor],
+  parameters: {
+    docs: {
+      page: defaultDocsPage,
+      source: { code: '<mgt-people-picker></mgt-people-picker>' }
+    }
+  }
 };
 
 export const peoplePicker = () => html`

--- a/stories/components/person/person.js
+++ b/stories/components/person/person.js
@@ -7,11 +7,18 @@
 
 import { html } from 'lit';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { defaultDocsPage } from '../../../.storybook/story-elements/defaultDocsPage';
 
 export default {
   title: 'Components | mgt-person',
   component: 'person',
-  decorators: [withCodeEditor]
+  decorators: [withCodeEditor],
+  parameters: {
+    docs: {
+      page: defaultDocsPage,
+      source: { code: '<mgt-person person-query="me" view="twoLines"></mgt-person>' }
+    }
+  }
 };
 
 export const person = () => html`

--- a/stories/components/personCard/personCard.a.js
+++ b/stories/components/personCard/personCard.a.js
@@ -7,11 +7,18 @@
 
 import { html } from 'lit';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { defaultDocsPage } from '../../../.storybook/story-elements/defaultDocsPage';
 
 export default {
   title: 'Components / mgt-person-card',
   component: 'person-card',
-  decorators: [withCodeEditor]
+  decorators: [withCodeEditor],
+  parameters: {
+    docs: {
+      page: defaultDocsPage,
+      source: { code: '<mgt-person-card person-query="me" id="online" show-presence></mgt-person-card>' }
+    }
+  }
 };
 
 export const personCard = () => html`

--- a/stories/components/picker/picker.js
+++ b/stories/components/picker/picker.js
@@ -7,11 +7,21 @@
 
 import { html } from 'lit';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { defaultDocsPage } from '../../../.storybook/story-elements/defaultDocsPage';
 
 export default {
   title: 'Components / mgt-picker',
-  component: 'mgt-picker',
-  decorators: [withCodeEditor]
+  component: 'picker',
+  decorators: [withCodeEditor],
+  parameters: {
+    docs: {
+      page: defaultDocsPage,
+      source: {
+        code:
+          '<mgt-picker resource="me/todo/lists" scopes="tasks.read, tasks.readwrite" placeholder="Select a task list" key-name="displayName"></mgt-picker>'
+      }
+    }
+  }
 };
 
 export const picker = () => html`

--- a/stories/components/tasks/tasks.stories.js
+++ b/stories/components/tasks/tasks.stories.js
@@ -6,24 +6,26 @@
  */
 
 import { html } from 'lit';
-import { withCodeEditor } from '../../.storybook/addons/codeEditorAddon/codeAddon';
+import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
 
 export default {
-  title: 'Components / mgt-todo',
-  component: 'todo',
-  decorators: [withCodeEditor]
+  title: 'Components / mgt-tasks',
+  component: 'tasks',
+  decorators: [withCodeEditor],
+  parameters: {
+    docs: {
+      page: defaultDocsPage,
+      source: { code: '<mgt-tasks></mgt-tasks>' }
+    }
+  }
 };
 
 export const tasks = () => html`
-  <mgt-todo></mgt-todo>
-`;
-
-export const ReadOnly = () => html`
-  <mgt-todo read-only></mgt-todo>
+  <mgt-tasks></mgt-tasks>
 `;
 
 export const darkTheme = () => html`
-  <mgt-todo class="mgt-dark"></mgt-todo>
+  <mgt-tasks class="mgt-dark"></mgt-tasks>
   <style>
     body {
       background-color: black;

--- a/stories/components/teamsChannelPicker/teamsChannelPicker.a.js
+++ b/stories/components/teamsChannelPicker/teamsChannelPicker.a.js
@@ -7,11 +7,20 @@
 
 import { html } from 'lit';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { defaultDocsPage } from '../../../.storybook/story-elements/defaultDocsPage';
 
 export default {
   title: 'Components / mgt-teams-channel-picker',
   component: 'teams-channel-picker',
-  decorators: [withCodeEditor]
+  decorators: [withCodeEditor],
+  parameters: {
+    docs: {
+      page: defaultDocsPage,
+      source: {
+        code: '<mgt-teams-channel-picker></mgt-teams-channel-picker>'
+      }
+    }
+  }
 };
 
 export const teamsChannelPicker = () => html`

--- a/stories/components/todo/todo.stories.js
+++ b/stories/components/todo/todo.stories.js
@@ -6,20 +6,30 @@
  */
 
 import { html } from 'lit';
-import { withCodeEditor } from '../../.storybook/addons/codeEditorAddon/codeAddon';
+import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
 
 export default {
-  title: 'Components / mgt-tasks',
-  component: 'tasks',
-  decorators: [withCodeEditor]
+  title: 'Components / mgt-todo',
+  component: 'todo',
+  decorators: [withCodeEditor],
+  parameters: {
+    docs: {
+      page: defaultDocsPage,
+      source: { code: '<mgt-todo></mgt-todo>' }
+    }
+  }
 };
 
 export const tasks = () => html`
-  <mgt-tasks></mgt-tasks>
+  <mgt-todo></mgt-todo>
+`;
+
+export const ReadOnly = () => html`
+  <mgt-todo read-only></mgt-todo>
 `;
 
 export const darkTheme = () => html`
-  <mgt-tasks class="mgt-dark"></mgt-tasks>
+  <mgt-todo class="mgt-dark"></mgt-todo>
   <style>
     body {
       background-color: black;

--- a/stories/samples/editor.stories.js
+++ b/stories/samples/editor.stories.js
@@ -10,7 +10,10 @@ import { withCodeEditor } from '../../.storybook/addons/codeEditorAddon/codeAddo
 
 export default {
   title: 'Editor',
-  decorators: [withCodeEditor]
+  decorators: [withCodeEditor],
+  parameters: {
+    viewMode: 'story'
+  }
 };
 
 export const Editor = () => html`

--- a/stories/samples/general.stories.js
+++ b/stories/samples/general.stories.js
@@ -10,7 +10,10 @@ import { withCodeEditor } from '../../.storybook/addons/codeEditorAddon/codeAddo
 
 export default {
   title: 'Samples / General',
-  decorators: [withCodeEditor]
+  decorators: [withCodeEditor],
+  parameters: {
+    viewMode: 'story'
+  }
 };
 
 export const LoginToShowAgenda = () => html`

--- a/stories/samples/templating.stories.js
+++ b/stories/samples/templating.stories.js
@@ -11,7 +11,10 @@ import { withCodeEditor } from '../../.storybook/addons/codeEditorAddon/codeAddo
 export default {
   title: 'Samples / Templating',
   component: 'get',
-  decorators: [withCodeEditor]
+  decorators: [withCodeEditor],
+  parameters: {
+    viewMode: 'story'
+  }
 };
 
 export const PersonCardAdditionalDetails = () => html`


### PR DESCRIPTION
Closes #2124

### PR Type
- Bugfix 

### Description of the changes

Removes button that does nothing.

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
- [ ] Accessibility tested and approved
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

