### PR TITLE
docs: fix person-card sections component names in localization

### DIFF
--- a/packages/mgt-components/src/components/mgt-contact/mgt-contact.ts
+++ b/packages/mgt-components/src/components/mgt-contact/mgt-contact.ts
@@ -109,7 +109,7 @@ export class MgtContact extends BasePersonCardSection {
     title: {
       icon: getSvg(SvgIcon.Person),
       showCompact: false,
-      title: this.strings.titleTitle
+      title: this.strings.personTitle
     },
     officeLocation: {
       icon: getSvg(SvgIcon.OfficeLocation),

--- a/packages/mgt-components/src/components/mgt-contact/strings.ts
+++ b/packages/mgt-components/src/components/mgt-contact/strings.ts
@@ -12,7 +12,7 @@ export const strings = {
   businessPhoneTitle: 'Business Phone',
   cellPhoneTitle: 'Mobile Phone',
   departmentTitle: 'Department',
-  titleTitle: 'Title',
+  personTitle: 'Title',
   officeLocationTitle: 'Office Location',
   copyToClipboardButton: 'Copy to clipboard'
 };

--- a/stories/components/personCard/personCard.stories.js
+++ b/stories/components/personCard/personCard.stories.js
@@ -86,7 +86,8 @@ export const localization = () => html`
       },
       'file-list': {
         filesSectionTitle: 'الملفات',
-        sharedTextSubtitle: 'مشترك'
+        sharedTextSubtitle: 'مشترك',
+        showMoreSubtitle: 'Show more 📂'
       },
       'profile': {
         SkillsAndExperienceSectionTitle: 'المهارات والخبرة',

--- a/stories/components/personCard/personCard.stories.js
+++ b/stories/components/personCard/personCard.stories.js
@@ -61,14 +61,10 @@ export const localization = () => html`
   import { LocalizationHelper } from '@microsoft/mgt-element';
   LocalizationHelper.strings = {
     _components: {
-      login: {
-        signInLinkSubtitle: 'تسجيل الدخول',
-        signOutLinkSubtitle: 'خروج'
-      },
       'person-card': {
         showMoreSectionButton: 'أظهر المزيد' // global declaration
       },
-      'person-card-contact': {
+      'contact': {
         contactSectionTitle: 'اتصل',
         emailTitle: 'البريد الإلكتروني',
         chatTitle: 'دردشة',
@@ -78,21 +74,21 @@ export const localization = () => html`
         titleTitle: 'لقب',
         officeLocationTitle: 'موقع المكتب'
       },
-      'person-card-organization': {
+      'organization': {
         reportsToSectionTitle: 'تقارير ل',
         directReportsSectionTitle: 'تقارير مباشرة',
         organizationSectionTitle: 'منظمة',
         youWorkWithSubSectionTitle: 'انت تعمل مع',
         userWorksWithSubSectionTitle: 'يعمل مع'
       },
-      'person-card-messages': {
+      'messages': {
         emailsSectionTitle: 'رسائل البريد الإلكتروني'
       },
-      'person-card-files': {
+      'file-list': {
         filesSectionTitle: 'الملفات',
         sharedTextSubtitle: 'مشترك'
       },
-      'person-card-profile': {
+      'profile': {
         SkillsAndExperienceSectionTitle: 'المهارات والخبرة',
         AboutCompactSectionTitle: 'حول',
         SkillsSubSectionTitle: 'مهارات',

--- a/stories/samples/general.stories.js
+++ b/stories/samples/general.stories.js
@@ -74,7 +74,8 @@ export const Localization = () => html`
         },
         'file-list': {
           filesSectionTitle: 'الملفات',
-          sharedTextSubtitle: 'مشترك'
+          sharedTextSubtitle: 'مشترك',
+          showMoreSubtitle: 'Show more 📂'
         },
         'profile': {
           SkillsAndExperienceSectionTitle: 'المهارات والخبرة',

--- a/stories/samples/general.stories.js
+++ b/stories/samples/general.stories.js
@@ -59,24 +59,24 @@ export const Localization = () => html`
         'person-card': {
           showMoreSectionButton: 'أظهر المزيد' // global declaration
         },
-        'person-card-contact': {
+        'contact': {
           contactSectionTitle: 'اتصل'
         },
-        'person-card-organization': {
+        'organization': {
           reportsToSectionTitle: 'تقارير ل',
           directReportsSectionTitle: 'تقارير مباشرة',
           organizationSectionTitle: 'منظمة',
           youWorkWithSubSectionTitle: 'انت تعمل مع',
           userWorksWithSubSectionTitle: 'يعمل مع'
         },
-        'person-card-messages': {
+        'messages': {
           emailsSectionTitle: 'رسائل البريد الإلكتروني'
         },
-        'person-card-files': {
+        'file-list': {
           filesSectionTitle: 'الملفات',
           sharedTextSubtitle: 'مشترك'
         },
-        'person-card-profile': {
+        'profile': {
           SkillsAndExperienceSectionTitle: 'المهارات والخبرة',
           AboutCompactSectionTitle: 'حول',
           SkillsSubSectionTitle: 'مهارات',


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2887 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
Documentation content changes
<!-- - Other... Please describe: -->

### Description of the changes
Corrects person-card section names in localization stories

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
