### PR TITLE
fix: remove mgt-agenda background colour

### DIFF
--- a/packages/mgt-components/src/components/mgt-agenda/mgt-agenda.theme.scss
+++ b/packages/mgt-components/src/components/mgt-agenda/mgt-agenda.theme.scss
@@ -11,8 +11,8 @@ $agenda-event-subject-color: var(--agenda-event-subject-color, var(--neutral-for
 $agenda-event-location-color: var(--agenda-event-location-color, var(--neutral-foreground-rest));
 $agenda-event-attendees-color: var(--agenda-event-attendees-color, var(--neutral-foreground-rest));
 $agenda-header-color: var(--agenda-header-color, var(--neutral-foreground-rest));
-$agenda-background-color: var(--agenda-background-color, var(--neutral-layer-floating));
+$agenda-background-color: var(--agenda-background-color, transparent);
 $agenda-header-background-color: var(--agenda-header-background-color, var(--neutral-layer-floating));
 $agenda-header-border-color: var(--agenda-header-border-color, var(--neutral-foreground-rest));
-$agenda-event-background-color: var(--agenda-event-border-color, var(--neutral-layer-floating));
-$agenda-event-background-color: var(--agenda-event-background-color, var(--neutral-layer-floating));
+$agenda-event-border-color: var(--agenda-event-border-color, var(--neutral-layer-floating));
+$agenda-event-background-color: var(--agenda-event-background-color, transparent);

--- a/stories/components/agenda/agenda.style.js
+++ b/stories/components/agenda/agenda.style.js
@@ -15,9 +15,10 @@ export default {
 };
 
 export const customCSSProperties = () => html`
-  <mgt-agenda group-by-day></mgt-agenda>
+  <mgt-agenda class="agenda" group-by-day></mgt-agenda>
   <style>
     .agenda {
+      --agenda-background-color: aquamarine;
       --agenda-event-box-shadow: 0px 2px 30px pink;
       --agenda-event-margin: 0px 10px 40px 10px;
       --agenda-event-padding: 8px 0px;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2455  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Removes mgt-agenda background color
### PR checklist
- [ ] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
