### PR TITLE
fix!: getUserPresence should only request presence.read

### DIFF
--- a/packages/mgt-components/src/graph/graph.presence.ts
+++ b/packages/mgt-components/src/graph/graph.presence.ts
@@ -51,7 +51,7 @@ export const getUserPresence = async (graph: IGraph, userId?: string): Promise<P
     }
   }
 
-  const scopes = userId ? ['presence.read.all'] : ['presence.read'];
+  const scopes = ['presence.read'];
   const resource = userId ? `/users/${userId}/presence` : '/me/presence';
 
   const result = (await graph


### PR DESCRIPTION

<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2808 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type

- Bugfix 

### Description of the changes

BREAKING CHANGE: applications which have previously requested presence.read.all and not presence.read will have a changed set of required scopes. This will require additional user consent or updating of pre-consented permissions when incremental consent is not enabled

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
