### PR TITLE
fix: typing for template props data context

### DIFF
--- a/packages/mgt-react/src/MgtTemplateProps.ts
+++ b/packages/mgt-react/src/MgtTemplateProps.ts
@@ -5,7 +5,9 @@
  * -------------------------------------------------------------------------------------------
  */
 
-export interface MgtTemplateProps {
+// Make type generic with a default of any to provide backwards compatibility and allow correct typing of the dataContext
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface MgtTemplateProps<T = any> {
   template?: string;
-  dataContext?: unknown;
+  dataContext?: T;
 }


### PR DESCRIPTION
Closes #2753<!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type

- Bugfix

### Description of the changes

makes MgtTemplateProps generic to define the type for dataContext with a default of any type this provides backwards compatability and allows for specific typing of templates.

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
