### PR TITLE
fix: subscription caching

### DIFF
--- a/packages/mgt-chat/src/statefulClient/Caching/SubscriptionCache.ts
+++ b/packages/mgt-chat/src/statefulClient/Caching/SubscriptionCache.ts
@@ -66,7 +66,7 @@ export class SubscriptionsCache {
       }
       cacheEntry.lastAccessDateTime = new Date().toISOString();
 
-      await store.put(cacheEntry, buildCacheKey(chatId, sessionId));
+      await store.put(cacheEntry, cacheKey);
     });
   }
 

--- a/packages/mgt-element/src/utils/CustomElement.ts
+++ b/packages/mgt-element/src/utils/CustomElement.ts
@@ -26,7 +26,6 @@ export const customElement = (tagName: string): ((classOrDescriptor: unknown) =>
     ((element as any).packageVersion || unknownVersion) as string;
   if (mgtElement) {
     return (classOrDescriptor: CustomElementConstructor) => {
-      // eslint-disable-next-line no-console
       error(
         `Tag name ${mgtTagName} is already defined using class ${mgtElement.name} version ${version(mgtElement)}\n`,
         `Currently registering class ${classOrDescriptor.name} with version ${version(classOrDescriptor)}\n`,


### PR DESCRIPTION
Closes #2863  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type

- Bugfix 

### Description of the changes

adds a transaction helper function to the CacheStore uses transactions to ensure atomic read and update when updating subscription cache data.

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
