### PR TITLE
fix(MgtProfile): Fix handling of null values for educations & work positions

### DIFF
--- a/packages/mgt-components/src/components/mgt-profile/mgt-profile.ts
+++ b/packages/mgt-components/src/components/mgt-profile/mgt-profile.ts
@@ -306,7 +306,9 @@ export class MgtProfile extends BasePersonCardSection {
                  ${position?.detail?.company?.displayName}
                </div>
                <div class="work-position__location" tabindex="0">
-                 ${position?.detail?.company?.address?.city}, ${position?.detail?.company?.address?.state}
+                 ${position?.detail?.company?.address?.city}${
+          position?.detail?.company?.address?.city && position?.detail?.company?.address?.state ? ', ' : ''
+        }${position?.detail?.company?.address?.state}
                </div>
              </div>
            </div>
@@ -353,7 +355,7 @@ export class MgtProfile extends BasePersonCardSection {
            </div>
            <div class="data-list__item__content">
              <div class="educational-activity__degree" tabindex="0">
-               ${educationalActivity.program.displayName || 'Bachelors Degree'}
+               ${educationalActivity.program.displayName}
              </div>
            </div>
          </div>
@@ -493,8 +495,14 @@ export class MgtProfile extends BasePersonCardSection {
   }
 
   private getDisplayDateRange(event: EducationalActivity): string {
+    // if startMonthYear is not defined, we do not show the date range (otherwise it will always start with 1970)
+    if (!event.startMonthYear) {
+      return null;
+    }
+
     const start = new Date(event.startMonthYear).getFullYear();
-    if (start === 0) {
+    // if the start year is 0 or 1 - it's probably an error or a strange "undefined"-value
+    if (start === 0 || start === 1) {
       return null;
     }
 


### PR DESCRIPTION
Closes #2713 

### PR Type
- Bugfix

### Description of the changes
Added some null/undefined handling to not show invalid data:
Old:
![image](https://github.com/microsoftgraph/microsoft-graph-toolkit/assets/878151/5a33834d-89e5-4726-bf3f-7eb491389160)

New:
![image](https://github.com/microsoftgraph/microsoft-graph-toolkit/assets/878151/d0d9de0c-0f4f-40ce-ad85-7265b17b883c)

this is for a case where an education has no programm displayName and startdate. It also fixes the issue when the startdate ist 0001-01-01 which is obviously also invalid. 
It also removes the ',' when no state or no city is given in a work position.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Contains **NO** breaking changes
