### PR TITLE
fix: using mgt-search-results instead of mgt-search-box

### DIFF
--- a/stories/components/preview/searchBox/searchBox.a.js
+++ b/stories/components/preview/searchBox/searchBox.a.js
@@ -48,9 +48,9 @@ export const events = () => html`
   <script>
     import '@microsoft/mgt-components/dist/es6/components/preview';
     const searchBox = document.querySelector('mgt-search-box');
-    const searchResults = document.querySelector('mgt-search-box');
+    const searchResults = document.querySelector('mgt-search-results');
     searchBox.addEventListener('searchTermChanged', (e) => {
       searchResults.queryString = e.detail;
-    })
+    });
   </script>
 `;


### PR DESCRIPTION
Closes #2394

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

### Description of the changes
Switching to `mgt-search-results` in the selector

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes