### PR TITLE
fix: max picker list height

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
       <mgt-todo></mgt-todo>
       <!-- <h2>mgt-file-list</h2>
       <mgt-file-list></mgt-file-list> -->
+      <mgt-picker resource="me/messages" scopes="mail.read" placeholder="Select a message" key-name="subject" max-pages="5"></mgt-picker>
       <!-- <h2>mgt-picker</h2>
       <mgt-picker resource="me/todo/lists" scopes="tasks.read, tasks.readwrite"></mgt-picker> -->
       <!-- <h2>mgt-search-box</h2>

--- a/packages/mgt-components/src/components/mgt-picker/mgt-picker.scss
+++ b/packages/mgt-components/src/components/mgt-picker/mgt-picker.scss
@@ -10,12 +10,13 @@
 @import './mgt-picker.theme';
 
 :host {
+  --max-height: var(--picker-max-height, 380px);
+  
   font-family: $font-family;
-}
 
-:host .picker,
-mgt-picker .picker {
-  background-color: $picker-background-color;
+ .picker {
+    background-color: $picker-background-color;
+  }
 }
 
 [dir='rtl'] {

--- a/packages/mgt-components/src/components/mgt-picker/mgt-picker.ts
+++ b/packages/mgt-components/src/components/mgt-picker/mgt-picker.ts
@@ -28,7 +28,7 @@ registerFluentComponents(fluentCombobox, fluentOption);
  * @extends {MgtTemplatedComponent}
  *
  * @cssprop --picker-background-color - {Color} Picker component background color
- * @cssprop --picker-list-max-height - {String} max height for options list
+ * @cssprop --picker-list-max-height - {String} max height for options list. Default value is 380px.
  */
 @customElement('picker')
 export class MgtPicker extends MgtTemplatedComponent {

--- a/packages/mgt-components/src/components/mgt-picker/mgt-picker.ts
+++ b/packages/mgt-components/src/components/mgt-picker/mgt-picker.ts
@@ -15,6 +15,7 @@ import { registerFluentComponents } from '../../utils/FluentComponents';
 import '../../styles/style-helper';
 import { Entity } from '@microsoft/microsoft-graph-types';
 import { DataChangedDetail } from '../mgt-get/mgt-get';
+import { styles } from './mgt-picker-css';
 
 registerFluentComponents(fluentCombobox, fluentOption);
 
@@ -27,11 +28,16 @@ registerFluentComponents(fluentCombobox, fluentOption);
  * @extends {MgtTemplatedComponent}
  *
  * @cssprop --picker-background-color - {Color} Picker component background color
+ * @cssprop --picker-list-max-height - {String} max height for options list
  */
 @customElement('picker')
 export class MgtPicker extends MgtTemplatedComponent {
   protected get strings() {
     return strings;
+  }
+
+  public static get styles() {
+    return styles;
   }
 
   /**


### PR DESCRIPTION
Closes #2421 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type

 - Bugfix 
 
### Description of the changes

adds a new variable to set the max height of the mgt-picker list defaults the max height of the mgt-picker list to 380px

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: [Link to docs PR here](https://github.com/microsoftgraph/microsoft-graph-docs/pull/21609)
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
