### PR TITLE
Add branch protection policy for next/* branches

### DIFF
--- a/.github/policies/branch-protection.yml
+++ b/.github/policies/branch-protection.yml
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: branch_protection_sdks
+description: Organization branch protection policy for Microsoft Graph Toolkit repository
+resource: repository
+configuration:
+  branchProtectionRules:
+  - branchNamePattern: next/*
+    requiredApprovingReviewsCount:
+      min: 1
+    # Must have a CODEOWNER approve for the PR to be merged.
+    requireCodeOwnersReview: true
+    
+    # Dismiss stale pull request approvals when new commits are pushed
+    dismissStaleReviews: true
+    
+    # Require conversation resolution before merging. Address all concerns, and resolve in the GitHub PR UI.
+    requiresConversationResolution: true
+
+    # Require status checks to pass before merging. TODO: this value should be true, we should work to support this.
+    # Used with the requiredStatusChecks setting to specify which checks must pass for the PR to be merged.
+    requiresStrictStatusChecks: true
+
+    requiredStatusChecks:
+    - GitOps/AdvancedSecurity
+    - license/cla
+    - Build pr
+    
+    # TODO: all commits should be signed. We need to get everyone signing their commits.
+    requiresCommitSignatures: false


### PR DESCRIPTION
I'm curious whether **Clean pr storybook** and **Deploy pr storybook** will optionally run? We should verify that these are skipped in a PR.

@gavinbarron can you verify that I have the correct required checks?

One thing we learned here is that we need to capture the required checks from branch protection UI before we change it here. Otherwise we need to review all of the GitHub workflows for applicability. Taking this  broadly, **before** we apply policy at the org-level for repos, we should capture the existing repo policy so that we are clear what we lose when the policy service clears the settings.  