### PR TITLE
fix: add space to filters template string in people-filters

### DIFF
--- a/packages/mgt-components/src/graph/graph.people.ts
+++ b/packages/mgt-components/src/graph/graph.people.ts
@@ -135,7 +135,7 @@ export const findPeople = async (
 
   if (filters !== '') {
     // Adding the default people filters to the search filters
-    filter += `${filters}`;
+    filter += ` ${filters}`;
   }
   let graphResult: CollectionResponse<Person>;
   try {

--- a/packages/mgt-components/src/graph/graph.people.ts
+++ b/packages/mgt-components/src/graph/graph.people.ts
@@ -135,7 +135,7 @@ export const findPeople = async (
 
   if (filters !== '') {
     // Adding the default people filters to the search filters
-    filter += ` ${filters}`;
+    filter += ` and  ${filters}`;
   }
   let graphResult: CollectionResponse<Person>;
   try {


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2738 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
add space to filters template string in people-filters
### PR checklist
- [ ] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
