### PR TITLE
fix: revert dot-options to use fluent controls

### DIFF
--- a/packages/mgt-components/src/components/sub-components/mgt-dot-options/mgt-dot-options.ts
+++ b/packages/mgt-components/src/components/sub-components/mgt-dot-options/mgt-dot-options.ts
@@ -79,15 +79,14 @@ export class MgtDotOptions extends MgtBaseComponent {
     const menuOptions = Object.keys(this.options);
 
     return html`
-      <div tabindex="0" class=${classMap({ 'dot-menu': true, open: this.open })}
+      <fluent-button
+        appearance="stealth"
         @click=${this.onDotClick}
-        @keydown=${this.onDotKeydown}>
-        <span class="dot-icon">\uE712</span>
-        <div tabindex="0" class="menu">
-          ${Object.keys(this.options).map(prop => this.getMenuOption(prop, this.options[prop]))}
-        </div>
-      </div>
-    `;
+        @keydown=${this.onDotKeydown}
+        class="DotIcon">\uE712</fluent-button>
+      <fluent-menu class=${classMap({ Menu: true, Open: this.open })}>
+        ${menuOptions.map(opt => this.getMenuOption(opt, this.options[opt]))}
+      </fluent-menu>`;
   }
 
   private handleItemClick = (e: MouseEvent, fn: MenuOptionEventFunction) => {
@@ -113,24 +112,9 @@ export class MgtDotOptions extends MgtBaseComponent {
    */
   public getMenuOption(name: string, clickFn: (e: Event) => void | any) {
     return html`
-      <div
-        class="dot-item"
-        @click="${(e: Event) => {
-          e.preventDefault();
-          e.stopPropagation();
-          clickFn(e);
-          this.open = false;
-        }}"
-        @keydown="${(e: KeyboardEvent) => {
-          if (e.code === 'Enter' || e.code === 'Space') {
-            e.preventDefault();
-            e.stopPropagation();
-            clickFn(e);
-            this.open = false;
-          }
-        }}"
-      >
-        <span class="dot-item-name">
+      <fluent-menu-item
+        @click=${(e: MouseEvent) => this.handleItemClick(e, clickFn)}
+        @keydown=${(e: KeyboardEvent) => this.handleItemKeydown(e, clickFn)}>
           ${name}
       </fluent-menu-item>`;
   }

--- a/packages/mgt-components/src/components/sub-components/mgt-dot-options/mgt-dot-options.ts
+++ b/packages/mgt-components/src/components/sub-components/mgt-dot-options/mgt-dot-options.ts
@@ -83,7 +83,7 @@ export class MgtDotOptions extends MgtBaseComponent {
         appearance="stealth"
         @click=${this.onDotClick}
         @keydown=${this.onDotKeydown}
-        class="DotIcon">\uE712</fluent-button>
+        class="dot-icon">\uE712</fluent-button>
       <fluent-menu class=${classMap({ Menu: true, Open: this.open })}>
         ${menuOptions.map(opt => this.getMenuOption(opt, this.options[opt]))}
       </fluent-menu>`;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2423  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type

- Bugfix 

### Description of the changes

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
