### PR TITLE
fix: Returning a JSON parsed version of the cache for insights types

### DIFF
--- a/packages/mgt-components/src/graph/graph.files.ts
+++ b/packages/mgt-components/src/graph/graph.files.ts
@@ -413,7 +413,7 @@ export const getMyInsightsFiles = async (graph: IGraph, insightType: string): Pr
   const cache: CacheStore<CacheFileList> = CacheService.getCache<CacheFileList>(schemas.fileLists, cacheStore);
   const fileList = await getFileListFromCache(cache, cacheStore, endpoint);
   if (fileList) {
-    return fileList.files as DriveItem[];
+    return fileList.files.map((file: string) => JSON.parse(file) as DriveItem);
   }
 
   // get files from graph request
@@ -460,7 +460,7 @@ export const getUserInsightsFiles = async (
   const cache: CacheStore<CacheFileList> = CacheService.getCache<CacheFileList>(schemas.fileLists, cacheStore);
   const fileList = await getFileListFromCache(cache, cacheStore, key);
   if (fileList) {
-    return fileList.files as DriveItem[];
+    return fileList.files.map((file: string) => JSON.parse(file) as DriveItem);
   }
 
   // get files from graph request

--- a/packages/mgt-components/src/graph/graph.files.ts
+++ b/packages/mgt-components/src/graph/graph.files.ts
@@ -413,6 +413,7 @@ export const getMyInsightsFiles = async (graph: IGraph, insightType: string): Pr
   const cache: CacheStore<CacheFileList> = CacheService.getCache<CacheFileList>(schemas.fileLists, cacheStore);
   const fileList = await getFileListFromCache(cache, cacheStore, endpoint);
   if (fileList) {
+    // fileList.files is string[] so JSON.parse to get proper objects
     return fileList.files.map((file: string) => JSON.parse(file) as DriveItem);
   }
 


### PR DESCRIPTION
Closes #2523

### PR Type
- Bugfix
- 
### Description of the changes
Returning a JSON parsed version of the cache for insights types. It was returning directly `fileList.files` but the files were still raw JSON.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes