### PR TITLE
fix: add method to clear selected channel in mgt-teams-channel-picker

### DIFF
--- a/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.ts
+++ b/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.ts
@@ -763,7 +763,7 @@ export class MgtTeamsChannelPicker extends MgtTemplatedComponent {
    * @memberof MgtTeamsChannelPicker
    */
   clearSelectedItem() {
-    this.removeSelectedChannel(null);
+    this.removeSelectedChannel(undefined);
     this.fireCustomEvent('selectionChanged', this.selectedItem);
   }
 

--- a/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.ts
+++ b/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.ts
@@ -758,6 +758,16 @@ export class MgtTeamsChannelPicker extends MgtTemplatedComponent {
   }
 
   /**
+   * Clears the selectedItem state.
+   *
+   * @memberof MgtTeamsChannelPicker
+   */
+  clearSelectedItem() {
+    this.removeSelectedChannel(null);
+    this.fireCustomEvent('selectionChanged', this.selectedItem);
+  }
+
+  /**
    * Handles operations that are performed on the DOM when you remove a
    * channel. For example on clicking the X button.
    *

--- a/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.ts
+++ b/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.ts
@@ -763,8 +763,7 @@ export class MgtTeamsChannelPicker extends MgtTemplatedComponent {
    * @memberof MgtTeamsChannelPicker
    */
   clearSelectedItem() {
-    this.removeSelectedChannel(undefined);
-    this.fireCustomEvent('selectionChanged', this.selectedItem);
+    this.removeSelectedChannel();
   }
 
   /**
@@ -773,7 +772,7 @@ export class MgtTeamsChannelPicker extends MgtTemplatedComponent {
    *
    * @param item a selected channel item
    */
-  private removeSelectedChannel(item: ChannelPickerItemState) {
+  private removeSelectedChannel(item?: ChannelPickerItemState) {
     this.selectChannel(item);
     const treeItems = this.renderRoot.querySelectorAll('fluent-tree-item');
     if (treeItems) {
@@ -971,7 +970,7 @@ export class MgtTeamsChannelPicker extends MgtTemplatedComponent {
     this.gainedFocus();
   };
 
-  private selectChannel(item: ChannelPickerItemState) {
+  private selectChannel(item?: ChannelPickerItemState) {
     if (item && this._selectedItemState !== item) {
       this._input.setAttribute('disabled', 'true');
     } else {

--- a/stories/components/teamsChannelPicker/teamsChannelPicker.stories.js
+++ b/stories/components/teamsChannelPicker/teamsChannelPicker.stories.js
@@ -86,33 +86,27 @@ export const selectChannel = () => html`
 
 export const clearSelectedItem = () => html`
   <mgt-teams-channel-picker></mgt-teams-channel-picker>
-
-  <button class="get">Get SelectedChannel</button>
   <button class="clear">Clear SelectedChannel</button>
 
   <div class="output"></div>
 
   <script>
-    document.querySelector('.get').addEventListener('click', _ => {
-      const picker = document.querySelector('mgt-teams-channel-picker');
-      const output = document.querySelector('.output');
+    const picker = document.querySelector('mgt-teams-channel-picker');
+    const output = document.querySelector('.output');
+    const clear = document.querySelector('.clear');
 
-      if (picker.selectedItem) {
-        output.innerHTML = '<b>channel:</b> ' + picker.selectedItem.channel.displayName;
-        output.innerHTML += '<br/><b>team:</b> ' + picker.selectedItem.team.displayName;
+    clear.addEventListener('click', _ => {
+      picker.clearSelectedItem();
+    });
+
+    picker.addEventListener('selectionChanged', e => {
+      if (e.detail) {
+        output.innerHTML = '<b>channel:</b> ' + e.detail.channel.displayName;
+        output.innerHTML += '<br/><b>team:</b> ' + e.detail.team.displayName;
       } else {
         output.innerText = 'no channel selected';
       }
-    });
-
-    document.querySelector('.clear').addEventListener('click', _ => {
-      const picker = document.querySelector('mgt-teams-channel-picker');
-      const output = document.querySelector('.output');
-      if (picker.selectedItem) {
-        picker.clearSelectedItem();
-        output.innerText = 'no channel selected';
-      }
-    });
+    })
   </script>
 `;
 

--- a/stories/components/teamsChannelPicker/teamsChannelPicker.stories.js
+++ b/stories/components/teamsChannelPicker/teamsChannelPicker.stories.js
@@ -84,6 +84,38 @@ export const selectChannel = () => html`
   </script>
 `;
 
+export const clearSelectedItem = () => html`
+  <mgt-teams-channel-picker></mgt-teams-channel-picker>
+
+  <button class="get">Get SelectedChannel</button>
+  <button class="clear">Clear SelectedChannel</button>
+
+  <div class="output"></div>
+
+  <script>
+    document.querySelector('.get').addEventListener('click', _ => {
+      const picker = document.querySelector('mgt-teams-channel-picker');
+      const output = document.querySelector('.output');
+
+      if (picker.selectedItem) {
+        output.innerHTML = '<b>channel:</b> ' + picker.selectedItem.channel.displayName;
+        output.innerHTML += '<br/><b>team:</b> ' + picker.selectedItem.team.displayName;
+      } else {
+        output.innerText = 'no channel selected';
+      }
+    });
+
+    document.querySelector('.clear').addEventListener('click', _ => {
+      const picker = document.querySelector('mgt-teams-channel-picker');
+      const output = document.querySelector('.output');
+      if (picker.selectedItem) {
+        picker.clearSelectedItem();
+        output.innerText = 'no channel selected';
+      }
+    });
+  </script>
+`;
+
 export const RTL = () => html`
   <body dir="rtl">
     <mgt-teams-channel-picker></mgt-teams-channel-picker>


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2818 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Adds clearSelectedItem() method to clear selected channel in mgt-teams-channel-picker

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
