### PR TITLE
bug: remove mgt-spfx dependency from react webpart sample

### DIFF
--- a/samples/sp-webpart/package.json
+++ b/samples/sp-webpart/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@microsoft/mgt-element": "*",
     "@microsoft/mgt-react": "*",
-    "@microsoft/mgt-spfx": "*",
     "@microsoft/mgt-spfx-utils": "*",
     "@microsoft/mgt-sharepoint-provider": "*",
     "@microsoft/sp-core-library": "1.16.1",


### PR DESCRIPTION
Closes #2175 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
- Bugfix 

### Description of the changes
Removes mgt-spfx from sp-webpart dependencies as it's not being used with disambiguation

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information