### PR TITLE
feat: add config switch to use cananry graph

### DIFF
--- a/packages/mgt-chat/src/statefulClient/GraphConfig.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphConfig.ts
@@ -5,24 +5,27 @@ export class GraphConfig {
 
   public static version = 'v1.0';
 
-  // public static subscriptionConnectionVersion = 'testprodv1.0e2ewebsockets';
+  public static canarySubscriptionVersion = 'testprodv1.0e2ewebsockets';
+
+  public static webSocketsPrefix = 'websockets:';
 
   public static get graphEndpoint(): GraphEndpoint {
-    // return GraphConfig.useCanary ? 'https://canary.graph.microsoft.com' :
-    return 'https://graph.microsoft.com';
+    return GraphConfig.useCanary ? 'https://canary.graph.microsoft.com' : 'https://graph.microsoft.com';
+  }
+
+  public static get baseCanaryUrl(): string {
+    return `${GraphConfig.graphEndpoint}/${this.canarySubscriptionVersion}`;
   }
 
   public static get subscriptionEndpoint(): string {
-    return '/subscriptions';
+    return GraphConfig.useCanary ? `${GraphConfig.baseCanaryUrl}/subscriptions` : '/subscriptions';
   }
 
-  // public static adjustNotificationUrl(url: string): string {
-  //   let temp = url;
-  //   if (GraphConfig.useCanary && url) {
-  //     temp = url.replace('https://graph.microsoft.com/1.0', GraphConfig.baseCanaryUrl);
-  //     temp = temp.replace('https://graph.microsoft.com/beta', GraphConfig.baseCanaryUrl);
-  //   }
-  //   temp = temp.replace(GraphConfig.version, GraphConfig.subscriptionConnectionVersion);
-  //   return temp.replace('wss:', '');
-  // }
+  public static adjustNotificationUrl(url: string): string {
+    if (GraphConfig.useCanary && url) {
+      url = url.replace('https://graph.microsoft.com/1.0', GraphConfig.baseCanaryUrl);
+      url = url.replace('https://graph.microsoft.com/beta', GraphConfig.baseCanaryUrl);
+    }
+    return url.replace(GraphConfig.webSocketsPrefix, '');
+  }
 }

--- a/packages/mgt-element/src/Graph.ts
+++ b/packages/mgt-element/src/Graph.ts
@@ -147,7 +147,7 @@ export class Graph implements IGraph {
  * @returns {Graph}
  * @memberof Graph
  */
-export const createFromProvider = (provider: IProvider, version?: string, component?: Element): Graph => {
+export const createFromProvider = (provider: IProvider, version?: string, component?: Element | string): Graph => {
   const middleware: Middleware[] = [
     new AuthenticationHandler(provider),
     new RetryHandler(new RetryHandlerOptions()),


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2761 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type

- Feature

### Description of the changes

Adds a config based mechanism to allow developers to target the canary deployment of graph for faster testing of changes related to mgt-chat which are in flight from AGS and/or workload teams

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
