### PR TITLE
fix: filter out the initiator ID from the system usernames

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "prettier.prettierPath": "./node_modules/prettier",
   "editor.codeActionsOnSave": {
-    "source.fixAll.tslint": true
+    "source.fixAll.tslint": "explicit"
   },
   "lit-html.tags": ["mgtHtml"],
   "typescript.tsdk": "node_modules/typescript/lib",

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatClient.ts
@@ -610,7 +610,10 @@ class StatefulGraphChatClient implements StatefulClient<GraphChatClient> {
         awaits.push(getUserWithPhoto(this.graph, id));
       }
       const people = await Promise.all(awaits);
-      const userNames = userIds?.map(m => this.getUserName(m, people)).join(', ');
+      const userNames = userIds
+        ?.filter(id => id !== initiatorId)
+        .map(m => this.getUserName(m, people))
+        .join(', ');
       switch (eventDetail['@odata.type']) {
         case '#microsoft.graph.membersAddedEventMessageDetail':
           messageContent = `${this.getUserName(initiatorId, people)} added ${userNames}`;

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatClient.ts
@@ -614,17 +614,18 @@ class StatefulGraphChatClient implements StatefulClient<GraphChatClient> {
         ?.filter(id => id !== initiatorId)
         .map(m => this.getUserName(m, people))
         .join(', ');
+      const initiatorUsername = this.getUserName(initiatorId, people);
       switch (eventDetail['@odata.type']) {
         case '#microsoft.graph.membersAddedEventMessageDetail':
-          messageContent = `${this.getUserName(initiatorId, people)} added ${userNames}`;
+          messageContent = `${initiatorUsername} added ${userNames}`;
           break;
         case '#microsoft.graph.membersDeletedEventMessageDetail':
-          messageContent = `${this.getUserName(initiatorId, people)} removed ${userNames}`;
+          messageContent = `${initiatorUsername} removed ${userNames}`;
           break;
         case '#microsoft.graph.chatRenamedEventMessageDetail':
           messageContent = eventDetail.chatDisplayName
-            ? `${this.getUserName(initiatorId, people)} renamed the chat to ${eventDetail.chatDisplayName}`
-            : `${this.getUserName(initiatorId, people)} removed the group name for this conversation`;
+            ? `${initiatorUsername} renamed the chat to ${eventDetail.chatDisplayName}`
+            : `${initiatorUsername} removed the group name for this conversation`;
           break;
         // TODO: move this default case to a console.warn before release and emit an empty message
         // it's here to help us catch messages we have't handled yet


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2837 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Filter out the initiator username from system messages when listing added users. Refactors to getting the initiator name in a variable.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
