### PR TITLE
fix: make spfx version script work for rc version

### DIFF
--- a/scripts/setVersion.js
+++ b/scripts/setVersion.js
@@ -44,6 +44,10 @@ const updateSpfxSolutionVersion = (solutions, version) => {
   if (isPreview) {
     version = version.replace(/-preview\./, '.');
   }
+  const isRC = version.indexOf('-rc') > 0;
+  if (isRC) {
+    version = version.replace(/-rc\./, '.');
+  }
   for (let solution of solutions) {
     console.log(`updating spfx solution ${solution} with version ${version}`);
     const data = fs.readFileSync(solution, 'utf8');


### PR DESCRIPTION
Fix to spfx publishing script to allow for correct publishing when version being published uses the `-rc.*`  suffix