### PR TITLE
fix: move timers to use timeouts

### DIFF
--- a/packages/mgt-chat/src/utils/Timer.ts
+++ b/packages/mgt-chat/src/utils/Timer.ts
@@ -14,6 +14,31 @@ export class Timer {
     this.worker.port.onmessage = this.onMessage;
   }
 
+  public setTimeout(callback: () => void, delay: number): string {
+    const timeoutWork: TimerWork = {
+      type: 'setTimeout',
+      id: uuid(),
+      delay
+    };
+
+    this.work.set(timeoutWork.id, callback);
+
+    this.worker.port.postMessage(timeoutWork);
+
+    return timeoutWork.id;
+  }
+
+  public clearTimeout(id: string): void {
+    if (this.work.has(id)) {
+      const timeoutWork: TimerWork = {
+        type: 'clearTimeout',
+        id
+      };
+      this.worker.port.postMessage(timeoutWork);
+      this.work.delete(id);
+    }
+  }
+
   public setInterval(callback: () => void, delay: number): string {
     const intervalWork: TimerWork = {
       type: 'setInterval',

--- a/packages/mgt-chat/src/utils/timerWorker.ts
+++ b/packages/mgt-chat/src/utils/timerWorker.ts
@@ -1,6 +1,6 @@
 export interface TimerWork {
   id: string;
-  type: 'clearInterval' | 'setInterval' | 'runCallback';
+  type: 'clearInterval' | 'setInterval' | 'runCallback' | 'setTimeout' | 'clearTimeout';
   delay?: number;
 }
 
@@ -23,8 +23,21 @@ ctx.onconnect = (e: MessageEvent<unknown>) => {
         intervals.set(jobId, interval);
         break;
       }
-      case 'clearInterval':
+      case 'setTimeout': {
+        const timeout = setTimeout(() => {
+          const message: TimerWork = { ...event.data, ...{ type: 'runCallback' } };
+          port.postMessage(message);
+        }, delay);
+        intervals.set(jobId, timeout);
+        break;
+      }
+      case 'clearTimeout': {
         clearTimeout(intervals.get(jobId));
+        intervals.delete(jobId);
+        break;
+      }
+      case 'clearInterval':
+        clearInterval(intervals.get(jobId));
         intervals.delete(jobId);
     }
   };


### PR DESCRIPTION
### PR Type

- Bugfix

### Description of the changes

timers now use setTimeout on a worker rather than setInterval to ensure we don't get overlaps

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
