### PR TITLE
fix: styling of nested disambiguated components

### DIFF
--- a/packages/mgt-components/src/components/mgt-agenda/mgt-agenda.scss
+++ b/packages/mgt-components/src/components/mgt-agenda/mgt-agenda.scss
@@ -19,7 +19,6 @@ $agenda-event-time-font-size: var(--agenda-event-time-font-size, 12px);
 $agenda-event-subject-font-size: var(--agenda-event-subject-font-size, 20px);
 $agenda-event-location-font-size: var(--agenda-event-location-font-size, 12px);
 
-mgt-agenda,
 :host {
   --card-height: auto;
   --card-width: 99%;
@@ -187,7 +186,7 @@ fluent-card.event {
   }
 }
 
-:host mgt-people {
+:host .event-attendees {
   --color: $agenda-event-attendees-color;
 }
 
@@ -211,8 +210,7 @@ fluent-card.event {
 }
 
 @media (forced-colors: active) and (prefers-color-scheme: dark) {
-  :host,
-  mgt-agenda {
+  :host {
     .agenda {
       .event {
         &-location-container {
@@ -232,8 +230,7 @@ fluent-card.event {
 }
 
 @media (forced-colors: active) and (prefers-color-scheme: light) {
-  :host,
-  mgt-agenda {
+  :host {
     .agenda {
       .event {
         &-location-container {

--- a/packages/mgt-components/src/components/mgt-file/mgt-file.scss
+++ b/packages/mgt-components/src/components/mgt-file/mgt-file.scss
@@ -36,8 +36,7 @@ $line3-text-transform: var(--file-line3-text-transform, initial);
   background-color: $file-background-color;
 }
 
-:host .item,
-mgt-file .item {
+:host .item {
   display: flex;
   flex-flow: row nowrap;
   align-items: center;

--- a/packages/mgt-components/src/components/mgt-login/mgt-login.scss
+++ b/packages/mgt-components/src/components/mgt-login/mgt-login.scss
@@ -17,17 +17,15 @@ $login-popup-background-color: #{var(--login-popup-background-color, var(--neutr
 $button-padding: var(--login-button-padding, 0);
 
 :host {
-  mgt-person {
-    &.signed-in-person {
-      --person-background-color: $signed-in-background-color;
+  .signed-in-person {
+    --person-background-color: $signed-in-background-color;
 
-      padding: var(--login-button-padding, 10px 16px);
-    }
+    padding: var(--login-button-padding, 10px 16px);
+  }
 
-    &.account {
-      padding: 0;
-      margin: 7px 0;
-    }
+  .account {
+    padding: 0;
+    margin: 7px 0;
   }
 
   fluent-button {
@@ -84,7 +82,7 @@ $button-padding: var(--login-button-padding, 0);
 
   .login-root {
     .small {
-      mgt-person {
+      .signed-in-person {
         padding: 0;
         background: transparent;
 
@@ -112,7 +110,6 @@ $button-padding: var(--login-button-padding, 0);
       }
     }
 
-    mgt-flyout,
     .flyout {
       .flyout-command {
         color: var(--accent-foreground-rest);

--- a/packages/mgt-components/src/components/mgt-people/mgt-people.scss
+++ b/packages/mgt-components/src/components/mgt-people/mgt-people.scss
@@ -9,8 +9,7 @@
 @import '../../styles/shared-styles';
 @import './mgt-people.theme';
 
-:host .people-list,
-mgt-people .people-list {
+:host .people-list {
   list-style: none;
   margin: var(--people-list-margin, 8px 4px 8px 8px);
   padding: unset;
@@ -19,8 +18,7 @@ mgt-people .people-list {
   gap: var(--people-avatar-gap, 4px);
 }
 
-:host .overflow,
-mgt-people .overflow {
+:host .overflow {
   span {
     vertical-align: middle;
     color: var(--people-overflow-font-color, currentColor);

--- a/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.scss
+++ b/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.scss
@@ -439,9 +439,7 @@ $person-card-base-icons-left-spacing: var(--person-card-base-icons-left-spacing,
 }
 
 :host .person-root.large,
-:host .person-root.threelines,
-:host mgt-person.person-root.large,
-:host mgt-person.person-root.threelines {
+:host .person-root.threelines {
   --person-avatar-size-3-lines: 75px;
 }
 

--- a/packages/mgt-components/src/components/mgt-person/mgt-person.scss
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.scss
@@ -42,7 +42,7 @@ $person-line4-text-line-height: var(--person-line4-text-line-height, 16px);
   font-size: var(--default-font-size);
   font-family: var(--default-font-family);
 
-  mgt-flyout {
+  .flyout {
     [slot='anchor'] {
       display: flex;
 
@@ -57,8 +57,7 @@ $person-line4-text-line-height: var(--person-line4-text-line-height, 16px);
     }
   }
 
-  .person-root,
-  mgt-person .person-root {
+  .person-root {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -258,9 +257,7 @@ $person-line4-text-line-height: var(--person-line4-text-line-height, 16px);
 
 @media (forced-colors: active) and (prefers-color-scheme: dark) {
   :host svg,
-  :host svg > path,
-  mgt-person svg,
-  mgt-person svg > path {
+  :host svg > path {
     fill: rgb(255 255 255) !important;
     fill-rule: nonzero !important;
     clip-rule: nonzero !important;
@@ -269,9 +266,7 @@ $person-line4-text-line-height: var(--person-line4-text-line-height, 16px);
 
 @media (forced-colors: active) and (prefers-color-scheme: dark) {
   :host svg,
-  :host svg > path,
-  mgt-person svg,
-  mgt-person svg > path {
+  :host svg > path {
     fill: rgb(0 0 0) !important;
     fill-rule: nonzero !important;
     clip-rule: nonzero !important;

--- a/packages/mgt-components/src/components/mgt-tasks/mgt-tasks.scss
+++ b/packages/mgt-components/src/components/mgt-tasks/mgt-tasks.scss
@@ -438,7 +438,7 @@ $task-new-dropdown-border-radius: var(--task-new-dropdown-border-radius, calc(va
     }
   }
 
-  mgt-people {
+  .people {
     [slot='no-data'] {
       margin-top: 8px;
       color: $task-new-person-icon-text-color;

--- a/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.scss
+++ b/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.scss
@@ -9,8 +9,7 @@
 @import '../../styles/shared-styles';
 @import './mgt-teams-channel-picker.theme';
 
-:host,
-:host mgt-teams-channel-picker {
+:host {
   font-family: $font-family;
 
   .container {
@@ -66,9 +65,7 @@
       margin: auto;
     }
   }
-}
 
-:host {
   fluent-card {
     background: $dropdown-background-color;
 

--- a/samples/sp-webpart/.eslintrc.js
+++ b/samples/sp-webpart/.eslintrc.js
@@ -1,5 +1,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
   module.exports = {
     extends: ['@microsoft/eslint-config-spfx/lib/profiles/default'],
-    parserOptions: { tsconfigRootDir: __dirname }
+    parserOptions: { tsconfigRootDir: __dirname },
+    rules: {
+      '@typescript-eslint/no-empty-function': 'off',
+      '@typescript-eslint/no-extra-semi': 'off',
+    }
   };

--- a/samples/sp-webpart/config/package-solution.json
+++ b/samples/sp-webpart/config/package-solution.json
@@ -3,7 +3,7 @@
   "solution": {
     "name": "mgt-demo-client-side-solution",
     "id": "b0ed193e-b333-4796-b249-e34916ef7a85",
-    "version": "1.3.0.0",
+    "version": "1.4.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false,


### PR DESCRIPTION
Closes #2468  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
- Bugfix 

### Description of the changes

removes all mgt-* tag selectors from scss and uses classes instead to ensure that when developers use disambiguation styling is not broken

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
