### PR TITLE
chore: branch policy changes

### DIFF
--- a/.github/policies/branch-protection.yml
+++ b/.github/policies/branch-protection.yml
@@ -25,7 +25,7 @@ configuration:
     requiredStatusChecks:
     - GitOps/AdvancedSecurity
     - license/cla
-    - 'Build pr / build (16.x) (pull_request)'
+    - build (16.x)
     
     # TODO: all commits should be signed. We need to get everyone signing their commits.
     requiresCommitSignatures: false


### PR DESCRIPTION
change next/* protection policy check to use matrixed stage name for build stage on node 16

### PR Type
- Build or CI related changes

