### PR TITLE
fix: use iterator to load events from event-query

### DIFF
--- a/packages/mgt-components/src/components/mgt-agenda/mgt-agenda.graph.ts
+++ b/packages/mgt-components/src/components/mgt-agenda/mgt-agenda.graph.ts
@@ -8,6 +8,16 @@
 import { GraphPageIterator, IGraph, prepScopes } from '@microsoft/mgt-element';
 import * as MicrosoftGraph from '@microsoft/microsoft-graph-types';
 
+export const getEventsQueryPageIterator = async (
+  graph: IGraph,
+  query: string,
+  scopes = 'calendars.read'
+): Promise<GraphPageIterator<MicrosoftGraph.Event>> => {
+  const request = graph.api(query).middlewareOptions(prepScopes(scopes)).orderby('start/dateTime');
+
+  return GraphPageIterator.create<MicrosoftGraph.Event>(graph, request);
+};
+
 /**
  * returns Calender events iterator associated with either the logged in user or a specific groupId
  *
@@ -24,8 +34,6 @@ export const getEventsPageIterator = async (
   endDateTime: Date,
   groupId?: string
 ): Promise<GraphPageIterator<MicrosoftGraph.Event>> => {
-  const scopes = 'calendars.read';
-
   const sdt = `startdatetime=${startDateTime.toISOString()}`;
   const edt = `enddatetime=${endDateTime.toISOString()}`;
 
@@ -39,7 +47,5 @@ export const getEventsPageIterator = async (
 
   uri += `/calendarview?${sdt}&${edt}`;
 
-  const request = graph.api(uri).middlewareOptions(prepScopes(scopes)).orderby('start/dateTime');
-
-  return GraphPageIterator.create<MicrosoftGraph.Event>(graph, request);
+  return getEventsQueryPageIterator(graph, uri);
 };

--- a/packages/mgt-components/src/components/mgt-agenda/mgt-agenda.ts
+++ b/packages/mgt-components/src/components/mgt-agenda/mgt-agenda.ts
@@ -182,9 +182,9 @@ export class MgtAgenda extends MgtTemplatedComponent {
 
   /**
    * allows developer to specify preferred timezone that should be used for
-   * retrieving events from Graph, eg. `Pacific Standard Time`. The preferred timezone for
-   * the current user can be retrieved by calling `me/mailboxSettings` and
-   * retrieving the value of the `timeZone` property.
+   * rendering events retrieved from Graph, eg. `America/Los_Angeles`.
+   * By default events are rendered using the current timezone of the
+   * device being used.
    *
    * @type {string}
    */

--- a/packages/mgt-components/src/components/mgt-agenda/mgt-agenda.ts
+++ b/packages/mgt-components/src/components/mgt-agenda/mgt-agenda.ts
@@ -20,7 +20,7 @@ import {
 import '../../styles/style-helper';
 import '../mgt-person/mgt-person';
 import { styles } from './mgt-agenda-css';
-import { getEventsPageIterator } from './mgt-agenda.graph';
+import { getEventsPageIterator, getEventsQueryPageIterator } from './mgt-agenda.graph';
 import { SvgIcon, getSvg } from '../../utils/SvgHelper';
 import { MgtPeople } from '../mgt-people/mgt-people';
 import { registerFluentComponents } from '../../utils/FluentComponents';
@@ -629,17 +629,14 @@ export class MgtAgenda extends MgtTemplatedComponent {
           } else {
             query = this.eventQuery;
           }
+          const iterator = await getEventsQueryPageIterator(graph, query, scope);
+          if (iterator?.value) {
+            events = iterator.value;
 
-          let request = graph.api(query);
-
-          if (scope) {
-            request = request.middlewareOptions(prepScopes(scope));
-          }
-
-          const results = (await request.get()) as CollectionResponse<MicrosoftGraph.Event>;
-
-          if (results?.value) {
-            events = results.value;
+            while (iterator.hasNext) {
+              await iterator.next();
+              events = iterator.value;
+            }
           }
           // eslint-disable-next-line no-empty
         } catch (e) {}

--- a/stories/components/agenda/agenda.properties.js
+++ b/stories/components/agenda/agenda.properties.js
@@ -15,7 +15,7 @@ export default {
 };
 
 export const getByEventQuery = () => html`
-  <mgt-agenda event-query="/me/events?orderby=start/dateTime"></mgt-agenda>
+  <mgt-agenda event-query="/me/calendarview?$orderby=start/dateTime&startdatetime=2023-07-12T00:00:00.000Z&enddatetime=2023-07-18T00:00:00.000Z"></mgt-agenda>
 `;
 
 export const groupByDay = () => html`


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2596 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type

- Bugfix 

### Description of the changes

uses a page iterator to get data when event-query is provided
updates event-query story to ensure more than a single page of data is requeested

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
