### PR TITLE
fix: stop keydown from bubbling beyond people-picker

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -1548,6 +1548,7 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
    * @param event - event tracked on user input (keydown)
    */
   private readonly onUserKeyDown = (event: KeyboardEvent): void => {
+    event.stopPropagation();
     const keyName = event.key;
     const selectedList = this.renderRoot.querySelector('.selected-list');
     const isCmdOrCtrlKey = event.getModifierState('Control') || event.getModifierState('Meta');
@@ -1595,7 +1596,6 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
     if (keyName === 'Enter') {
       if (!event.shiftKey && this._foundPeople) {
         event.preventDefault();
-        event.stopPropagation();
 
         const foundPerson = this._foundPeople[this._arrowSelectionCount];
         if (foundPerson) {
@@ -1611,10 +1611,6 @@ export class MgtPeoplePicker extends MgtTemplatedComponent {
       } else {
         this.showFlyout();
       }
-    }
-
-    if (keyName === 'Escape') {
-      event.stopPropagation();
     }
 
     if (keyName === 'Tab') {


### PR DESCRIPTION
Closes #2891 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type

- Bugfix 

### Description of the changes

stops propagation of the keydown event from the people picker search input. 

this ensures that keystrokes which might trigger in pages shortcuts in SharePoint don't reach those event listener and break the component experience.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
