### PR TITLE
chore: refactor tests to await render events

### DIFF
--- a/packages/mgt-components/src/components/mgt-person/mgt-person.tests.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.tests.ts
@@ -4,7 +4,7 @@
  * See License in the project root for license information.
  * -------------------------------------------------------------------------------------------
  */
-import { fixture, html, expect, waitUntil } from '@open-wc/testing';
+import { fixture, html, expect, oneEvent } from '@open-wc/testing';
 import { MockProvider, Providers } from '@microsoft/mgt-element';
 import { registerMgtPersonComponent } from './mgt-person';
 
@@ -16,7 +16,7 @@ describe('mgt-person - tests', () => {
 
   it('should render', async () => {
     const person = await fixture(html`<mgt-person person-query="me" view="twoLines"></mgt-person>`);
-    await waitUntil(() => person.shadowRoot.querySelector('img'), 'mgt-person did not update');
+    await oneEvent(person, 'person-image-rendered');
     await expect(person).shadowDom.to.equal(
       `<div class=" person-root twolines " dir="ltr">
         <div class="avatar-wrapper">
@@ -33,7 +33,7 @@ describe('mgt-person - tests', () => {
 
   it('should pop up a flyout on click', async () => {
     const person = await fixture(html`<mgt-person person-query="me" view="twoLines" person-card="click"></mgt-person>`);
-    await waitUntil(() => person.shadowRoot.querySelector('img'), 'mgt-person did not update');
+    await oneEvent(person, 'person-image-rendered');
     await expect(person).shadowDom.to.equal(
       `<div class=" person-root twolines " dir="ltr"tabindex="0">
         <mgt-flyout
@@ -67,11 +67,7 @@ describe('mgt-person - tests', () => {
     person.shadowRoot.querySelector('img').click();
     // need to use wait until here because of the dynamic import of the person card
     // this can be flaky due to the dynamic import and timing variance
-    await waitUntil(
-      () => person.shadowRoot.querySelector('div[data-testid="flyout-slot"]'),
-      'mgt-person failed to render flyout',
-      { interval: 500, timeout: 10000 }
-    );
+    await oneEvent(person, 'flyout-content-rendered');
     const flyout = person.shadowRoot.querySelector('div[data-testid="flyout-slot"]');
     await expect(flyout).dom.to.be.equal(`
       <div slot="flyout" data-testid="flyout-slot">

--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -732,6 +732,7 @@ export class MgtPerson extends MgtTemplatedComponent {
         ${hasInitials ? initials : contactIconTemplate}
       </span>
 `;
+    if (hasImage) this.fireCustomEvent('person-image-rendered');
 
     return hasImage ? imageTemplate : textTemplate;
   }
@@ -1059,6 +1060,7 @@ export class MgtPerson extends MgtTemplatedComponent {
    * @memberof MgtPerson
    */
   protected renderFlyoutContent(personDetails: IDynamicPerson, image: string, presence: Presence): TemplateResult {
+    this.fireCustomEvent('flyout-content-rendered');
     return (
       this.renderTemplate('person-card', { person: personDetails, personImage: image }) ||
       mgtHtml`


### PR DESCRIPTION
refactor mgt-person tests to await render events rather than the dom mutation
This should allow us to not specify a timeout.