### PR TITLE
fix: set the initial message to an empty string in text area

### DIFF
--- a/packages/mgt-chat/src/components/NewChat/NewChat.tsx
+++ b/packages/mgt-chat/src/components/NewChat/NewChat.tsx
@@ -66,20 +66,15 @@ const NewChat: FC<NewChatProps> = ({ mode = 'auto', onChatCreated, onCancelClick
   );
   // chat name data control
   const [chatName, setChatName] = useState<string>('');
-  const onChatNameChanged = useCallback(
-    (_: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, data: InputOnChangeData) => {
-      setChatName(data.value);
-    },
-    []
-  );
+  const onChatNameChanged = useCallback((_: React.FormEvent<HTMLInputElement>, data: InputOnChangeData) => {
+    setChatName(data.value);
+  }, []);
+
   // initial message data control
   const [initialMessage, setInitialMessage] = useState<string>('');
-  const onInitialMessageChange = useCallback(
-    (event: React.FormEvent<HTMLTextAreaElement>, data: TextareaOnChangeData) => {
-      setInitialMessage(data.value);
-    },
-    []
-  );
+  const onInitialMessageChange = useCallback((_: React.FormEvent<HTMLTextAreaElement>, data: TextareaOnChangeData) => {
+    setInitialMessage(data.value);
+  }, []);
   const createChat = useCallback(() => {
     const graphClient: IGraph = graph('mgt-new-chat');
     setState('creating chat');

--- a/packages/mgt-chat/src/components/NewChat/NewChat.tsx
+++ b/packages/mgt-chat/src/components/NewChat/NewChat.tsx
@@ -73,7 +73,7 @@ const NewChat: FC<NewChatProps> = ({ mode = 'auto', onChatCreated, onCancelClick
     []
   );
   // initial message data control
-  const [initialMessage, setInitialMessage] = useState<string>();
+  const [initialMessage, setInitialMessage] = useState<string>('');
   const onInitialMessageChange = useCallback(
     (event: React.FormEvent<HTMLTextAreaElement>, data: TextareaOnChangeData) => {
       setInitialMessage(data.value);

--- a/packages/mgt-chat/src/components/NewChat/NewChat.tsx
+++ b/packages/mgt-chat/src/components/NewChat/NewChat.tsx
@@ -65,7 +65,7 @@ const NewChat: FC<NewChatProps> = ({ mode = 'auto', onChatCreated, onCancelClick
     [mode]
   );
   // chat name data control
-  const [chatName, setChatName] = useState<string>();
+  const [chatName, setChatName] = useState<string>('');
   const onChatNameChanged = useCallback(
     (_: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, data: InputOnChangeData) => {
       setChatName(data.value);


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2835  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Set the `initialMessage` state to an empty string. This prevents it from being undefined, then being set to defined which causes the error.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
