### PR TITLE
feat: optionally pass the group-id value from tasks to people picker

### DIFF
--- a/packages/mgt-components/src/components/mgt-tasks/mgt-tasks.ts
+++ b/packages/mgt-components/src/components/mgt-tasks/mgt-tasks.ts
@@ -794,6 +794,15 @@ export class MgtTasks extends MgtTemplatedComponent {
     this.isNewTaskVisible = !this.isNewTaskVisible;
   }
 
+  private handleNewTaskDateChange(e: Event) {
+    const value = (e.target as HTMLInputElement).value;
+    if (value) {
+      this._newTaskDueDate = new Date(value + 'T17:00');
+    } else {
+      this._newTaskDueDate = null;
+    }
+  }
+
   private handleSelectedPlan(e: Event) {
     this._newTaskGroupId = (e.target as HTMLInputElement).value;
     if (this.dataSource === TasksSource.planner) {
@@ -1018,14 +1027,7 @@ export class MgtTasks extends MgtTemplatedComponent {
           aria-label="new-taskDate-input"
           role="textbox"
           .value="${this.dateToInputValue(this._newTaskDueDate)}"
-          @change="${(e: Event) => {
-            const value = (e.target as HTMLInputElement).value;
-            if (value) {
-              this._newTaskDueDate = new Date(value + 'T17:00');
-            } else {
-              this._newTaskDueDate = null;
-            }
-          }}"
+          @change="${this.handleNewTaskDateChange}"
         />
       </span>
     `;

--- a/packages/mgt-components/src/components/mgt-tasks/mgt-tasks.ts
+++ b/packages/mgt-components/src/components/mgt-tasks/mgt-tasks.ts
@@ -1302,10 +1302,7 @@ export class MgtTasks extends MgtTemplatedComponent {
       }
     }
 
-    // TODO(musale) when is groupId and targetId used? I use it here only for
-    // the creation of new tasks.
-    const newTaskGroupId = this.groupId || this._newTaskContainerId;
-    const planGroupId = this.isNewTaskVisible ? newTaskGroupId : assignedGroup;
+    const planGroupId = this.isNewTaskVisible ? this._newTaskContainerId : assignedGroup;
 
     assignedPeopleHTML = html`
       <mgt-people

--- a/packages/mgt-components/src/components/mgt-tasks/mgt-tasks.ts
+++ b/packages/mgt-components/src/components/mgt-tasks/mgt-tasks.ts
@@ -1271,7 +1271,7 @@ export class MgtTasks extends MgtTemplatedComponent {
 
   private renderAssignedPeople(task: ITask) {
     let assignedPeopleHTML = null;
-    let assignedGroup: string;
+    let assignedGroupId: string;
 
     const taskAssigneeClasses = {
       NewTaskAssignee: task === null,
@@ -1298,11 +1298,11 @@ export class MgtTasks extends MgtTemplatedComponent {
       const planId = task?._raw?.planId;
       if (planId) {
         const group = this._groups.filter(group => group.id === planId);
-        assignedGroup = group.pop()?.containerId;
+        assignedGroupId = group.pop()?.containerId;
       }
     }
 
-    const planGroupId = this.isNewTaskVisible ? this._newTaskContainerId : assignedGroup;
+    const planGroupId = this.isNewTaskVisible ? this._newTaskContainerId : assignedGroupId;
 
     assignedPeopleHTML = html`
       <mgt-people

--- a/packages/mgt-components/src/components/mgt-tasks/task-sources.ts
+++ b/packages/mgt-components/src/components/mgt-tasks/task-sources.ts
@@ -174,6 +174,14 @@ export interface ITaskGroup {
    * @memberof ITaskGroup
    */
   _raw?: any;
+
+  /**
+   * Plan Container ID. Same as the group ID of the group in the plan.
+   *
+   * @type {string}
+   * @memberof ITaskGroup
+   */
+  containerId?: string;
 }
 /**
  * A common interface for both planner and todo tasks
@@ -324,8 +332,9 @@ export class PlannerTaskSource extends TaskSourceBase implements ITaskSource {
    */
   public async getTaskGroups(): Promise<ITaskGroup[]> {
     const plans = await getAllMyPlannerPlans(this.graph);
-
-    return plans.map(plan => ({ id: plan.id, title: plan.title } as ITaskGroup));
+    return plans.map(
+      plan => ({ id: plan.id, title: plan.title, containerId: plan?.container?.containerId } as ITaskGroup)
+    );
   }
 
   /**

--- a/packages/mgt-components/src/graph/graph.user.ts
+++ b/packages/mgt-components/src/graph/graph.user.ts
@@ -10,7 +10,6 @@ import { User } from '@microsoft/microsoft-graph-types';
 
 import { findPeople, PersonType } from './graph.people';
 import { schemas } from './cacheStores';
-import { UserType } from '..';
 import { GraphRequest } from '@microsoft/microsoft-graph-client';
 
 /**
@@ -240,9 +239,9 @@ export async function getUsersForUserIds(
           cache.putValue(id, { user: JSON.stringify(user) });
         }
       }
-    }
-    if (searchInput && Object.keys(peopleSearchMatches).length) {
-      return Promise.all(Object.values(peopleSearchMatches));
+      if (searchInput && Object.keys(peopleSearchMatches).length) {
+        return Promise.all(Object.values(peopleSearchMatches));
+      }
     }
     return Promise.all(Object.values(peopleDict));
   } catch (_) {

--- a/packages/mgt-components/src/graph/graph.user.ts
+++ b/packages/mgt-components/src/graph/graph.user.ts
@@ -220,27 +220,29 @@ export async function getUsersForUserIds(
     }
   }
   try {
-    const responses = await batch.executeAll();
-    // iterate over userIds to ensure the order of ids
-    for (const id of userIds) {
-      const response = responses.get(id);
-      if (response && response.content) {
-        const user = response.content;
-        if (searchInput) {
-          const displayName = user?.displayName.toLowerCase();
-          if (displayName.contains(searchInput)) {
-            peopleSearchMatches[id] = user;
+    if (batch.hasRequests) {
+      const responses = await batch.executeAll();
+      // iterate over userIds to ensure the order of ids
+      for (const id of userIds) {
+        const response = responses.get(id);
+        if (response && response.content) {
+          const user = response.content;
+          if (searchInput) {
+            const displayName = user?.displayName.toLowerCase();
+            if (displayName.contains(searchInput)) {
+              peopleSearchMatches[id] = user;
+            }
+          } else {
+            peopleDict[id] = user;
           }
-        } else {
-          peopleDict[id] = user;
-        }
 
-        if (getIsUsersCacheEnabled()) {
-          cache.putValue(id, { user: JSON.stringify(user) });
+          if (getIsUsersCacheEnabled()) {
+            cache.putValue(id, { user: JSON.stringify(user) });
+          }
         }
-      }
-      if (searchInput && Object.keys(peopleSearchMatches).length) {
-        return Promise.all(Object.values(peopleSearchMatches));
+        if (searchInput && Object.keys(peopleSearchMatches).length) {
+          return Promise.all(Object.values(peopleSearchMatches));
+        }
       }
     }
     return Promise.all(Object.values(peopleDict));

--- a/stories/components/tasks.stories.js
+++ b/stories/components/tasks.stories.js
@@ -24,6 +24,12 @@ export const tasks = () => html`
 
 export const tasksWithGroupId = () => html`
   <mgt-tasks group-id="45327068-6785-4073-8553-a750d6c16a45"></mgt-tasks>
+  <!--
+    NOTE: the default tenant doesn't have the required Tasks.ReadWrite and
+    Group.ReadWrite.All permissions. Add &login=true to the URL and load to be
+    able to Sign In with your tenant. Lastly, you update the group-id to your
+    tenant group-id value for any group you want to try out.
+  -->
 `;
 
 export const darkTheme = () => html`

--- a/stories/components/tasks.stories.js
+++ b/stories/components/tasks.stories.js
@@ -25,10 +25,8 @@ export const tasks = () => html`
 export const tasksWithGroupId = () => html`
   <mgt-tasks group-id="45327068-6785-4073-8553-a750d6c16a45"></mgt-tasks>
   <!--
-    NOTE: the default tenant doesn't have the required Tasks.ReadWrite and
-    Group.ReadWrite.All permissions. Add &login=true to the URL and load to be
-    able to Sign In with your tenant. Lastly, you update the group-id to your
-    tenant group-id value for any group you want to try out.
+    NOTE: the default sandbox tenant doesn't have the required Tasks.ReadWrite and
+    Group.ReadWrite.All permissions. Test this component in your tenant.
   -->
 `;
 

--- a/stories/components/tasks.stories.js
+++ b/stories/components/tasks.stories.js
@@ -6,8 +6,8 @@
  */
 
 import { html } from 'lit-element';
-import { withCodeEditor } from '../../.storybook/addons/codeEditorAddon/codeAddon';
 import { versionInfo } from '../versionInfo';
+import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
 
 export default {
   parameters: {
@@ -20,6 +20,10 @@ export default {
 
 export const tasks = () => html`
   <mgt-tasks></mgt-tasks>
+`;
+
+export const tasksWithGroupId = () => html`
+  <mgt-tasks group-id="45327068-6785-4073-8553-a750d6c16a45"></mgt-tasks>
 `;
 
 export const darkTheme = () => html`

--- a/stories/components/tasks.stories.js
+++ b/stories/components/tasks.stories.js
@@ -6,8 +6,8 @@
  */
 
 import { html } from 'lit-element';
+import { withCodeEditor } from '../../.storybook/addons/codeEditorAddon/codeAddon';
 import { versionInfo } from '../versionInfo';
-import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
 
 export default {
   parameters: {


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2141 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

 - Bugfix
 - Feature 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
- Passed down the `group-id` vlue if it is set in `mgt-tasks`.
- Fixed storybook import bug for tasks.
- Fixed bug with returning null from `mgt-people` when there are no batch requests and the people values are fetched from the cache.
- Updated storybook for tasks with `group-id` story.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
