### PR TITLE
chore: branch policy update

### DIFF
--- a/.github/policies/branch-protection.yml
+++ b/.github/policies/branch-protection.yml
@@ -25,7 +25,7 @@ configuration:
     requiredStatusChecks:
     - GitOps/AdvancedSecurity
     - license/cla
-    - Build pr
+    - 'Build pr / build (16.x)'
     
     # TODO: all commits should be signed. We need to get everyone signing their commits.
     requiresCommitSignatures: false


### PR DESCRIPTION
editing require status check to use full name of node 16.x build