### PR TITLE
fix: include mgt-mock-provider as dependency to mgt

### DIFF
--- a/packages/mgt/package.json
+++ b/packages/mgt/package.json
@@ -47,7 +47,8 @@
     "@microsoft/mgt-components": "*",
     "@microsoft/mgt-proxy-provider": "*",
     "@microsoft/mgt-sharepoint-provider": "*",
-    "@microsoft/mgt-msal2-provider": "*"
+    "@microsoft/mgt-msal2-provider": "*",
+    "@microsoft/mgt-mock-provider": "*"
   },
   "devDependencies": {
     "@webcomponents/webcomponentsjs": "^2.5.0"


### PR DESCRIPTION
Closes #2333 

### PR Type

- Bugfix 

### Description of the changes

Adds @microsoft/mgt-mock-provider as a dependency in package.json of @microsoft/mgt

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes
