### PR TITLE
fix(a11y): set aria-expanded for mgt-login when open/closed

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,11 @@
         font-family: var(--body-font);
         padding: 24px 12px;
       }
+      .right-align {
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-end;
+      }
     </style>
   </head>
 
@@ -44,7 +49,9 @@
     <h1>Developer test page</h1>
     <main>
       <h2>mgt-login</h2>
-      <mgt-login login-view="compact"></mgt-login>
+      <div class="right-align">
+        <mgt-login login-view="compact"></mgt-login>
+      </div>
       <mgt-login></mgt-login>
       <h2>mgt-person me query two lines card on click with presence</h2>
       <!-- <mgt-person person-query="me" view="twoLines" person-card="click" show-presence></mgt-person> -->

--- a/packages/mgt-components/src/components/mgt-login/mgt-login.ts
+++ b/packages/mgt-components/src/components/mgt-login/mgt-login.ts
@@ -8,6 +8,7 @@
 import { CSSResult, html, TemplateResult } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import {
   Providers,
   ProviderState,
@@ -166,7 +167,7 @@ export class MgtLogin extends MgtTemplatedComponent {
    * @private
    * @type {boolean}
    */
-  @property({ attribute: false }) private _isFlyoutOpen: boolean;
+  @state() private _isFlyoutOpen: boolean;
 
   /**
    * The image blob string
@@ -319,13 +320,14 @@ export class MgtLogin extends MgtTemplatedComponent {
       small: this.loginView === 'avatar'
     });
     const appearance = isSignedIn ? 'stealth' : 'neutral';
-    const buttonContentTemplate =
-      isSignedIn && this.userDetails
-        ? this.renderSignedInButtonContent(this.userDetails, this._image)
-        : this.renderSignedOutButtonContent();
-
+    const showSignedInState = isSignedIn && this.userDetails;
+    const buttonContentTemplate = showSignedInState
+      ? this.renderSignedInButtonContent(this.userDetails, this._image)
+      : this.renderSignedOutButtonContent();
+    const expandedState: boolean | undefined = showSignedInState ? this._isFlyoutOpen : undefined;
     return html`
       <fluent-button
+        aria-expanded="${ifDefined(expandedState)}"
         appearance=${appearance}
         aria-label=${ariaLabel}
         ?disabled=${this.isLoadingState}

--- a/packages/mgt-components/src/components/sub-components/mgt-flyout/mgt-flyout.ts
+++ b/packages/mgt-components/src/components/sub-components/mgt-flyout/mgt-flyout.ts
@@ -244,7 +244,17 @@ export class MgtFlyout extends MgtBaseComponent {
     `;
   }
 
-  private updateFlyout() {
+  /**
+   * Updates the position of the flyout.
+   * Makes a second recursive call to ensure the flyout is positioned correctly.
+   * This is needed as the width of the flyout is not settled until afer the first render.
+   *
+   * @private
+   * @param {boolean} [firstPass=true]
+   * @return {*}
+   * @memberof MgtFlyout
+   */
+  private updateFlyout(firstPass = true) {
     if (!this.isOpen) {
       return;
     }
@@ -413,6 +423,9 @@ export class MgtFlyout extends MgtBaseComponent {
       } else {
         flyout.style.maxHeight = null;
         flyout.style.setProperty('--mgt-flyout-set-height', 'unset');
+      }
+      if (firstPass) {
+        window.requestAnimationFrame(() => this.updateFlyout(false));
       }
     }
   }

--- a/stories/components/login/login.stories.js
+++ b/stories/components/login/login.stories.js
@@ -37,6 +37,19 @@ export const ShowPresenceLogin = () => html`
   <mgt-login show-presence login-view="full"></mgt-login>
 `;
 
+export const RightAligned = () => html`
+<div class="right">
+    <mgt-login login-view="compact"></mgt-login>
+</div>
+<style>
+.right {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+}
+</style>
+`;
+
 export const Templates = () => html`
   <mgt-login>
     <template data-type="signed-out-button-content">


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2269 
Closes #2354 

### PR Type
- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Sets the aria-expanded attribute of the button rendered when a user is signed in

Fixes the positioning of the pop-up when the button is on the right of the screen and is narrower than the pop-up

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
- [X] Accessibility tested and approved
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
