### PR TITLE
fix: remove deprecated providers on storybook overview page

### DIFF
--- a/stories/overview.stories.mdx
+++ b/stories/overview.stories.mdx
@@ -62,26 +62,23 @@ The components are also available as [React components](https://learn.microsoft.
 
 Additionaly the following components are available as preview components. These components are not yet ready for production use and are subject to change.
 
-| Preview Component                                                                | Description                                                                                                                                      |
-| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [Search Box](?path=/story/preview-mgt-search-box--search-box)                    | An input box for search scenarios.                                                                                                               |
-| [Seach Results](?path=/story/preview-mgt-search-results--search-results)         | A component for executing search queries and displaying search results.                                                                          |
+| Preview Component                                                        | Description                                                             |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| [Search Box](?path=/story/preview-mgt-search-box--search-box)            | An input box for search scenarios.                                      |
+| [Seach Results](?path=/story/preview-mgt-search-results--search-results) | A component for executing search queries and displaying search results. |
 
 #### Providers
 
 [Providers](https://learn.microsoft.com/graph/toolkit/providers/providers) enable authentication and provide the implementation for acquiring access tokens on various platforms and expose a Microsoft Graph client for calling the Microsoft Graph APIs. The components work best when used with a provider, but the providers can be used on their own.
 
-| Providers                                                                      | Description                                                                                                                                |
-| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| [MSAL](https://learn.microsoft.com/graph/toolkit/providers/msal)               | Uses msal.js to sign in users and acquire tokens to use with Microsoft Graph.                                                              |
-| [MSAL2](https://learn.microsoft.com/graph/toolkit/providers/msal2)             | Uses msal-browser to sign in users and acquire tokens to use with Microsoft Graph.                                                         |
-| [SharePoint](https://learn.microsoft.com/graph/toolkit/providers/sharepoint)   | Authenticates and provides Microsoft Graph access to components inside of SharePoint web parts.                                            |
-| [Teams](https://learn.microsoft.com/graph/toolkit/providers/teams)             | Uses msal.js to sign in users and acquire tokens on the client in Microsoft Teams tabs.                                                    |
-| [Teams MSAL2](https://learn.microsoft.com/graph/toolkit/providers/teams-msal2) | Uses msal-browser to sign in users and acquire tokens in Microsoft Teams tabs. Supports Single Sign-On with custom backend.                |
-| [TeamsFx](https://learn.microsoft.com/graph/toolkit/providers/teamsfx)         | Use the TeamsFx provider inside your Microsoft Teams applications to provide Microsoft Graph Toolkit components access to Microsoft Graph. |
-| [Electron](https://learn.microsoft.com/graph/toolkit/providers/electron)       | Authenticates and provides Microsoft Graph access to components inside of Electron apps                                                    |
-| [Proxy](https://learn.microsoft.com/graph/toolkit/providers/proxy)             | Allows the use of backend authentication by routing all calls to Microsoft Graph through your backend.                                     |
-| [Custom](https://learn.microsoft.com/graph/toolkit/providers/custom)           | Create a custom provider to enable authentication and access to Microsoft Graph with your application's existing authentication code.      |
+| Providers                                                                    | Description                                                                                                                                |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| [MSAL2](https://learn.microsoft.com/graph/toolkit/providers/msal2)           | Uses msal-browser to sign in users and acquire tokens to use with Microsoft Graph.                                                         |
+| [SharePoint](https://learn.microsoft.com/graph/toolkit/providers/sharepoint) | Authenticates and provides Microsoft Graph access to components inside of SharePoint web parts.                                            |
+| [TeamsFx](https://learn.microsoft.com/graph/toolkit/providers/teamsfx)       | Use the TeamsFx provider inside your Microsoft Teams applications to provide Microsoft Graph Toolkit components access to Microsoft Graph. |
+| [Electron](https://learn.microsoft.com/graph/toolkit/providers/electron)     | Authenticates and provides Microsoft Graph access to components inside of Electron apps                                                    |
+| [Proxy](https://learn.microsoft.com/graph/toolkit/providers/proxy)           | Allows the use of backend authentication by routing all calls to Microsoft Graph through your backend.                                     |
+| [Custom](https://learn.microsoft.com/graph/toolkit/providers/custom)         | Create a custom provider to enable authentication and access to Microsoft Graph with your application's existing authentication code.      |
 
 ### Who should use it?
 


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2558  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Remove deprecated providers from storybook overview page
### PR checklist
- [ ] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
