### PR TITLE
fix: sessionId management

### DIFF
--- a/packages/mgt-chat/src/statefulClient/GraphNotificationClient.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphNotificationClient.ts
@@ -369,8 +369,8 @@ export class GraphNotificationClient {
   }
 
   public async subscribeToChatNotifications(chatId: string, sessionId: string) {
-    // if we have a "previous" chat state at present, unsubscribe
-    if (this.chatId && this.sessionId && chatId !== this.chatId && sessionId !== this.sessionId) {
+    // if we have a "previous" chat state at present, unsubscribe for the previous chatId
+    if (this.chatId && this.sessionId && chatId !== this.chatId) {
       await this.unsubscribeFromChatNotifications(this.chatId, this.sessionId);
     }
     this.chatId = chatId;

--- a/packages/mgt-chat/src/statefulClient/useGraphChatClient.ts
+++ b/packages/mgt-chat/src/statefulClient/useGraphChatClient.ts
@@ -10,13 +10,45 @@ import { v4 as uuid } from 'uuid';
 import { StatefulGraphChatClient } from './StatefulGraphChatClient';
 import { log } from '@microsoft/mgt-element';
 
+/**
+ * The key name to use for storing the sessionId in session storage
+ */
+const keyName = 'mgt-chat-session-id';
+
+/**
+ * reads a string from session storage, or if there is no string for the keyName, generate a new uuid and place in storage
+ */
+const getOrGenerateSessionId = () => {
+  const value = sessionStorage.getItem(keyName);
+
+  if (value) {
+    return value;
+  } else {
+    const newValue = uuid();
+    sessionStorage.setItem(keyName, newValue);
+    return newValue;
+  }
+};
+
+/**
+ * Provides a stable sessionId for the lifetime of the browser tab.
+ * @returns a string that is either read from session storage or generated and placed in session storage
+ */
+const useSessionId = (): string => {
+  // when a function is passed to useState, it is only invoked on the first render
+  const [sessionId] = useState<string>(getOrGenerateSessionId);
+
+  return sessionId;
+};
+
+/**
+ * Custom hook to abstract the creation of a stateful graph chat client.
+ * @param {string} chatId the current chatId to be rendered
+ * @returns {StatefulGraphChatClient} a stateful graph chat client that is subscribed to the given chatId
+ */
 export const useGraphChatClient = (chatId: string): StatefulGraphChatClient => {
-  const [sessionId, setSessionId] = useState<string | undefined>();
+  const sessionId = useSessionId();
   const [chatClient] = useState<StatefulGraphChatClient>(() => new StatefulGraphChatClient());
-  // generate a new sessionId when the chatId changes
-  useEffect(() => {
-    setSessionId(uuid());
-  }, [chatId]);
 
   // when chatId or sessionId changes this effect subscribes or unsubscribes
   // the component to/from web socket based notifications for the given chatId


### PR DESCRIPTION
Closes #2860  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type

- Bugfix

### Description of the changes

moves sessionId to be held in sessionStorage to provide a stable id for the lifetime of the browser tab

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
