### PR TITLE
fix: set the text size for NewChat to a global default value

### DIFF
--- a/packages/mgt-chat/src/components/NewChat/NewChat.tsx
+++ b/packages/mgt-chat/src/components/NewChat/NewChat.tsx
@@ -34,7 +34,12 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     gridRowGap: '16px',
-    minWidth: '300px'
+    minWidth: '300px',
+    '& textarea': {
+      '::placeholder': {
+        fontSize: 'var(--type-ramp-base-font-size)'
+      }
+    }
   },
   formButtons: {
     display: 'flex',

--- a/packages/mgt-chat/src/components/NewChat/NewChat.tsx
+++ b/packages/mgt-chat/src/components/NewChat/NewChat.tsx
@@ -36,6 +36,7 @@ const useStyles = makeStyles({
     gridRowGap: '16px',
     minWidth: '300px',
     '& textarea': {
+      fontSize: 'var(--type-ramp-base-font-size)',
       '::placeholder': {
         fontSize: 'var(--type-ramp-base-font-size)'
       }


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2807 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->
- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Changed the placeholder and typed value's text size to `var(--type-ramp-base-font-size)` which is also used by the people-picker. This enables consistency in text sizes for the two components.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
