### PR TITLE
fix: update mgt-taxonomy-picker colors to match mgt-picker

### DIFF
--- a/packages/mgt-components/src/components/mgt-taxonomy-picker/mgt-taxonomy-picker.scss
+++ b/packages/mgt-components/src/components/mgt-taxonomy-picker/mgt-taxonomy-picker.scss
@@ -10,10 +10,24 @@
 @import './mgt-taxonomy-picker.theme';
 
 :host {
-  --max-height: var(--taxonomy-picker-max-height, 380px);
+  --max-height: var(--taxonomy-picker-list-max-height, 380px);
 
   .picker {
     background-color: $taxonomy-picker-background-color;
+  }
+
+  fluent-combobox {
+    &::part(selected-value) {
+      &::placeholder {
+        color: $taxonomy-picker-placeholder-color;
+      }
+
+      &:hover {
+        &::placeholder {
+          color: $taxonomy-picker-placeholder-hover-color;
+        }
+      }
+    }
   }
 }
 

--- a/packages/mgt-components/src/components/mgt-taxonomy-picker/mgt-taxonomy-picker.theme.scss
+++ b/packages/mgt-components/src/components/mgt-taxonomy-picker/mgt-taxonomy-picker.theme.scss
@@ -8,3 +8,8 @@
 @import '../../styles/shared-sass-variables';
 
 $taxonomy-picker-background-color: var(--taxonomy-picker-background-color, transparent);
+$taxonomy-picker-placeholder-color: var(--taxonomy-picker-placeholder-color, var(--input-filled-placeholder-rest));
+$taxonomy-picker-placeholder-hover-color: var(
+  --taxonomy-picker-placeholder-color-hover,
+  var(--secondary-text-hover-color)
+);

--- a/packages/mgt-components/src/components/mgt-taxonomy-picker/mgt-taxonomy-picker.ts
+++ b/packages/mgt-components/src/components/mgt-taxonomy-picker/mgt-taxonomy-picker.ts
@@ -33,6 +33,8 @@ registerFluentComponents(fluentCombobox, fluentOption);
  *
  * @cssprop --taxonomy-picker-background-color - {Color} Picker component background color
  * @cssprop --taxonomy-picker-list-max-height - {String} max height for options list. Default value is 380px.
+ * @cssprop --taxonomy-picker-placeholder-color - {Color} Text color for the placeholder in the picker
+ * @cssprop --taxonomy-picker-placeholder-hover-color - {Color} Text color for the placeholder in the picker on hover
  */
 @customElement('taxonomy-picker')
 export class MgtTaxonomyPicker extends MgtTemplatedComponent {


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2728  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Update mgt-taxonomy-picker placeholder colors to match mgt-picker

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR:https://github.com/microsoftgraph/microsoft-graph-docs/pull/22735 <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
