### PR TITLE
fix: direct reports list formatting

### DIFF
--- a/packages/mgt-components/src/components/mgt-organization/mgt-organization.scss
+++ b/packages/mgt-components/src/components/mgt-organization/mgt-organization.scss
@@ -63,8 +63,7 @@ $organization-direct-report-person-avatar-size: var(--organization-direct-report
       padding: 12px;
       display: flex;
       align-items: center;
-      margin-left: 20px;
-      margin-right: 20px;
+      margin-inline: 20px;
 
       &.org-member--target {
         background-color: $organization-active-org-member-target-background-color;
@@ -138,10 +137,18 @@ $organization-direct-report-person-avatar-size: var(--organization-direct-report
       padding: 12px 20px;
 
       .direct-report {
-        cursor: pointer;
-        width: 38px;
         margin-right: 4px;
-        display: inline;
+      }
+    }
+
+    .direct-report-list {
+      border: 1px solid $organization-coworker-border-color;
+      margin-inline: 20px;
+
+      .org-member--direct-report {
+        border: none;
+        cursor: pointer;
+        margin-inline: 0;
 
         .direct-report__person-image {
           --person-avatar-size: #{$organization-direct-report-person-avatar-size};

--- a/packages/mgt-components/src/components/mgt-organization/mgt-organization.ts
+++ b/packages/mgt-components/src/components/mgt-organization/mgt-organization.ts
@@ -252,7 +252,7 @@ export class MgtOrganization extends BasePersonCardSection {
 
     return html`
       <div class="org-member__separator"></div>
-      <div>
+      <div class="direct-report-list">
         ${directReports.map(
           person => mgtHtml`
             <div
@@ -275,7 +275,6 @@ export class MgtOrganization extends BasePersonCardSection {
                 ${getSvg(SvgIcon.ExpandRight)}
               </div>
             </div>
-            <div class="org-member__separator"></div>
           `
         )}
       </div>


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2872 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type

 - Bugfix 

### Description of the changes
Reformatted list of direct reports to have a single containing border:
![direct reports list in person card](https://github.com/microsoftgraph/microsoft-graph-toolkit/assets/7122716/dd263872-efcb-4f27-83c7-d696d365ca72)


### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
