### PR TITLE
docs: fix zoom truncation for get story

### DIFF
--- a/stories/components/get/get.stories.js
+++ b/stories/components/get/get.stories.js
@@ -96,7 +96,6 @@ export const GetEmail = () => html`
       text-overflow: ellipsis;
       word-wrap: break-word;
       overflow: hidden;
-      max-height: 2.8em;
       line-height: 1.4em;
     }
   </style>
@@ -185,29 +184,27 @@ export const PollingRate = () => html`
 `;
 
 export const refresh = () => html`
-    <mgt-get cache-enabled="true" resource="/me/presence" version="beta" scopes="Presence.Read">
-      <template data-type="default"> {{availability}} </template>
-      <template data-type="loading">
+<mgt-get cache-enabled="true" resource="/me" version="beta">
+    <template data-type="default"> {{ this.displayName }}</template>
+    <template data-type="loading">
         <h2>Loading...?!?!</h2>
-      </template>
-    </mgt-get>
+    </template>
+</mgt-get>
 
-    <div>
-      <label>get.refresh(false)</label>
-      <button id="false">Soft refresh</button>
-    </div>
-    <label>get.refresh(true)</label>
-    <button id="true">Hard refresh</button>
+<div>
+    <label>get.refresh(false)</label>
+    <button id="false">Soft refresh</button>
+</div>
+<label>get.refresh(true)</label>
+<button id="true">Hard refresh</button>
 
+<script>
+document.querySelector('#false').addEventListener('click', _ =>{
+      document.querySelector('mgt-get').refresh(false)
+})
 
-  <script>
-
-    document.querySelector('#false').addEventListener('click', _ =>{
-          document.querySelector('mgt-get').refresh(false)
-    })
-
-    document.querySelector('#true').addEventListener('click', _ =>{
-      document.querySelector('mgt-get').refresh(true)
-    })
-  </script>
+document.querySelector('#true').addEventListener('click', _ =>{
+  document.querySelector('mgt-get').refresh(true)
+})
+</script>
 `;


### PR DESCRIPTION
Closes #2350 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type

 - Documentation content changes 

### Description of the changes

removes a css rule that truncates data display
changes the refresh story as it's broken due to using presence apis which the sandbox does not support

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
