### PR TITLE
fix: person card color

### DIFF
--- a/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.scss
+++ b/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.scss
@@ -43,7 +43,6 @@ $person-card-base-icons-left-spacing: var(--person-card-base-icons-left-spacing,
   --file-list-background-color: transparent;
   --file-list-box-shadow: none;
   --file-item-background-color: transparent;
-  --card-height: auto;
 
   .small {
     max-height: 100vh;

--- a/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.theme.scss
+++ b/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.theme.scss
@@ -19,7 +19,7 @@
 @import '../../components/mgt-messages/mgt-messages.theme';
 @import '../../components/mgt-file-list/mgt-file-list.theme';
 
-$person-card-background-color: var(--person-card-background-color, transparent);
+$person-card-background-color: var(--person-card-background-color, var(--neutral-layer-floating));
 $person-card-expanded-background-color-hover: var(
   --person-card-expanded-background-color-hover,
   var(--neutral-fill-hover)

--- a/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.ts
+++ b/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.ts
@@ -564,7 +564,7 @@ export class MgtPersonCard extends MgtTemplatedComponent {
       ? html`<div @keydown=${this.handleEndOfCard} aria-label=${this.strings.endOfCard} tabindex="0" id="end-of-container"></div>`
       : html``;
     return html`
-      <fluent-card class="root" dir=${this.direction}>
+      <div class="root" dir=${this.direction}>
         <div class=${classMap({ small: this._smallView })}>
           ${navigationTemplate}
           ${closeCardTemplate}
@@ -572,7 +572,7 @@ export class MgtPersonCard extends MgtTemplatedComponent {
           <div class="expanded-details-container">${expandedDetailsTemplate}</div>
           ${tabLocker}
         </div>
-      </fluent-card>
+      </div>
      `;
   }
 


### PR DESCRIPTION
Closes #2534  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
 - Bugfix 

### Description of the changes

removes fluent card and manually styles card background 
now uses --neutral-floating-layer as card background color

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
