### PR TITLE
feat: optionally pass the group-id value from tasks to people picker

### DIFF
--- a/packages/mgt-components/src/graph/graph.user.ts
+++ b/packages/mgt-components/src/graph/graph.user.ts
@@ -258,8 +258,8 @@ export async function getUsersForUserIds(
       if (searchInput && Object.keys(peopleSearchMatches).length) {
         return Promise.all(Object.values(peopleSearchMatches));
       }
-      return Promise.all(Object.values(peopleDict));
     }
+    return Promise.all(Object.values(peopleDict));
   } catch (_) {
     // fallback to making the request one by one
     try {

--- a/stories/components/tasks/tasks.stories.js
+++ b/stories/components/tasks/tasks.stories.js
@@ -7,6 +7,7 @@
 
 import { html } from 'lit';
 import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+import { defaultDocsPage } from '../../../.storybook/story-elements/defaultDocsPage';
 
 export default {
   title: 'Components / mgt-tasks',
@@ -22,6 +23,10 @@ export default {
 
 export const tasks = () => html`
   <mgt-tasks></mgt-tasks>
+`;
+
+export const tasksWithGroupId = () => html`
+  <mgt-tasks group-id="45327068-6785-4073-8553-a750d6c16a45"></mgt-tasks>
 `;
 
 export const darkTheme = () => html`

--- a/stories/components/tasks/tasks.stories.js
+++ b/stories/components/tasks/tasks.stories.js
@@ -27,6 +27,12 @@ export const tasks = () => html`
 
 export const tasksWithGroupId = () => html`
   <mgt-tasks group-id="45327068-6785-4073-8553-a750d6c16a45"></mgt-tasks>
+  <!--
+    NOTE: the default tenant doesn't have the required Tasks.ReadWrite and
+    Group.ReadWrite.All permissions. Add &login=true to the URL and load to be
+    able to Sign In with your tenant. Lastly, you update the group-id to your
+    tenant group-id value for any group you want to try out.
+  -->
 `;
 
 export const darkTheme = () => html`


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #<!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

 - Bugfix
 - Feature 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
- Passed down the `group-id` vlue if it is set in `mgt-tasks`.
- Fixed storybook import bug for tasks.
- Fixed bug with returning null from `mgt-people` when there are no batch requests and the people values are fetched from the cache.
- Updated storybook for tasks with `group-id` story.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
