### PR TITLE
add support for nested values in mgt-picker key-name

### DIFF
--- a/packages/mgt-components/src/components/mgt-picker/mgt-picker.ts
+++ b/packages/mgt-components/src/components/mgt-picker/mgt-picker.ts
@@ -249,12 +249,26 @@ export class MgtPicker extends MgtTemplatedTaskComponent {
         placeholder=${this.placeholder}>
           ${this.response.map(
             item => html`
-            <fluent-option value=${item.id} @click=${(e: MouseEvent) => this.handleClick(e, item)}> ${
-              item[this.keyName]
-            } </fluent-option>`
+            <fluent-option value=${item.id} @click=${(e: MouseEvent) =>
+              this.handleClick(e, item)}> ${this.getNestedPropertyValue(item, this.keyName)} </fluent-option>`
           )}
       </fluent-combobox>
      `;
+  }
+
+  private getNestedPropertyValue(item: Entity, keyName: string) {
+    const keys = keyName.split('.');
+    let value: Entity | object | string = item;
+
+    for (const key of keys) {
+      value = value[key] as object | string;
+
+      if (value === undefined) {
+        return '';
+      }
+    }
+
+    return value;
   }
 
   /**

--- a/packages/mgt-components/src/components/mgt-picker/mgt-picker.ts
+++ b/packages/mgt-components/src/components/mgt-picker/mgt-picker.ts
@@ -264,6 +264,7 @@ export class MgtPicker extends MgtTemplatedTaskComponent {
       value = value[key] as object | string;
 
       if (value === undefined) {
+        console.warn(`mgt-picker: Key '${key}' is undefined.`);
         return '';
       }
     }


### PR DESCRIPTION
Closes #2907 

### PR Type
Feature


### Description of the changes
Allows the use of nested values in the mgt-picker component's key-name property, for example "fields.myCustomColumn"

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: No docs update needed
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
Stories not updated but existing stories have been tested
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
