### PR TITLE
Set the mouse cursor to pointer on hover for Person Card enabled mgt-…

### DIFF
--- a/packages/mgt-components/src/components/mgt-person/mgt-person.scss
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.scss
@@ -45,6 +45,7 @@ $person-line4-text-line-height: var(--person-line4-text-line-height, 16px);
   .flyout {
     [slot='anchor'] {
       display: flex;
+      cursor: pointer;
 
       &.vertical {
         flex-direction: column;


### PR DESCRIPTION


Closes #2651

### PR Type
Bugfix

### Description of the changes
The mgt-person component should have a cursor of type pointer display when mouse over event occurs on the mgt-person component if it is equipped with either a Person Card Hover or Person Card Click.
I have updated the mgt-person.scss styles to include this property.
Current workaround is to set your own mouse pointer style via custom css every time.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information

