### PR TITLE
feat: add support for using premium apis

### DIFF
--- a/packages/mgt-chat/src/components/Chat/Chat.tsx
+++ b/packages/mgt-chat/src/components/Chat/Chat.tsx
@@ -10,11 +10,13 @@ import ChatMessageBar from '../ChatMessageBar/ChatMessageBar';
 import { renderMGTMention } from '../../utils/mentions';
 import { registerAppIcons } from '../styles/registerIcons';
 import { ChatHeader } from '../ChatHeader/ChatHeader';
+import { GraphConfig } from '../../statefulClient/GraphConfig';
 
 registerAppIcons();
 
 interface IMgtChatProps {
   chatId: string;
+  usePremiumApis?: boolean;
 }
 
 const useStyles = makeStyles({
@@ -91,7 +93,7 @@ const messageThreadStyles: MessageThreadStyles = {
   }
 };
 
-export const Chat = ({ chatId }: IMgtChatProps) => {
+export const Chat = ({ chatId, usePremiumApis }: IMgtChatProps) => {
   const styles = useStyles();
   const chatClient: StatefulGraphChatClient = useGraphChatClient(chatId);
   const [chatState, setChatState] = useState(chatClient.getState());
@@ -101,6 +103,10 @@ export const Chat = ({ chatId }: IMgtChatProps) => {
       chatClient.offStateChange(setChatState);
     };
   }, [chatClient]);
+
+  useEffect(() => {
+    GraphConfig.usePremiumApis = usePremiumApis ?? false;
+  }, [usePremiumApis]);
 
   const isLoading = ['creating server connections', 'subscribing to notifications', 'loading messages'].includes(
     chatState.status

--- a/packages/mgt-chat/src/statefulClient/GraphConfig.ts
+++ b/packages/mgt-chat/src/statefulClient/GraphConfig.ts
@@ -17,6 +17,7 @@ export class GraphConfig {
   public static canarySubscriptionVersion = 'testprodv1.0e2ewebsockets';
 
   public static webSocketsPrefix = 'websockets:';
+  static usePremiumApis = false;
 
   public static get graphEndpoint(): GraphEndpoint {
     return GraphConfig.useCanary ? 'https://canary.graph.microsoft.com' : 'https://graph.microsoft.com';

--- a/packages/mgt-chat/src/statefulClient/graph.chat.ts
+++ b/packages/mgt-chat/src/statefulClient/graph.chat.ts
@@ -16,6 +16,7 @@ import { CacheService, IGraph, prepScopes } from '@microsoft/mgt-element';
 import { ResponseType } from '@microsoft/microsoft-graph-client';
 import { AadUserConversationMember, Chat, ChatMessage } from '@microsoft/microsoft-graph-types';
 import { chatOperationScopes } from './chatOperationScopes';
+import { addPremiumApiSegment } from '../utils/addPremiumApiSegment';
 
 /**
  * Generic collection response from graph
@@ -40,7 +41,7 @@ export type MessageCollection = GraphCollection<ChatMessage>;
  */
 export const loadChat = async (graph: IGraph, chatId: string): Promise<Chat> =>
   (await graph
-    .api(`/chats/${chatId}?$expand=members`)
+    .api(addPremiumApiSegment(`/chats/${chatId}?$expand=members`))
     .middlewareOptions(prepScopes(...chatOperationScopes.loadChat))
     .get()) as Chat;
 
@@ -59,7 +60,7 @@ export const loadChatThread = async (
   messageCount: number
 ): Promise<MessageCollection> => {
   const response = (await graph
-    .api(`/chats/${chatId}/messages`)
+    .api(addPremiumApiSegment(`/chats/${chatId}/messages`))
     .orderby('createdDateTime DESC')
     .top(messageCount)
     .middlewareOptions(prepScopes(...chatOperationScopes.loadChatMessages))
@@ -86,7 +87,7 @@ export const loadChatThreadDelta = async (
   messageCount: number
 ): Promise<MessageCollection> => {
   const response = (await graph
-    .api(`/chats/${chatId}/messages`)
+    .api(addPremiumApiSegment(`/chats/${chatId}/messages`))
     .filter(`lastModifiedDateTime gt ${lastModified}`)
     .orderby('lastModifiedDateTime DESC')
     .top(messageCount)
@@ -128,7 +129,7 @@ export const sendChatMessage = async (graph: IGraph, chatId: string, content: st
   // if (fail) throw new Error('fail');
 
   return (await graph
-    .api(`/chats/${chatId}/messages`)
+    .api(addPremiumApiSegment(`/chats/${chatId}/messages`))
     .middlewareOptions(prepScopes(...chatOperationScopes.sendChatMessage))
     .post({ body: { content } })) as ChatMessage;
 };
@@ -155,7 +156,7 @@ export const updateChatMessage = async (
   // if (fail) throw new Error('fail');
 
   await graph
-    .api(`/chats/${chatId}/messages/${messageId}`)
+    .api(addPremiumApiSegment(`/chats/${chatId}/messages/${messageId}`))
     .middlewareOptions(prepScopes(...chatOperationScopes.updateChatMessage))
     .patch({ body: { content } });
 };
@@ -170,14 +171,14 @@ export const updateChatMessage = async (
  */
 export const deleteChatMessage = async (graph: IGraph, chatId: string, messageId: string): Promise<void> => {
   await graph
-    .api(`/me/chats/${chatId}/messages/${messageId}/softDelete`)
+    .api(addPremiumApiSegment(`/me/chats/${chatId}/messages/${messageId}/softDelete`))
     .middlewareOptions(prepScopes(...chatOperationScopes.deleteChatMessage))
     .post({});
 };
 
 export const removeChatMember = async (graph: IGraph, chatId: string, membershipId: string): Promise<void> => {
   await graph
-    .api(`/chats/${chatId}/members/${membershipId}`)
+    .api(addPremiumApiSegment(`/chats/${chatId}/members/${membershipId}`))
     .middlewareOptions(prepScopes(...chatOperationScopes.removeChatMember))
     .delete();
 };
@@ -201,7 +202,7 @@ export const addChatMembers = async (
       return {
         id: index,
         method: 'POST',
-        url: `/chats/${chatId}/members`,
+        url: addPremiumApiSegment(`/chats/${chatId}/members`),
         headers: {
           'Content-Type': 'application/json'
         },
@@ -236,7 +237,7 @@ export const loadChatImage = async (graph: IGraph, url: string): Promise<string 
     }
   }
   const response = (await graph
-    .api(url)
+    .api(addPremiumApiSegment(url))
     .responseType(ResponseType.RAW)
     .middlewareOptions(prepScopes(...chatOperationScopes.loadChatImage))
     .get()) as Response & { '@odata.mediaEtag'?: string };
@@ -288,7 +289,7 @@ export const createChatThread = async (
   if (isGroupChat && chatName) body.topic = chatName;
 
   const chat = (await graph
-    .api('/chats')
+    .api(addPremiumApiSegment('/chats'))
     .middlewareOptions(prepScopes(...chatOperationScopes.createChat))
     .post(body)) as Chat;
   if (!chat?.id) throw new Error('Chat id not returned from create chat thread');
@@ -308,7 +309,7 @@ export const createChatThread = async (
  */
 export const updateChatTopic = async (graph: IGraph, chatId: string, topic: string | null): Promise<void> => {
   await graph
-    .api(`/chats/${chatId}`)
+    .api(addPremiumApiSegment(`/chats/${chatId}`))
     .middlewareOptions(prepScopes(...chatOperationScopes.updateChatMessage))
     .patch({ topic });
 };

--- a/packages/mgt-chat/src/utils/addPremiumApiSegment.tests.ts
+++ b/packages/mgt-chat/src/utils/addPremiumApiSegment.tests.ts
@@ -1,0 +1,25 @@
+import { GraphConfig } from '../statefulClient/GraphConfig';
+import { addPremiumApiSegment } from './addPremiumApiSegment';
+import { expect } from '@open-wc/testing';
+
+describe('addPremiumApiSegment tests', () => {
+  it('should return the original url if premium apis are not enabled', async () => {
+    const url = 'https://graph.microsoft.com/v1.0/me';
+    const result = addPremiumApiSegment(url);
+    await expect(result).to.eql(url);
+  });
+
+  it('should add the premium api segment to the url', async () => {
+    const url = 'https://graph.microsoft.com/v1.0/me';
+    GraphConfig.usePremiumApis = true;
+    const result = addPremiumApiSegment(url);
+    await expect(result).to.eql(`${url}?model=B`);
+  });
+
+  it('should add the premium api segment to the url when it already has query params', async () => {
+    const url = 'https://graph.microsoft.com/v1.0/me?select=id';
+    GraphConfig.usePremiumApis = true;
+    const result = addPremiumApiSegment(url);
+    await expect(result).to.eql(`${url}&model=B`);
+  });
+});

--- a/packages/mgt-chat/src/utils/addPremiumApiSegment.ts
+++ b/packages/mgt-chat/src/utils/addPremiumApiSegment.ts
@@ -1,0 +1,10 @@
+import { GraphConfig } from '../statefulClient/GraphConfig';
+
+export const addPremiumApiSegment = (url: string) => {
+  // early exit if premium apis are not enabled
+  if (!GraphConfig.usePremiumApis) {
+    return url;
+  }
+  const urlHasExistingQueryParams = url.includes('?');
+  return `${url}${urlHasExistingQueryParams ? '&' : '?'}model=B`;
+};

--- a/samples/react-chat/package.json
+++ b/samples/react-chat/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fluentui/react-components": "^9.19.1",
     "@microsoft/mgt-chat": "*",
     "@microsoft/mgt-msal2-provider": "*",
     "@microsoft/mgt-react": "*",

--- a/samples/react-chat/src/App.tsx
+++ b/samples/react-chat/src/App.tsx
@@ -1,9 +1,10 @@
-import React, { memo, useCallback, useState } from 'react';
+import React, { ChangeEvent, memo, useCallback, useState } from 'react';
 import './App.css';
 import { Get, Login } from '@microsoft/mgt-react';
 import { Chat, NewChat } from '@microsoft/mgt-chat';
 import { Chat as GraphChat } from '@microsoft/microsoft-graph-types';
 import ChatListTemplate from './components/ChatListTemplate/ChatListTemplate';
+import { FluentProvider, Switch, SwitchOnChangeData, teamsLightTheme } from '@fluentui/react-components';
 
 const ChatList = memo(({ chatSelected }: { chatSelected: (e: GraphChat) => void }) => {
   return (
@@ -25,30 +26,38 @@ function App() {
     setShowNewChat(false);
   }, []);
 
+  const [usePremiumApis, setUsePremiumApis] = useState<boolean>(false);
+  const onToggleChanged = useCallback((ev: ChangeEvent<HTMLInputElement>, data: SwitchOnChangeData) => {
+    setUsePremiumApis(data.checked ?? false);
+  }, []);
+
   return (
     <div className="App">
-      <header className="App-header">
-        Mgt Chat test harness
-        <br />
-        <Login />
-      </header>
-      <main className="main">
-        <div className="chat-selector">
-          <ChatList chatSelected={chatSelected} />
-          Selected chat: {chatId}
+      <FluentProvider theme={teamsLightTheme}>
+        <header className="App-header">
+          Mgt Chat test harness
           <br />
-          <button onClick={() => setChatId('')}>Clear selected chat</button>
-          <br />
-          <button onClick={() => setShowNewChat(true)}>New Chat</button>
-          {showNewChat && (
-            <div className="new-chat">
-              <NewChat onChatCreated={onChatCreated} onCancelClicked={() => setShowNewChat(false)} mode="auto" />
-            </div>
-          )}
-        </div>
+          <Login />
+        </header>
+        <main className="main">
+          <div className="chat-selector">
+            <Switch onChange={onToggleChanged} checked={usePremiumApis} label="Use premium APIs?" />
+            <ChatList chatSelected={chatSelected} />
+            Selected chat: {chatId}
+            <br />
+            <button onClick={() => setChatId('')}>Clear selected chat</button>
+            <br />
+            <button onClick={() => setShowNewChat(true)}>New Chat</button>
+            {showNewChat && (
+              <div className="new-chat">
+                <NewChat onChatCreated={onChatCreated} onCancelClicked={() => setShowNewChat(false)} mode="auto" />
+              </div>
+            )}
+          </div>
 
-        <div className="chat-pane">{chatId && <Chat chatId={chatId} />}</div>
-      </main>
+          <div className="chat-pane">{chatId && <Chat chatId={chatId} usePremiumApis={usePremiumApis} />}</div>
+        </main>
+      </FluentProvider>
     </div>
   );
 }


### PR DESCRIPTION
Closes #2722

### PR Type

- Feature

### Description of the changes

Adds the ability for a developer to specify that a chat component should append `model=B` to graph calls thus enabling higher throughput and attracting cost. Needs to have Azure billing configured.

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
