### PR TITLE
fix: hide storybook canvas button

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -18,6 +18,9 @@ addParameters({
   previewTabs: {
     'storybook/docs/panel': {
       hidden: true
+    },
+    canvas: {
+      hidden: true
     }
   },
   docs: {


### PR DESCRIPTION
Closes #1642

### PR Type
- Bugfix 

### Description of the changes
Removes a button that does nothing.

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: N/A
- [ ] Accessibility tested and approved
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

