### PR TITLE
fix: apply theme color to calendar icon of date input

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,13 +30,13 @@
   </head>
 
   <body>
-    <!-- <mgt-msal2-provider
+    <mgt-msal2-provider
       client-id="2dfea037-938a-4ed8-9b35-c05708a1b241"
       redirect-uri="http://localhost:3000"
       scopes="user.read,user.read.all,mail.readBasic,people.read,people.read.all,sites.read.all,user.readbasic.all,contacts.read,presence.read,presence.read.all,tasks.readwrite,tasks.read,calendars.read,group.read.all,files.read,files.read.all,files.readwrite,files.readwrite.all"
-    ></mgt-msal2-provider> -->
+    ></mgt-msal2-provider>
 
-    <mgt-mock-provider></mgt-mock-provider>
+    <!-- <mgt-mock-provider></mgt-mock-provider> -->
     <header>
       <mgt-theme-toggle></mgt-theme-toggle>
     </header>
@@ -50,26 +50,25 @@
       <!-- <mgt-person person-query="me" view="twoLines" person-card="click" show-presence></mgt-person> -->
       <mgt-person-card person-query="me"></mgt-person-card>
       <!-- <h2>mgt-people-picker</h2>
-      <mgt-people-picker></mgt-people-picker>
-      <h2>mgt-teams-channel-picker</h2>
-      <mgt-teams-channel-picker></mgt-teams-channel-picker>
+      <mgt-people-picker></mgt-people-picker> -->
+      <!-- <h2>mgt-teams-channel-picker</h2>
+      <mgt-teams-channel-picker></mgt-teams-channel-picker> -->
       <h2>mgt-tasks</h2>
       <mgt-tasks></mgt-tasks>
-      <h2>mgt-agenda group-by-day</h2>
-      <mgt-agenda group-by-day></mgt-agenda>
-      <h2>mgt-people show-presence</h2>
-      <mgt-people show-presence></mgt-people>
+      <!-- <h2>mgt-agenda group-by-day</h2>
+      <mgt-agenda group-by-day></mgt-agenda> -->
+      <!-- <h2>mgt-people show-presence</h2>
+      <mgt-people show-presence></mgt-people> -->
       <h2>mgt-todo</h2>
       <mgt-todo></mgt-todo>
-      <h2>mgt-file-list</h2>
-      <mgt-file-list></mgt-file-list>
-      <h2>mgt-picker</h2>
-      <mgt-picker resource="me/todo/lists" scopes="tasks.read, tasks.readwrite"></mgt-picker>
-      <h2>mgt-search-box</h2>
+      <!-- <h2>mgt-file-list</h2>
+      <mgt-file-list></mgt-file-list> -->
+      <!-- <h2>mgt-picker</h2>
+      <mgt-picker resource="me/todo/lists" scopes="tasks.read, tasks.readwrite"></mgt-picker> -->
+      <!-- <h2>mgt-search-box</h2>
       <mgt-search-box search-term="contoso"></mgt-search-box>
       <h2>mgt-search-results</h2>
-      <mgt-search-results query-string="contoso"></mgt-search-results>
-      <mgt-picker resource="me/todo/lists" scopes="tasks.read, tasks.readwrite"></mgt-picker> -->
+      <mgt-search-results query-string="contoso"></mgt-search-results> -->
     </main>
   </body>
 </html>

--- a/packages/mgt-components/src/components/CacheResponse.ts
+++ b/packages/mgt-components/src/components/CacheResponse.ts
@@ -1,3 +1,10 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
 import { CacheItem } from '@microsoft/mgt-element';
 
 /**

--- a/packages/mgt-components/src/components/mgt-messages/mgt-messages.theme.scss
+++ b/packages/mgt-components/src/components/mgt-messages/mgt-messages.theme.scss
@@ -1,3 +1,10 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
 @import '../../styles/shared-sass-variables.scss';
 
 $message-subject-color: var(--message-subject-color, var(--neutral-foreground-color));

--- a/packages/mgt-components/src/components/mgt-search-box/mgt-search-box.scss
+++ b/packages/mgt-components/src/components/mgt-search-box/mgt-search-box.scss
@@ -1,3 +1,10 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
 @import '../../styles/shared-styles.scss';
 
 :host fluent-search {

--- a/packages/mgt-components/src/components/mgt-search-results/mgt-search-results.scss
+++ b/packages/mgt-components/src/components/mgt-search-results/mgt-search-results.scss
@@ -1,3 +1,10 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
 @import '../../styles/shared-styles.scss';
 
 $answer-border-radius: var(--answer-border-radius, 4px);

--- a/packages/mgt-components/src/components/mgt-tasks/mgt-tasks.scss
+++ b/packages/mgt-components/src/components/mgt-tasks/mgt-tasks.scss
@@ -186,6 +186,15 @@ $task-new-dropdown-border-radius: var(--task-new-dropdown-border-radius, calc(va
               display: grid;
               grid-auto-flow: column;
               column-gap: 12px;
+              .TaskDue {
+                fluent-text-field {
+                  &.dark {
+                    &::part(control) {
+                      color-scheme: dark;
+                    }
+                  }
+                }
+              }
             }
           }
 

--- a/packages/mgt-components/src/components/mgt-tasks/mgt-tasks.ts
+++ b/packages/mgt-components/src/components/mgt-tasks/mgt-tasks.ts
@@ -33,6 +33,7 @@ import { styles } from './mgt-tasks-css';
 import { strings } from './strings';
 import { ITask, ITaskFolder, ITaskGroup, ITaskSource, PlannerTaskSource, TodoTaskSource } from './task-sources';
 import { getSvg, SvgIcon } from '../../utils/SvgHelper';
+import { isElementDark } from '../../utils/isDark';
 
 /**
  * Defines how a person card is shown when a user interacts with
@@ -413,7 +414,7 @@ export class MgtTasks extends MgtTemplatedComponent {
 
   @property() private _currentGroup: string;
   @property() private _currentFolder: string;
-
+  @state() private _isDarkMode = false;
   @state() private _me: User = null;
   private previousMediaQuery: ComponentMediaQuery;
 
@@ -432,6 +433,9 @@ export class MgtTasks extends MgtTemplatedComponent {
   public connectedCallback() {
     super.connectedCallback();
     window.addEventListener('resize', this.onResize);
+    window.addEventListener('darkmodechanged', this.onThemeChanged);
+    // invoked to ensure we have the correct initial value for _isDarkMode
+    this.onThemeChanged();
   }
 
   /**
@@ -441,6 +445,7 @@ export class MgtTasks extends MgtTemplatedComponent {
    */
   public disconnectedCallback() {
     window.removeEventListener('resize', this.onResize);
+    window.removeEventListener('darkmodechanged', this.onThemeChanged);
     super.disconnectedCallback();
   }
 
@@ -598,6 +603,10 @@ export class MgtTasks extends MgtTemplatedComponent {
       this.previousMediaQuery = this.mediaQuery;
       this.requestUpdate();
     }
+  };
+
+  private onThemeChanged = () => {
+    this._isDarkMode = isElementDark(this);
   };
 
   private async _loadTargetTodoTasks(ts: ITaskSource) {
@@ -1050,10 +1059,12 @@ export class MgtTasks extends MgtTemplatedComponent {
           ${folders.length > 0 ? folderOptions : html`<fluent-option selected>No folders found</fluent-option>`}
         </fluent-select>`;
 
+    const dateField = { dark: this._isDarkMode, NewTask: true };
+
     const taskDue = html`
       <fluent-text-field
         type="date"
-        class="NewTask"
+        class=${classMap(dateField)}
         aria-label="${this.strings.addTaskDate}"
         .value="${this.dateToInputValue(this._newTaskDueDate)}"
         @change=${this.handleDateChange}>

--- a/packages/mgt-components/src/components/mgt-tasks/task-sources.ts
+++ b/packages/mgt-components/src/components/mgt-tasks/task-sources.ts
@@ -1,10 +1,10 @@
-/* eslint-disable max-classes-per-file */
 /**
  * -------------------------------------------------------------------------------------------
  * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
  * See License in the project root for license information.
  * -------------------------------------------------------------------------------------------
  */
+/* eslint-disable max-classes-per-file */
 
 import { IGraph, BetaGraph } from '@microsoft/mgt-element';
 import { PlannerAssignments } from '@microsoft/microsoft-graph-types';

--- a/packages/mgt-components/src/components/mgt-theme-toggle/mgt-theme-toggle.ts
+++ b/packages/mgt-components/src/components/mgt-theme-toggle/mgt-theme-toggle.ts
@@ -95,7 +95,6 @@ class MgtThemeToggle extends MgtBaseComponent {
 
   private onSwitchChanged = (e: Event) => {
     this.darkModeActive = (e.target as HTMLInputElement).checked;
-    this.fireCustomEvent('darkmodechanged', this.darkModeActive);
   };
 
   private applyTheme(active: boolean) {
@@ -104,5 +103,6 @@ class MgtThemeToggle extends MgtBaseComponent {
 
     document.body.classList.remove('mgt-dark-mode', 'mgt-light-mode');
     document.body.classList.add(`mgt-${targetTheme}-mode`);
+    this.fireCustomEvent('darkmodechanged', this.darkModeActive, true, false, true);
   }
 }

--- a/packages/mgt-components/src/components/mgt-todo/mgt-todo.scss
+++ b/packages/mgt-components/src/components/mgt-todo/mgt-todo.scss
@@ -104,13 +104,20 @@
           fill: $task-color;
         }
 
-        .date {
-          margin-inline-start: 10px;
-          color: $task-color;
-          width: auto;
-          cursor: pointer;
-          &::after {
-            border-bottom: none;
+        fluent-text-field {
+          &.date {
+            margin-inline-start: 10px;
+            color: $task-color;
+            width: auto;
+            cursor: pointer;
+            &::after {
+              border-bottom: none;
+            }
+            &.dark {
+              &::part(control) {
+                color-scheme: dark;
+              }
+            }
           }
         }
 

--- a/packages/mgt-components/src/components/mgt-todo/mgt-todo.ts
+++ b/packages/mgt-components/src/components/mgt-todo/mgt-todo.ts
@@ -30,6 +30,7 @@ import { styles } from './mgt-todo-css';
 import { strings } from './strings';
 import { registerFluentComponents } from '../../utils/FluentComponents';
 import { fluentCheckbox, fluentRadioGroup, fluentButton } from '@fluentui/web-components';
+import { isElementDark } from '../../utils/isDark';
 
 registerFluentComponents(fluentCheckbox, fluentRadioGroup, fluentButton);
 
@@ -103,6 +104,7 @@ export class MgtTodo extends MgtTasksBase {
   private _isNewTaskBeingAdded: boolean;
   private _graph: IGraph;
   @state() private currentList: TodoTaskList;
+  @state() private _isDarkMode = false;
 
   constructor() {
     super();
@@ -113,6 +115,32 @@ export class MgtTodo extends MgtTasksBase {
     this._isLoadingTasks = false;
     this.addEventListener('selectionChanged', this.handleSelectionChanged);
   }
+
+  /**
+   * updates provider state
+   *
+   * @memberof MgtTasks
+   */
+  public connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener('darkmodechanged', this.onThemeChanged);
+    // invoked to ensure we have the correct initial value for _isDarkMode
+    this.onThemeChanged();
+  }
+
+  /**
+   * removes updates on provider state
+   *
+   * @memberof MgtTasks
+   */
+  public disconnectedCallback() {
+    window.removeEventListener('darkmodechanged', this.onThemeChanged);
+    super.disconnectedCallback();
+  }
+
+  private onThemeChanged = () => {
+    this._isDarkMode = isElementDark(this);
+  };
 
   /**
    * Render the list of todo tasks
@@ -214,12 +242,12 @@ export class MgtTodo extends MgtTasksBase {
         ${getSvg(SvgIcon.Cancel)}
       </fluent-button>
     `;
-
+    const dateClass = { dark: this._isDarkMode, date: true };
     const calendarTemplate = html`
       <fluent-text-field
         type="date"
         id="new-taskDate-input"
-        class="date"
+        class="${classMap(dateClass)}"
         aria-label="${this.strings.newTaskDateInputLabel}"
         .value="${this.dateToInputValue(this._newTaskDueDate)}"
         @change="${this.handleDateChange}">

--- a/packages/mgt-components/src/utils/isDark.ts
+++ b/packages/mgt-components/src/utils/isDark.ts
@@ -1,5 +1,18 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
 import { SwatchRGB, baseLayerLuminance, isDark } from '@fluentui/web-components';
 
+/**
+ * Utility to help quickly determine if an element is dark based fluentui theme
+ *
+ * @param element HTMLElement to check if dark
+ * @returns true if the element is dark
+ */
 export const isElementDark = (element: HTMLElement) => {
   const luminance = baseLayerLuminance.getValueFor(element);
   return isDark(SwatchRGB.create(luminance, luminance, luminance));

--- a/packages/mgt-components/src/utils/isDark.ts
+++ b/packages/mgt-components/src/utils/isDark.ts
@@ -1,0 +1,6 @@
+import { SwatchRGB, baseLayerLuminance, isDark } from '@fluentui/web-components';
+
+export const isElementDark = (element: HTMLElement) => {
+  const luminance = baseLayerLuminance.getValueFor(element);
+  return isDark(SwatchRGB.create(luminance, luminance, luminance));
+};

--- a/packages/mgt-element/src/CollectionResponse.ts
+++ b/packages/mgt-element/src/CollectionResponse.ts
@@ -1,4 +1,11 @@
 /**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
+/**
  * Holder type for collection responses
  *
  * @interface CollectionResponse

--- a/packages/mgt-element/src/mock/MockMiddleware.ts
+++ b/packages/mgt-element/src/mock/MockMiddleware.ts
@@ -1,3 +1,10 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
 import { Context, Middleware } from '@microsoft/microsoft-graph-client';
 import { SessionCache, storageAvailable } from '../utils/SessionCache';
 

--- a/packages/mgt-element/src/utils/BatchRequest.ts
+++ b/packages/mgt-element/src/utils/BatchRequest.ts
@@ -1,4 +1,11 @@
 /**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
+/**
  * Represents a request to be executed in a batch
  *
  * @class BatchRequest

--- a/packages/mgt-element/src/utils/CacheStore.ts
+++ b/packages/mgt-element/src/utils/CacheStore.ts
@@ -1,3 +1,10 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
 import { openDB } from 'idb';
 import { Providers } from '../providers/Providers';
 import { CacheItem, CacheSchema, dbListKey } from './CacheService';

--- a/packages/mgt-element/src/utils/LocalizationHelper.ts
+++ b/packages/mgt-element/src/utils/LocalizationHelper.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/tslint/config */
 /**
  * -------------------------------------------------------------------------------------------
  * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.

--- a/packages/mgt-element/src/utils/TeamsHelper.ts
+++ b/packages/mgt-element/src/utils/TeamsHelper.ts
@@ -1,3 +1,10 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
 // eslint-disable-next-line @typescript-eslint/tslint/config
 export interface loginContext {
   // eslint-disable-next-line @typescript-eslint/tslint/config


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2299  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
- Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

add a new utility to determine if an element should be considered to be in dark mode or not
set the color-scheme of date type inputs based on dark mode settings
adds event listeners to handle cases where the theme is changed and the date input needs to re-render

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
- [ ] Accessibility tested and approved
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
