### PR TITLE
fix: voice over for person in list

### DIFF
--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -8,6 +8,7 @@
 import { Contact, Presence } from '@microsoft/microsoft-graph-types';
 import { customElement, html, internalProperty, property, TemplateResult } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map';
+import { ifDefined } from 'lit-html/directives/if-defined';
 import { findPeople, getEmailFromGraphEntity } from '../../graph/graph.people';
 import { getGroupImage, getPersonImage } from '../../graph/graph.photos';
 import { getUserPresence } from '../../graph/graph.presence';
@@ -586,7 +587,10 @@ export class MgtPerson extends MgtTemplatedComponent {
       };
 
       personTemplate = html`
-        <div class=${classMap(rootClasses)} tabindex="0">
+        <div 
+          class=${classMap(rootClasses)}
+          tabindex=${ifDefined(this.personCardInteraction === PersonCardInteraction.click ? '0' : undefined)}
+        >
           ${imageWithPresenceTemplate} ${detailsTemplate}
         </div>
       `;

--- a/stories/components/person/person.properties.js
+++ b/stories/components/person/person.properties.js
@@ -364,4 +364,26 @@ export const moreExamples = () => html`
       line2-property="officeLocation"
     ></mgt-person>
   </div>
+
+
+  <div>
+    <div>Lists of people</div>
+    <ul role="menu">
+      <li role="menuitem" data-is-focusable="true" class="ui-list__item" tabindex="0">
+        <mgt-person
+          person-query="me"
+          view="twoLines"
+          line2-property="jobTitle"
+        ></mgt-person>
+      </li>
+      <li role="menuitem" data-is-focusable="true" class="ui-list__item" tabindex="-1">
+        <mgt-person
+          user-id="2804bc07-1e1f-4938-9085-ce6d756a32d2"
+          view="twoLines"
+          line2-property="jobTitle"
+        ></mgt-person>
+      </li>
+    </ul>
+  </div>
+
 `;


### PR DESCRIPTION
Closes #2120

### PR Type
- Bugfix

### Description of the changes
Conditionally removes tabindex attribute allowing voice over to see inside the html for mgt-person when nested inside an html element with the role menuitem

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
