### PR TITLE
chore: remove branch filter on ci test reporting workflow

### DIFF
--- a/.github/workflows/pr-reporting.yml
+++ b/.github/workflows/pr-reporting.yml
@@ -5,7 +5,6 @@ on:
     workflows: [Build pr]
     types:
       - completed
-    branches: [main, release/**, next/**]
 
 jobs:
   pr_report:
@@ -19,7 +18,7 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           artifact: test-results
-          name: JEST Tests # Name of the check run which will be created
+          name: Test Results # Name of the check run which will be created
           path: junit.xml # Path to test results
           reporter: jest-junit # Format of test results
       - name: Download coverage artifacts with cli


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2801 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type

- Build or CI related changes 

### Description of the changes

ensures that any run of the CI pipeline will trigger the pr-reporting pipeline.

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
