### PR TITLE
fix: set react peer dependency as range

### DIFF
--- a/packages/mgt-element/src/utils/version.ts
+++ b/packages/mgt-element/src/utils/version.ts
@@ -8,4 +8,4 @@
 // THIS FILE IS AUTO GENERATED
 // ANY CHANGES WILL BE LOST DURING BUILD
 
-export const PACKAGE_VERSION = '3.0.0-preview.2';
+export const PACKAGE_VERSION = '3.0.0-rc.1';

--- a/packages/mgt-react/package.json
+++ b/packages/mgt-react/package.json
@@ -41,8 +41,8 @@
     "wc-react": "^0.5.0"
   },
   "peerDependencies": {
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^17.0.1 || ^18.0.0",
+    "react-dom": "^17.0.1 || ^18.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Closes #2392

### PR Type
 - Bugfix 

### Description of the changes

Set semver range for React peer dependency
This is linked to #2063

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information

The semver range of ^17.0.1 || ^18.0.0 was tested using https://semver.npmjs.com/