### PR TITLE
fix: increase area for placeholder

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.scss
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.scss
@@ -41,7 +41,9 @@ $people-picker-selected-person-avatar-size: var(--people-picker-selected-person-
     }
 
     &::part(control) {
-      width: min-content;
+      width: auto;
+      flex-grow: 1;
+      min-width: 25%;
       height: calc((var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px);
       word-spacing: inherit;
       text-indent: inherit;

--- a/stories/components/peoplePicker/peoplePicker.properties.stories.js
+++ b/stories/components/peoplePicker/peoplePicker.properties.stories.js
@@ -14,6 +14,10 @@ export default {
   decorators: [withCodeEditor]
 };
 
+export const setPlaceholder = () => html`
+<mgt-people-picker placeholder="Select people"></mgt-people-picker>
+`;
+
 export const showPresence = () => html`
 <mgt-people-picker show-presence></mgt-people-picker>
 `;


### PR DESCRIPTION
Closes #2915


### PR Type
<!-- Please uncomment one or more that apply to this PR -->

 - Bugfix 

### Description of the changes

allows the input to expand to show a larger placeholder

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
