### PR TITLE
fix: guard on non-existent result

### DIFF
--- a/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.ts
+++ b/packages/mgt-components/src/components/mgt-teams-channel-picker/mgt-teams-channel-picker.ts
@@ -746,7 +746,7 @@ export class MgtTeamsChannelPicker extends MgtTemplatedComponent {
       for (const team of teams) {
         const channelsForTeam = responses.get(team.id);
         // skip over any teams that don't have channels
-        if (!channelsForTeam.content?.value?.length) continue;
+        if (!channelsForTeam?.content?.value?.length) continue;
         this.items.push({
           item: team,
           channels: channelsForTeam.content.value.map(c => ({ item: c }))


### PR DESCRIPTION
Closes #2665 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type

 - Bugfix 

### Description of the changes

Adds a guard when attempting to access the content property that is reportedly causing an intermittent issue.

Note: I can't reproduce this issue so I'm making a best guess based on the fact Map.get can return undefined and there is only one unguarded access to a property to called content in the teams channel picker.

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
