### PR TITLE
fix: display of flyout hidden by dialog

### DIFF
--- a/samples/react-contoso/src/pages/ChatPage.tsx
+++ b/samples/react-contoso/src/pages/ChatPage.tsx
@@ -53,6 +53,9 @@ const useStyles = makeStyles({
   },
   dialog: {
     display: 'block'
+  },
+  dialogSurface: {
+    contain: 'unset'
   }
 });
 
@@ -84,7 +87,7 @@ const ChatPage: React.FunctionComponent = () => {
                   New Chat
                 </Button>
               </DialogTrigger>
-              <DialogSurface>
+              <DialogSurface className={styles.dialogSurface}>
                 <DialogBody className={styles.dialog}>
                   <DialogTitle>New Chat</DialogTitle>
                   <NewChat


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2829 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type

- Bugfix 

### Description of the changes

CSS fix for using a people picker in a fluent v9 Dialog

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
New behvior:
![people picker flyout in a fluent v9 dialog](https://github.com/microsoftgraph/microsoft-graph-toolkit/assets/7122716/4afba0bc-52bd-4480-b0de-24ed33de53fd)
