### PR TITLE
feat: add custom focus ring color

### DIFF
--- a/packages/mgt-components/src/components/mgt-login/mgt-login.scss
+++ b/packages/mgt-components/src/components/mgt-login/mgt-login.scss
@@ -60,10 +60,6 @@ mgt-login .login-button {
     border-radius: 4px;
   }
 
-  &:focus {
-    outline: 0;
-  }
-
   &:disabled {
     opacity: 0.4;
     pointer-events: none;
@@ -74,7 +70,7 @@ mgt-login .login-button {
   }
 
   &:focus-visible {
-    outline: auto;
+    outline-style: $focus-ring-style;
   }
 }
 

--- a/packages/mgt-components/src/styles/shared-styles.scss
+++ b/packages/mgt-components/src/styles/shared-styles.scss
@@ -5,6 +5,8 @@
  * -------------------------------------------------------------------------------------------
  */
 
+$focus-ring-style: var(--focus-ring-style, auto);
+
 :host([hidden]) {
   display: none;
 }
@@ -17,7 +19,15 @@
   --theme-primary-color: #0078d7;
   --theme-dark-color: #005a9e;
 }
-
+:focus-visible {
+  // ensure default is correctly set for Firefox
+  outline-color: var(--focus-ring-color, Highlight);
+  // ensure default is set for other browsers
+  outline-color: var(--focus-ring-color, -webkit-focus-ring-color);
+  // set the style of the focus ring
+  // this needs to be something other than auto in Firefox to use the custom color
+  outline-style: $focus-ring-style;
+}
 .ms-Icon {
   display: inline-block;
   font-family: 'FabricMDL2Icons';

--- a/stories/samples/general.stories.js
+++ b/stories/samples/general.stories.js
@@ -166,10 +166,10 @@ export const cache = () => html`
   </script>
 `;
 export const theme = () => html`
-  <div class="mgt-light">
+  <div class="mgt-light root">
     <header class="mgt-dark">
       <p>I should be dark, regional class</p>
-      <mgt-teams-channel-picker></mgt-teams-channel-picker>
+      <mgt-people-picker></mgt-people-picker>
       <div class="mgt-light">
         <p>I should be light, second level regional class</p>
         <mgt-teams-channel-picker></mgt-teams-channel-picker>
@@ -187,6 +187,10 @@ export const theme = () => html`
     <mgt-teams-channel-picker class="mgt-foo"></mgt-teams-channel-picker>
   </div>
   <style>
+    .root {
+      --focus-ring-color: red;
+      --focus-ring-style: solid;
+    }
     .custom1 {
       --input-border: 2px solid teal;
       --input-background-color: #33c2c2;


### PR DESCRIPTION
Closes #2286 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type

- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

adds the ability for developers to define the color used for the focus ring
requires the developer to set the --focus-ring-style for application in Firefox
uses the General > Theme story as a working example

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
