### PR TITLE
fix: remove theme-toggle capability from custom CSS property and templating stories

### DIFF
--- a/.storybook/addons/codeEditorAddon/codeAddon.js
+++ b/.storybook/addons/codeEditorAddon/codeAddon.js
@@ -68,8 +68,8 @@ export const withCodeEditor = makeDecorator({
   name: `withCodeEditor`,
   parameterName: 'myParameter',
   skipIfNoParametersOrOptions: false,
-  wrapper: (getStory, context, { options }) => {
-    const disableThemeToggle = context &&  context.name === 'Custom CSS Properties';
+  wrapper: (getStory, context) => {
+    const disableThemeToggle = context &&  (context.name === 'Custom CSS Properties' || context.title.toLowerCase().includes('templating'));
     let story = getStory(context);
 
     let storyHtml;

--- a/.storybook/addons/codeEditorAddon/codeAddon.js
+++ b/.storybook/addons/codeEditorAddon/codeAddon.js
@@ -68,8 +68,11 @@ export const withCodeEditor = makeDecorator({
   name: `withCodeEditor`,
   parameterName: 'myParameter',
   skipIfNoParametersOrOptions: false,
-  wrapper: (getStory, context) => {
-    const disableThemeToggle = context &&  (context.name === 'Custom CSS Properties' || context.title.toLowerCase().includes('templating'));
+  wrapper: (getStory, context, { options }) => {
+    const forOptions = options ? options.disableThemeToggle : false;
+    const forContext =
+      context && (context.name === 'Custom CSS Properties' || context.title.toLowerCase().includes('templating'));
+    const disableThemeToggle = forOptions || forContext;
     let story = getStory(context);
 
     let storyHtml;

--- a/.storybook/addons/codeEditorAddon/codeAddon.js
+++ b/.storybook/addons/codeEditorAddon/codeAddon.js
@@ -69,7 +69,7 @@ export const withCodeEditor = makeDecorator({
   parameterName: 'myParameter',
   skipIfNoParametersOrOptions: false,
   wrapper: (getStory, context, { options }) => {
-    const disableThemeToggle = options ? options.disableThemeToggle : false;
+    const disableThemeToggle = context &&  context.name === 'Custom CSS Properties';
     let story = getStory(context);
 
     let storyHtml;

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,15 +1,3 @@
-<script src="https://az725175.vo.msecnd.net/scripts/jsll-4.js" type="text/javascript"></script>
-<script type="text/javascript">
-  var config = {
-    autoCapture: {
-      lineage: true
-    },
-    coreData: {
-      appId: 'JS:GraphToolkit'
-    }
-  };
-  awa.init(config);
-</script>
 <style>
   a {
     text-decoration: underline !important;

--- a/stories/components/agenda/agenda.style.js
+++ b/stories/components/agenda/agenda.style.js
@@ -23,7 +23,7 @@ export const darkTheme = () => html`
   </style>
 `;
 
-export const customProperties = () => html`
+export const customCSSProperties = () => html`
   <mgt-agenda group-by-day></mgt-agenda>
   <style>
     mgt-agenda {

--- a/stories/components/agenda/agenda.style.js
+++ b/stories/components/agenda/agenda.style.js
@@ -23,7 +23,7 @@ export const darkTheme = () => html`
   </style>
 `;
 
-export const customProperties = () => html`
+export const customCSSProperties = () => html`
   <mgt-agenda class="agenda" group-by-day></mgt-agenda>
   <style>
     .agenda {

--- a/stories/components/login/login.styles.js
+++ b/stories/components/login/login.styles.js
@@ -18,7 +18,7 @@ export const darkTheme = () => html`
   <mgt-login class="mgt-dark"></mgt-login>
 `;
 
-export const customCssProperties = () => html`
+export const customCSSProperties = () => html`
 <mgt-login class="login"></mgt-login>
 <style>
   .login {

--- a/stories/components/login/login.styles.js
+++ b/stories/components/login/login.styles.js
@@ -18,7 +18,7 @@ export const darkTheme = () => html`
   <mgt-login class="mgt-dark"></mgt-login>
 `;
 
-export const customCssProperties = () => html`
+export const customCSSProperties = () => html`
 <mgt-login></mgt-login>
 <style>
   mgt-login {

--- a/stories/components/people/people.styles.js
+++ b/stories/components/people/people.styles.js
@@ -23,7 +23,7 @@ export const darkTheme = () => html`
  </style>
 `;
 
-export const customCssProperties = () => html`
+export const customCSSProperties = () => html`
 <mgt-people></mgt-people>
 <style>
   mgt-people {

--- a/stories/components/people/people.styles.js
+++ b/stories/components/people/people.styles.js
@@ -23,7 +23,7 @@ export const darkTheme = () => html`
  </style>
 `;
 
-export const customCssProperties = () => html`
+export const customCSSProperties = () => html`
 <mgt-people class="people"></mgt-people>
 <style>
   .people {

--- a/stories/components/peoplePicker/peoplePicker.style.js
+++ b/stories/components/peoplePicker/peoplePicker.style.js
@@ -17,7 +17,7 @@ export default {
 export const darkTheme = () => html`
   <mgt-people-picker class="mgt-dark"></mgt-people-picker>`;
 
-export const customCssProperties = () => html`
+export const customCSSProperties = () => html`
 <mgt-people-picker></mgt-people-picker>
 <style>
   mgt-people-picker {

--- a/stories/components/peoplePicker/peoplePicker.style.js
+++ b/stories/components/peoplePicker/peoplePicker.style.js
@@ -17,7 +17,7 @@ export default {
 export const darkTheme = () => html`
   <mgt-people-picker class="mgt-dark"></mgt-people-picker>`;
 
-export const customCssProperties = () => html`
+export const customCSSProperties = () => html`
 <mgt-people-picker class="people-picker"></mgt-people-picker>
 <style>
   .people-picker {

--- a/stories/components/tasks/tasks.style.js
+++ b/stories/components/tasks/tasks.style.js
@@ -21,7 +21,7 @@ export default {
   }
 };
 
-export const CustomCSSProperties = () => html`
+export const customCSSProperties = () => html`
   <style>
     mgt-tasks {
         --tasks-header-padding: 28px 14px;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2240  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Removes the theme toggle from the custom CSS properties story and templating pages. These pages are customized hence we default to a light mode in the playground.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
- [x] Accessibility tested and approved
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
