### PR TITLE
feat!: add show-presence to mgt-people-picker

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -343,6 +343,12 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
   })
   public disableImages: boolean;
 
+  @property({
+    attribute: 'show-presence',
+    type: Boolean
+  })
+  public showPresence: boolean;
+
   /**
    * array of user picked people.
    *
@@ -960,7 +966,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       mgtHtml`
          <mgt-person
           class="person"
-          show-presence
+          ?show-presence=${this.showPresence}
           view="twoLines"
           line2-property="jobTitle,mail"
           .personDetails=${person}

--- a/packages/mgt-react/src/generated/people-picker.ts
+++ b/packages/mgt-react/src/generated/people-picker.ts
@@ -19,6 +19,7 @@ export type PeoplePickerProps = {
 	people?: IDynamicPerson[];
 	showMax?: number;
 	disableImages?: boolean;
+	showPresence?: boolean;
 	selectedPeople?: IDynamicPerson[];
 	defaultSelectedUserIds?: string[];
 	defaultSelectedGroupIds?: string[];

--- a/stories/components/peoplePicker/peoplePicker.properties.stories.js
+++ b/stories/components/peoplePicker/peoplePicker.properties.stories.js
@@ -14,8 +14,12 @@ export default {
   decorators: [withCodeEditor]
 };
 
+export const showPresence = () => html`
+<mgt-people-picker show-presence></mgt-people-picker>
+`;
+
 export const groupId = () => html`
-  <mgt-people-picker group-id="02bd9fd6-8f93-4758-87c3-1fb73740a315"></mgt-people-picker>
+<mgt-people-picker group-id="02bd9fd6-8f93-4758-87c3-1fb73740a315"></mgt-people-picker>
 `;
 
 export const singleSelectMode = () => html`


### PR DESCRIPTION
Closes #2794 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type

- Feature

### Description of the changes

add show-presence attribute to mgt-people-picker

BREAKING CHANGE: this changes the default behavior of mgt-people-picker to not show presence

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
Impact of breaking change is that now people picker usages will not show presence by default.