### PR TITLE
fix: people picker single select mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
       <!-- <mgt-person person-query="me" view="twoLines" person-card="hover" show-presence></mgt-person> -->
       <!-- <mgt-person-card person-query="me"></mgt-person-card> -->
       <h2>mgt-people-picker</h2>
-      <mgt-people-picker show-max="6"></mgt-people-picker>
+      <mgt-people-picker selection-mode="single" show-max="6"></mgt-people-picker>
       <!-- <h2>mgt-teams-channel-picker</h2>
       <mgt-teams-channel-picker></mgt-teams-channel-picker> -->
       <!-- <h2>mgt-tasks</h2>

--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -606,6 +606,10 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     this.addEventListener('paste', this.handlePaste);
   }
 
+  private get hasMaxSelections(): boolean {
+    return this.selectionMode === 'single' && this.selectedPeople.length >= 1;
+  }
+
   /**
    * Focuses the input element when focus is called
    *
@@ -739,18 +743,8 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
    * @memberof MgtPeoplePicker
    */
   protected renderInput(selectedPeopleTemplate: TemplateResult): TemplateResult {
-    const placeholder = !this.disabled
-      ? this.placeholder
-        ? this.placeholder
-        : this.strings.inputPlaceholderText
-      : this.placeholder || '';
-
-    const selectionMode = this.selectionMode ? this.selectionMode : 'multiple';
-
-    if (selectionMode === 'single' && this.selectedPeople.length >= 1) {
-      this.lostFocus();
-      return html``;
-    }
+    const placeholder = this.disabled ? '' : this.placeholder || this.strings.inputPlaceholderText;
+    const maxSelectionsAriaLabel = this.hasMaxSelections ? this.strings.maxSelectionsAriaLabel : '';
 
     const searchIcon = html`<span class="search-icon">${getSvg(SvgIcon.Search)}</span>`;
     const startSlot = this.selectedPeople?.length > 0 ? selectedPeopleTemplate : searchIcon;
@@ -761,16 +755,17 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
         slot="anchor"
         id="people-picker-input"
         role="combobox"
-        placeholder=${placeholder}
-        aria-label=${this.ariaLabel || placeholder || this.strings.selectContact}
-        @click="${this.handleInputClick}"
-        @focus="${this.gainedFocus}"
-        @keydown="${this.onUserKeyDown}"
+        placeholder=${this.hasMaxSelections ? this.strings.maxSelectionsPlaceHolder : placeholder}
+        aria-label=${this.ariaLabel || maxSelectionsAriaLabel || placeholder || this.strings.selectContact}
+        @click="${this.hasMaxSelections ? undefined : this.handleInputClick}"
+        @focus="${this.hasMaxSelections ? undefined : this.gainedFocus}"
+        @keydown="${this.hasMaxSelections ? undefined : this.onUserKeyDown}"
         @keyup="${this.onUserKeyUp}"
-        @input="${this.onUserInput}"
+        @input="${this.hasMaxSelections ? undefined : this.onUserInput}"
         @blur="${this.lostFocus}"
-        ?disabled=${this.disabled}>
-          <span slot="start">${startSlot}</span>
+        ?disabled=${this.disabled}
+      >
+        <span slot="start">${startSlot}</span>
       </fluent-text-field>
     `;
   }

--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -1474,6 +1474,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     const inputControl = this.input.shadowRoot.querySelector<HTMLInputElement>('input');
     if (this.hasMaxSelections && inputControl) {
       inputControl.setAttribute('disabled', 'true');
+      this.input.value = inputControl.value = '';
     }
     this.hideFlyout();
   }

--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -1290,10 +1290,14 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       }
       return p.id !== person.id;
     });
+    const inputControl = this.input.shadowRoot.querySelector<HTMLInputElement>('input');
+    if (this.hasMaxSelections && inputControl) {
+      inputControl.removeAttribute('disabled');
+    }
     this.selectedPeople = filteredPersonArr;
     void this.loadState();
     this.fireCustomEvent('selectionChanged', this.selectedPeople);
-    this.input?.focus();
+    inputControl?.focus();
   }
 
   /**
@@ -1467,6 +1471,10 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
   // handle suggestion list item click
   private handleSuggestionClick(person: IDynamicPerson): void {
     this.addPerson(person);
+    const inputControl = this.input.shadowRoot.querySelector<HTMLInputElement>('input');
+    if (this.hasMaxSelections && inputControl) {
+      inputControl.setAttribute('disabled', 'true');
+    }
     this.hideFlyout();
   }
 

--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -1562,6 +1562,10 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
           this.addPerson(foundPerson);
           this.hideFlyout();
           this.input.value = '';
+          const inputControl = this.input.shadowRoot.querySelector<HTMLInputElement>('input');
+          if (this.hasMaxSelections && inputControl) {
+            inputControl.setAttribute('disabled', 'true');
+          }
         }
       } else if (this.allowAnyEmail) {
         this.handleAnyEmail();

--- a/packages/mgt-components/src/components/mgt-people-picker/strings.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/strings.ts
@@ -7,7 +7,7 @@
 
 export const strings = {
   inputPlaceholderText: 'Start typing a name',
-  maxSelectionsPlaceHolder: 'Maximum contact selections added',
+  maxSelectionsPlaceHolder: 'Max contacts added',
   maxSelectionsAriaLabel: 'Maximum contact selections reached',
   noResultsFound: "We didn't find any matches.",
   loadingMessage: 'Loading...',

--- a/packages/mgt-components/src/components/mgt-people-picker/strings.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/strings.ts
@@ -7,8 +7,8 @@
 
 export const strings = {
   inputPlaceholderText: 'Start typing a name',
-  maxSelectionsPlaceHolder: 'Max contacts added',
-  maxSelectionsAriaLabel: 'Maxiumum contact selections reached',
+  maxSelectionsPlaceHolder: 'Maximum contact selections added',
+  maxSelectionsAriaLabel: 'Maximum contact selections reached',
   noResultsFound: "We didn't find any matches.",
   loadingMessage: 'Loading...',
   selected: 'selected',

--- a/packages/mgt-components/src/components/mgt-people-picker/strings.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/strings.ts
@@ -7,6 +7,8 @@
 
 export const strings = {
   inputPlaceholderText: 'Start typing a name',
+  maxSelectionsPlaceHolder: 'Max contacts added',
+  maxSelectionsAriaLabel: 'Maxiumum contact selections reached',
   noResultsFound: "We didn't find any matches.",
   loadingMessage: 'Loading...',
   suggestedContact: 'suggested contact',

--- a/stories/components/peoplePicker/peoplePicker.a.js
+++ b/stories/components/peoplePicker/peoplePicker.a.js
@@ -65,6 +65,8 @@ export const localization = () => html`
      _components: {
        'people-picker': {
          inputPlaceholderText: 'Search for 🤼',
+          maxSelectionsPlaceHolder: 'Maxiumum reached',
+          maxSelectionsAriaLabel: 'You can only select 1 person',
          noResultsFound: '🤷‍♀️',
          loadingMessage: '🦔'
        }

--- a/stories/components/peoplePicker/peoplePicker.properties.js
+++ b/stories/components/peoplePicker/peoplePicker.properties.js
@@ -18,6 +18,10 @@ export const groupId = () => html`
   <mgt-people-picker group-id="02bd9fd6-8f93-4758-87c3-1fb73740a315"></mgt-people-picker>
 `;
 
+export const singleSelectMode = () => html`
+<mgt-people-picker selection-mode="single"></mgt-people-picker>
+`;
+
 export const dynamicGroupId = () => html`
   <mgt-people-picker id="picker"></mgt-people-picker>
   <div>


### PR DESCRIPTION
Closes #2542  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
 - Bugfix 

### Description of the changes

Makes single select mode show data and allow interaction after making a selection

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here --> https://github.com/microsoftgraph/microsoft-graph-docs/pull/21788
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
