### PR TITLE
feat!: convert enums to string unions

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,9 +95,9 @@
       </div>
       <!-- <mgt-login></mgt-login> -->
       <!-- <h2>mgt-person me query two lines card on click with presence</h2> -->
-      <mgt-person person-query="me" view="twoLines" person-card="hover" show-presence></mgt-person>
+      <mgt-person person-query="me" view="twolines" person-card="hover" show-presence></mgt-person>
       <mgt-person-card person-query="me"></mgt-person-card>
-      <!-- <mgt-person person-query="me" view="twoLines" person-card="hover" show-presence></mgt-person> -->
+      <!-- <mgt-person person-query="me" view="twolines" person-card="hover" show-presence></mgt-person> -->
       <mgt-person fetch-image person-details='{
         "id": "a2a36b00-b196-4286-adfc-7c1bedbffa39",
         "deletedDateTime": null,

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "setLicense": "gulp setLicense",
     "test": "npm run wtr:coverage",
     "version:tsc": "tsc -v",
-    "wtr": "wtr --puppeteer",
+    "wtr": "wtr --playwright",
     "wtr:coverage": "wtr --playwright --coverage",
     "wtr:watch": "wtr --playwright --watch"
   },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "setLicense": "gulp setLicense",
     "test": "npm run wtr:coverage",
     "version:tsc": "tsc -v",
-    "wtr": "wtr --playwright",
+    "wtr": "wtr --puppeteer",
     "wtr:coverage": "wtr --playwright --coverage",
     "wtr:watch": "wtr --playwright --watch"
   },

--- a/packages/mgt-components/src/components/PersonCardInteraction.ts
+++ b/packages/mgt-components/src/components/PersonCardInteraction.ts
@@ -5,28 +5,24 @@
  * -------------------------------------------------------------------------------------------
  */
 
-/* istanbul ignore file */
+const interactions = ['none', 'hover', 'click'] as const;
 
 /**
  * Defines how a person card is shown when a user interacts with
  * a person component
  *
- * @export
- * @enum {number}
  */
-export enum PersonCardInteraction {
-  /**
-   * Don't show person card
-   */
-  none,
+export type PersonCardInteraction = (typeof interactions)[number];
 
-  /**
-   * Show person card on hover
-   */
-  hover,
+export const isPersonCardInteraction = (value: unknown): value is PersonCardInteraction =>
+  typeof value === 'string' && interactions.includes(value as PersonCardInteraction);
 
-  /**
-   * Show person card on click
-   */
-  click
-}
+export const personCardConverter = (
+  value: string,
+  defaultValue: PersonCardInteraction = 'none'
+): PersonCardInteraction => {
+  if (isPersonCardInteraction(value)) {
+    return value;
+  }
+  return defaultValue;
+};

--- a/packages/mgt-components/src/components/components.ts
+++ b/packages/mgt-components/src/components/components.ts
@@ -29,6 +29,12 @@ import './mgt-search-results/mgt-search-results';
 import './mgt-theme-toggle/mgt-theme-toggle';
 import './sub-components/mgt-spinner/mgt-spinner';
 
+// type exports
+import type { PersonCardInteraction } from './PersonCardInteraction';
+
+export { PersonCardInteraction };
+
+// component exports
 export * from './mgt-agenda/mgt-agenda';
 export * from './mgt-file/mgt-file';
 export * from './mgt-file-list/mgt-file-list';

--- a/packages/mgt-components/src/components/mgt-file-list/mgt-file-list.ts
+++ b/packages/mgt-components/src/components/mgt-file-list/mgt-file-list.ts
@@ -245,8 +245,8 @@ export class MgtFileList extends MgtTemplatedTaskComponent implements CardSectio
   public insightType: OfficeGraphInsightString;
 
   /**
-   * Sets what data to be rendered (file icon only, oneLine, twoLines threeLines).
-   * Default is 'threeLines'.
+   * Sets what data to be rendered (file icon only, oneline, twolines threelines).
+   * Default is 'threelines'.
    *
    * @type {ViewType}
    * @memberof MgtFileList

--- a/packages/mgt-components/src/components/mgt-file-list/mgt-file-list.ts
+++ b/packages/mgt-components/src/components/mgt-file-list/mgt-file-list.ts
@@ -37,7 +37,7 @@ import {
 } from '../../graph/graph.files';
 import './mgt-file-upload/mgt-file-upload';
 import { getSvg, SvgIcon } from '../../utils/SvgHelper';
-import { OfficeGraphInsightString, ViewType } from '../../graph/types';
+import { OfficeGraphInsightString, ViewType, viewTypeConverter } from '../../graph/types';
 import { styles } from './mgt-file-list-css';
 import { strings } from './strings';
 import { MgtFile, registerMgtFileComponent } from '../mgt-file/mgt-file';
@@ -253,21 +253,9 @@ export class MgtFileList extends MgtTemplatedTaskComponent implements CardSectio
    */
   @property({
     attribute: 'item-view',
-    converter: value => {
-      if (!value || value.length === 0) {
-        return ViewType.threelines;
-      }
-
-      value = value.toLowerCase();
-
-      if (typeof ViewType[value] === 'undefined') {
-        return ViewType.threelines;
-      } else {
-        return ViewType[value] as ViewType;
-      }
-    }
+    converter: value => viewTypeConverter(value, 'threelines')
   })
-  public itemView = ViewType.threelines;
+  public itemView: ViewType = 'threelines';
 
   /**
    * allows developer to provide file type to filter the list

--- a/packages/mgt-components/src/components/mgt-file/mgt-file.ts
+++ b/packages/mgt-components/src/components/mgt-file/mgt-file.ts
@@ -246,7 +246,8 @@ export class MgtFile extends MgtTemplatedTaskComponent {
   @property({ attribute: 'line3-property' }) public line3Property: string;
 
   /**
-   * Sets what data to be rendered (file icon only, oneLine, twoLines threeLines).
+   * Sets what data will be rendered.
+   * Valid options are 'image', 'oneline', 'twolines', 'threelines', or 'fourlines'
    * Default is 'threeLines'.
    *
    * @type {ViewType}

--- a/packages/mgt-components/src/components/mgt-file/mgt-file.ts
+++ b/packages/mgt-components/src/components/mgt-file/mgt-file.ts
@@ -27,7 +27,7 @@ import {
   getUserInsightsDriveItemById
 } from '../../graph/graph.files';
 import { formatBytes, getRelativeDisplayDate } from '../../utils/Utils';
-import { OfficeGraphInsightString, ViewType } from '../../graph/types';
+import { OfficeGraphInsightString, ViewType, viewTypeConverter } from '../../graph/types';
 import { getFileTypeIconUriByExtension } from '../../styles/fluent-icons';
 import { getSvg, SvgIcon } from '../../utils/SvgHelper';
 import { strings } from './strings';
@@ -254,19 +254,7 @@ export class MgtFile extends MgtTemplatedTaskComponent {
    */
   @property({
     attribute: 'view',
-    converter: value => {
-      if (!value || value.length === 0) {
-        return ViewType.threelines;
-      }
-
-      value = value.toLowerCase();
-
-      if (typeof ViewType[value] === 'undefined') {
-        return ViewType.threelines;
-      } else {
-        return ViewType[value] as ViewType;
-      }
-    }
+    converter: value => viewTypeConverter(value, 'threelines')
   })
   public view: ViewType;
 
@@ -304,7 +292,7 @@ export class MgtFile extends MgtTemplatedTaskComponent {
     this.line1Property = 'name';
     this.line2Property = 'lastModifiedDateTime';
     this.line3Property = 'size';
-    this.view = ViewType.threelines;
+    this.view = 'threelines';
   }
 
   public renderContent = () => {
@@ -397,13 +385,13 @@ export class MgtFile extends MgtTemplatedTaskComponent {
    * @memberof MgtFile
    */
   protected renderDetails(driveItem: DriveItem): TemplateResult {
-    if (!driveItem || this.view === ViewType.image) {
+    if (!driveItem || this.view === 'image') {
       return html``;
     }
 
     const details: TemplateResult[] = [];
 
-    if (this.view > ViewType.image) {
+    if (this.view > 'image') {
       const text = this.getTextFromProperty(driveItem, this.line1Property);
       if (text) {
         details.push(html`
@@ -412,7 +400,7 @@ export class MgtFile extends MgtTemplatedTaskComponent {
       }
     }
 
-    if (this.view > ViewType.oneline) {
+    if (this.view > 'oneline') {
       const text = this.getTextFromProperty(driveItem, this.line2Property);
       if (text) {
         details.push(html`
@@ -421,7 +409,7 @@ export class MgtFile extends MgtTemplatedTaskComponent {
       }
     }
 
-    if (this.view > ViewType.twolines) {
+    if (this.view > 'twolines') {
       const text = this.getTextFromProperty(driveItem, this.line3Property);
       if (text) {
         details.push(html`

--- a/packages/mgt-components/src/components/mgt-file/mgt-file.ts
+++ b/packages/mgt-components/src/components/mgt-file/mgt-file.ts
@@ -248,7 +248,7 @@ export class MgtFile extends MgtTemplatedTaskComponent {
   /**
    * Sets what data will be rendered.
    * Valid options are 'image', 'oneline', 'twolines', 'threelines', or 'fourlines'
-   * Default is 'threeLines'.
+   * Default is 'threelines'.
    *
    * @type {ViewType}
    * @memberof MgtFile

--- a/packages/mgt-components/src/components/mgt-login/mgt-login.ts
+++ b/packages/mgt-components/src/components/mgt-login/mgt-login.ts
@@ -454,7 +454,7 @@ export class MgtLogin extends MgtTemplatedTaskComponent {
         <mgt-person
           .personDetails=${personDetails}
           .personImage=${personImage}
-          .view=${ViewType.twolines}
+          view="twolines"
           .line2Property=${'email'}
           ?vertical-layout=${this.usesVerticalPersonCard}
           class="person">
@@ -525,19 +525,19 @@ export class MgtLogin extends MgtTemplatedTaskComponent {
   }
 
   private parsePersonDisplayConfiguration(): PersonViewConfig {
-    const displayConfig: PersonViewConfig = { view: ViewType.twolines, avatarSize: 'small' };
+    const displayConfig: PersonViewConfig = { view: 'twolines', avatarSize: 'small' };
     switch (this.loginView) {
       case 'avatar':
-        displayConfig.view = ViewType.image;
+        displayConfig.view = 'image';
         displayConfig.avatarSize = 'small';
         break;
       case 'compact':
-        displayConfig.view = ViewType.oneline;
+        displayConfig.view = 'oneline';
         displayConfig.avatarSize = 'small';
         break;
       case 'full':
       default:
-        displayConfig.view = ViewType.twolines;
+        displayConfig.view = 'twolines';
         displayConfig.avatarSize = 'auto';
         break;
     }
@@ -610,7 +610,7 @@ export class MgtLogin extends MgtTemplatedTaskComponent {
                       <mgt-person
                         .personDetails=${details ? JSON.parse(details) : null}
                         .fallbackDetails=${{ displayName: account.name, mail: account.mail }}
-                        .view=${ViewType.twolines}
+                        .view=${'twolines'}
                         class="account"
                       ></mgt-person>
                     </li>`;

--- a/packages/mgt-components/src/components/mgt-organization/mgt-organization.ts
+++ b/packages/mgt-components/src/components/mgt-organization/mgt-organization.ts
@@ -13,7 +13,6 @@ import { getSvg, SvgIcon } from '../../utils/SvgHelper';
 import { MgtPersonCardState, UserWithManager } from '../mgt-person-card/mgt-person-card.types';
 import { styles } from './mgt-organization-css';
 import { strings } from './strings';
-import { ViewType } from '../../graph/types';
 import { mgtHtml } from '@microsoft/mgt-element';
 import { registerComponent } from '@microsoft/mgt-element';
 import { registerMgtPersonComponent } from '../mgt-person/mgt-person';
@@ -200,7 +199,7 @@ export class MgtOrganization extends BasePersonCardSection {
             class="org-member__person-image"
             .personDetails=${person}
             .fetchImage=${true}
-            .view=${ViewType.twolines}
+            view="twolines"
             .showPresence=${true}
           ></mgt-person>
         </div>
@@ -271,7 +270,7 @@ export class MgtOrganization extends BasePersonCardSection {
                   .personDetails=${person}
                   .fetchImage=${true}
                   .showPresence=${true}
-                  .view=${ViewType.twolines}
+                  view="twolines"
                 ></mgt-person>
               </div>
               <div tabindex="0" class="org-member__more">
@@ -311,7 +310,7 @@ export class MgtOrganization extends BasePersonCardSection {
                 .personDetails=${person}
                 .fetchImage=${true}
                 .showPresence=${true}
-                .view=${ViewType.twolines}
+                view="twolines"
               ></mgt-person>
             </div>
           `
@@ -337,7 +336,7 @@ export class MgtOrganization extends BasePersonCardSection {
              .personDetails=${person}
              .fetchImage=${true}
              .showPresence=${true}
-             .view=${ViewType.twolines}
+             view="twolines"
            ></mgt-person>
          </div>
        </div>
@@ -367,7 +366,7 @@ export class MgtOrganization extends BasePersonCardSection {
             .personDetails=${person}
             .fetchImage=${true}
             .showPresence=${true}
-            .view=${ViewType.twolines}
+            view="twolines"
           ></mgt-person>
         </div>
       </div>

--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -857,7 +857,7 @@ export class MgtPeoplePicker extends MgtTemplatedTaskComponent {
          <mgt-person
           class="person-image-result"
           ?show-presence=${this.showPresence}
-          view="twoLines"
+          view="twolines"
           line2-property="jobTitle,mail"
           .personDetails=${person}
           ?fetch-image=${!this.disableImages}

--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -162,7 +162,8 @@ export class MgtPeoplePicker extends MgtTemplatedTaskComponent {
   })
   public groupIds: string[] = [];
   /**
-   * value determining if search is filtered to a group.
+   * Value determining if search is filtered to a group.
+   * Valid options are 'any', 'person', 'group'
    *
    * @type {PersonType}
    */
@@ -173,8 +174,9 @@ export class MgtPeoplePicker extends MgtTemplatedTaskComponent {
   public type: PersonType = 'any';
 
   /**
-   * type of group to search for - requires personType to be
-   * set to "Group" or "All"
+   * Type of groups to search for - requires personType to be set to "Group" or "All"
+   * Valid values are 'any', 'unified', 'security', 'mailenabledsecurity', 'distribution'
+   * Default is ['any'].
    *
    * @type {GroupType}
    */
@@ -206,7 +208,9 @@ export class MgtPeoplePicker extends MgtTemplatedTaskComponent {
   public groupType: GroupType[] = ['any'];
 
   /**
-   * The type of user to search for. Default is any.
+   * The type of user to search for.
+   * Valid options are 'any', 'user', 'contact'
+   * Default is any.
    *
    * @type {UserType}
    * @memberof MgtPeoplePicker

--- a/packages/mgt-components/src/components/mgt-people/mgt-people.ts
+++ b/packages/mgt-components/src/components/mgt-people/mgt-people.ts
@@ -9,18 +9,17 @@ import * as MicrosoftGraph from '@microsoft/microsoft-graph-types';
 import { html, TemplateResult } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
-import { getPeople, getPeopleFromResource, PersonType } from '../../graph/graph.people';
+import { getPeople, getPeopleFromResource } from '../../graph/graph.people';
 import { getUsersPresenceByPeople } from '../../graph/graph.presence';
 import { findGroupMembers, getUsersForPeopleQueries, getUsersForUserIds } from '../../graph/graph.user';
 import { IDynamicPerson } from '../../graph/types';
 import { Providers, ProviderState, MgtTemplatedTaskComponent, mgtHtml } from '@microsoft/mgt-element';
 import '../../styles/style-helper';
-import { PersonCardInteraction } from './../PersonCardInteraction';
+import { type PersonCardInteraction, personCardConverter } from './../PersonCardInteraction';
+
 import { styles } from './mgt-people-css';
 import { MgtPerson, registerMgtPersonComponent } from '../mgt-person/mgt-person';
 import { registerComponent } from '@microsoft/mgt-element';
-
-export { PersonCardInteraction } from './../PersonCardInteraction';
 
 /**
  * web component to display a group of people or contacts by using their photos or initials.
@@ -124,23 +123,16 @@ export class MgtPeople extends MgtTemplatedTaskComponent {
 
   /**
    * Sets how the person-card is invoked
-   * Set to PersonCardInteraction.none to not show the card
+   * Set to "none" to not show the card
    *
    * @type {PersonCardInteraction}
    * @memberof MgtPerson
    */
   @property({
     attribute: 'person-card',
-    converter: (value, _type) => {
-      value = value.toLowerCase();
-      if (typeof PersonCardInteraction[value] === 'undefined') {
-        return PersonCardInteraction.hover;
-      } else {
-        return PersonCardInteraction[value] as PersonCardInteraction;
-      }
-    }
+    converter: (value, _type) => personCardConverter(value, 'hover')
   })
-  public personCardInteraction: PersonCardInteraction = PersonCardInteraction.hover;
+  public personCardInteraction: PersonCardInteraction = 'hover';
 
   /**
    * The resource to get
@@ -344,7 +336,7 @@ export class MgtPeople extends MgtTemplatedTaskComponent {
       this._arrowKeyLocation = -1;
       peopleContainer.blur();
     } else if (['Enter', 'space', ' '].includes(keyName)) {
-      if (this.personCardInteraction !== PersonCardInteraction.none) {
+      if (this.personCardInteraction !== 'none') {
         const personEl = peopleElements[this._arrowKeyLocation] as HTMLElement;
         const mgtPerson = personEl.querySelector<MgtPerson>('mgt-person');
         if (mgtPerson) {
@@ -424,7 +416,7 @@ export class MgtPeople extends MgtTemplatedTaskComponent {
 
         // populate people
         if (this.groupId) {
-          this.people = await findGroupMembers(graph, null, this.groupId, this.showMax, PersonType.person);
+          this.people = await findGroupMembers(graph, null, this.groupId, this.showMax, 'person');
         } else if (this.userIds) {
           this.people = await getUsersForUserIds(graph, this.userIds, '', '', this.fallbackDetails);
         } else if (this.peopleQueries) {

--- a/packages/mgt-components/src/components/mgt-people/mgt-people.ts
+++ b/packages/mgt-components/src/components/mgt-people/mgt-people.ts
@@ -123,7 +123,8 @@ export class MgtPeople extends MgtTemplatedTaskComponent {
 
   /**
    * Sets how the person-card is invoked
-   * Set to "none" to not show the card
+   * Valid options are: 'none', 'hover', or 'click'
+   * Set to 'none' to not show the card
    *
    * @type {PersonCardInteraction}
    * @memberof MgtPerson

--- a/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.ts
+++ b/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.ts
@@ -20,7 +20,7 @@ import { IGraph } from '@microsoft/mgt-element';
 import { Presence, User, Person } from '@microsoft/microsoft-graph-types';
 
 import { findPeople, getEmailFromGraphEntity } from '../../graph/graph.people';
-import { IDynamicPerson, ViewType } from '../../graph/types';
+import { IDynamicPerson } from '../../graph/types';
 import { getPersonImage } from '../../graph/graph.photos';
 import { getUserWithPhoto } from '../../graph/graph.userWithPhoto';
 import { getSvg, SvgIcon } from '../../utils/SvgHelper';
@@ -599,7 +599,7 @@ export class MgtPersonCard extends MgtTemplatedTaskComponent implements IHistory
         .personImage=${this.getImage()}
         .personPresence=${this.personPresence}
         .showPresence=${this.showPresence}
-        .view=${ViewType.threelines}
+        view="threelines"
       ></mgt-person>
     `;
   }

--- a/packages/mgt-components/src/components/mgt-person/mgt-person-types.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person-types.ts
@@ -4,17 +4,14 @@
  * See License in the project root for license information.
  * -------------------------------------------------------------------------------------------
  */
-export enum avatarType {
-  /**
-   * Renders avatar photo if available, falls back to initials
-   */
-  photo = 'photo',
 
-  /**
-   * Forces render avatar initials
-   */
-  initials = 'initials'
-}
+const avatarTypes = ['photo', 'initials'] as const;
+
+export type AvatarType = (typeof avatarTypes)[number];
+export const isAvatarType = (value: unknown): value is AvatarType =>
+  typeof value === 'string' && avatarTypes.includes(value as AvatarType);
+export const avatarTypeConverter = (value: string, defaultValue: AvatarType = 'photo'): AvatarType =>
+  isAvatarType(value) ? value : defaultValue;
 
 /**
  * Configuration object for the Person component

--- a/packages/mgt-components/src/components/mgt-person/mgt-person.tests.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.tests.ts
@@ -82,7 +82,7 @@ describe('mgt-person - tests', () => {
         givenName: 'Brian',
         surname: 'Herbert',
         personType: {}
-      })}' view="twoLines"></mgt-person>`
+      })}' view="twolines"></mgt-person>`
     );
     await expect(person.shadowRoot.querySelector('span.initials')).lightDom.to.equal('BH');
   });
@@ -96,7 +96,7 @@ describe('mgt-person - tests', () => {
         givenName: null,
         surname: null,
         personType: {}
-      })}' view="twoLines"></mgt-person>`);
+      })}' view="twolines"></mgt-person>`);
     await expect(person.shadowRoot.querySelector('span.initials')).lightDom.to.equal('FH');
   });
 
@@ -108,7 +108,7 @@ describe('mgt-person - tests', () => {
         givenName: 'Frank',
         surname: null,
         personType: {}
-      })}' view="twoLines"></mgt-person>`);
+      })}' view="twolines"></mgt-person>`);
     await expect(person.shadowRoot.querySelector('span.initials')).lightDom.to.equal('F');
   });
 
@@ -120,7 +120,7 @@ describe('mgt-person - tests', () => {
         givenName: 'Frank',
         surname: '',
         personType: {}
-      })}' view="twoLines"></mgt-person>`);
+      })}' view="twolines"></mgt-person>`);
     await expect(person.shadowRoot.querySelector('span.initials')).lightDom.to.equal('F');
   });
 
@@ -132,7 +132,7 @@ describe('mgt-person - tests', () => {
         givenName: null,
         surname: 'Herbert',
         personType: {}
-      })}' view="twoLines"></mgt-person>`);
+      })}' view="twolines"></mgt-person>`);
     await expect(person.shadowRoot.querySelector('span.initials')).lightDom.to.equal('H');
   });
   it('should render with last initial when only surname is populated and given name is an empty string', async () => {
@@ -143,7 +143,7 @@ describe('mgt-person - tests', () => {
         givenName: '',
         surname: 'Herbert',
         personType: {}
-      })}' view="twoLines"></mgt-person>`);
+      })}' view="twolines"></mgt-person>`);
     await expect(person.shadowRoot.querySelector('span.initials')).lightDom.to.equal('H');
   });
 
@@ -155,7 +155,7 @@ describe('mgt-person - tests', () => {
         givenName: null,
         surname: null,
         personType: {}
-      })}' view="twoLines"></mgt-person>`);
+      })}' view="twolines"></mgt-person>`);
     await expect(person.shadowRoot.querySelector('span.initials')).lightDom.to.equal('F');
   });
 
@@ -167,7 +167,7 @@ describe('mgt-person - tests', () => {
         givenName: null,
         surname: null,
         personType: {}
-      })}' view="twoLines"></mgt-person>`);
+      })}' view="twolines"></mgt-person>`);
     await expect(person.shadowRoot.querySelector('span.initials')).lightDom.to.equal('FV');
   });
 });

--- a/packages/mgt-components/src/components/mgt-person/mgt-person.tests.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.tests.ts
@@ -12,7 +12,7 @@ describe('mgt-person - tests', () => {
   registerMgtPersonComponent();
   Providers.globalProvider = new MockProvider(true);
   it('should render', async () => {
-    const person = await fixture(html`<mgt-person person-query="me" view="twoLines"></mgt-person>`);
+    const person = await fixture(html`<mgt-person person-query="me" view="twolines"></mgt-person>`);
     await oneEvent(person, 'person-image-rendered');
     await expect(person).shadowDom.to.equal(
       `<div class=" person-root twolines " dir="ltr">
@@ -30,7 +30,7 @@ describe('mgt-person - tests', () => {
   });
 
   it('should pop up a flyout on click', async () => {
-    const person = await fixture(html`<mgt-person person-query="me" view="twoLines" person-card="click"></mgt-person>`);
+    const person = await fixture(html`<mgt-person person-query="me" view="twolines" person-card="click"></mgt-person>`);
     await oneEvent(person, 'person-image-rendered');
     await expect(person).shadowDom.to.equal(
       `<div class=" person-root twolines " dir="ltr"tabindex="0">

--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -243,7 +243,8 @@ export class MgtPerson extends MgtTemplatedTaskComponent {
 
   /**
    * determines person component avatar size and apply presence badge accordingly.
-   * Default is "auto". When you set the view > 1, it will default to "auto".
+   * Valid options are 'small', 'large', and 'auto'
+   * Default is "auto". When you set the view more than oneline, it will default to "auto".
    *
    * @type {AvatarSize}
    */
@@ -360,8 +361,8 @@ export class MgtPerson extends MgtTemplatedTaskComponent {
   public verticalLayout: boolean;
 
   /**
-   * Determines and sets person avatar
-   *
+   * Determines and sets person avatar view
+   * Valid options are 'photo' or 'initials'
    *
    * @type {AvatarType}
    * @memberof MgtPerson
@@ -394,6 +395,7 @@ export class MgtPerson extends MgtTemplatedTaskComponent {
 
   /**
    * Sets how the person-card is invoked
+   * Valid options are: 'none', 'hover', or 'click'
    * Set to 'none' to not show the card
    *
    * @type {PersonCardInteraction}
@@ -470,7 +472,8 @@ export class MgtPerson extends MgtTemplatedTaskComponent {
   @property({ attribute: 'line4-property' }) public line4Property: string;
 
   /**
-   * Sets what data to be rendered (image only, oneLine, twoLines).
+   * Sets what data to be rendered.
+   * Valid options are 'image', 'oneline', 'twolines', 'threelines', or 'fourlines'
    * Default is 'image'.
    *
    * @type {ViewType}

--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -621,8 +621,8 @@ export class MgtPerson extends MgtTemplatedTaskComponent {
       noline: this.isNoLine(),
       oneline: this.isOneLine(),
       twolines: this.isTwoLines(),
-      threeLines: this.isThreeLines(),
-      fourLines: this.isFourLines()
+      threelines: this.isThreeLines(),
+      fourlines: this.isFourLines()
     };
 
     return html`

--- a/packages/mgt-components/src/components/mgt-planner/mgt-planner.ts
+++ b/packages/mgt-components/src/components/mgt-planner/mgt-planner.ts
@@ -27,7 +27,6 @@ import '../mgt-person/mgt-person';
 import '../sub-components/mgt-arrow-options/mgt-arrow-options';
 import '../sub-components/mgt-dot-options/mgt-dot-options';
 import { MgtFlyout, registerMgtFlyoutComponent } from '../sub-components/mgt-flyout/mgt-flyout';
-import { PersonCardInteraction } from '../PersonCardInteraction';
 import { styles } from './mgt-planner-css';
 import { strings } from './strings';
 import { ITask, ITaskFolder, ITaskGroup, ITaskSource, PlannerTaskSource } from './task-sources';
@@ -1118,7 +1117,7 @@ export class MgtPlanner extends MgtTemplatedTaskComponent {
       <mgt-people
         class="people people-${taskId}"
         .userIds=${assignedPeople}
-        .personCardInteraction=${PersonCardInteraction.none}
+        person-card="none"
         @click=${(e: MouseEvent) => this.handlePeopleClick(e, task)}
         @keydown=${(e: KeyboardEvent) => this.handlePeopleKeydown(e, task)}
       >

--- a/packages/mgt-components/src/components/mgt-search-results/mgt-search-results.ts
+++ b/packages/mgt-components/src/components/mgt-search-results/mgt-search-results.ts
@@ -933,7 +933,7 @@ export class MgtSearchResults extends MgtTemplatedTaskComponent {
             <div class="search-result-author">
               <mgt-person
                 person-query=${resource.lastModifiedBy.user.email}
-                view="oneLine"
+                view="oneline"
                 person-card="hover"
                 show-presence="true">
               </mgt-person>
@@ -1038,7 +1038,7 @@ export class MgtSearchResults extends MgtTemplatedTaskComponent {
             <div class="search-result-author">
               <mgt-person
                 person-query=${resource.lastModifiedBy.user.email}
-                view="oneLine"
+                view="oneline"
                 person-card="hover"
                 show-presence="true">
               </mgt-person>
@@ -1074,7 +1074,7 @@ export class MgtSearchResults extends MgtTemplatedTaskComponent {
     return mgtHtml`
       <div class="search-result">
         <mgt-person
-          view="fourLines"
+          view="fourlines"
           person-query=${resource.userPrincipalName}
           person-card="hover"
           show-presence="true">

--- a/packages/mgt-components/src/graph/graph.files.ts
+++ b/packages/mgt-components/src/graph/graph.files.ts
@@ -18,6 +18,7 @@ import { DriveItem, SharedInsight, Trending, UploadSession, UsedInsight } from '
 import { schemas } from './cacheStores';
 import { GraphRequest, ResponseType } from '@microsoft/microsoft-graph-client';
 import { blobToBase64 } from '../utils/Utils';
+import { MgtFileUploadConflictBehavior } from '../components/mgt-file-list/mgt-file-upload/mgt-file-upload';
 
 /**
  * Simple type guard to check if a response is an UploadSession
@@ -738,13 +739,13 @@ export const getGraphfile = async (graph: IGraph, resource: string): Promise<Dri
 export const getUploadSession = async (
   graph: IGraph,
   resource: string,
-  conflictBehavior: number
+  conflictBehavior: MgtFileUploadConflictBehavior
 ): Promise<UploadSession> => {
   try {
     // get from graph request
     const sessionOptions = {
       item: {
-        '@microsoft.graph.conflictBehavior': conflictBehavior === 0 || conflictBehavior === null ? 'rename' : 'replace'
+        '@microsoft.graph.conflictBehavior': conflictBehavior ? conflictBehavior : 'rename'
       }
     };
     let response: UploadSession;

--- a/packages/mgt-components/src/graph/graph.groups.ts
+++ b/packages/mgt-components/src/graph/graph.groups.ts
@@ -17,42 +17,19 @@ import {
 import { Group } from '@microsoft/microsoft-graph-types';
 import { schemas } from './cacheStores';
 
+const groupTypeValues = ['any', 'unified', 'security', 'mailenabledsecurity', 'distribution'] as const;
+
 /**
  * Group Type enumeration
  *
  * @export
- * @enum {number}
+ * @enum {string}
  */
-export enum GroupType {
-  /**
-   * Any group Type
-   */
-  any = 0,
-
-  /**
-   * Office 365 group
-   */
-  // eslint-disable-next-line no-bitwise
-  unified = 1 << 0,
-
-  /**
-   * Security group
-   */
-  // eslint-disable-next-line no-bitwise
-  security = 1 << 1,
-
-  /**
-   * Mail Enabled Security group
-   */
-  // eslint-disable-next-line no-bitwise
-  mailenabledsecurity = 1 << 2,
-
-  /**
-   * Distribution Group
-   */
-  // eslint-disable-next-line no-bitwise
-  distribution = 1 << 3
-}
+export type GroupType = (typeof groupTypeValues)[number];
+export const isGroupType = (value: unknown): value is GroupType =>
+  typeof value === 'string' && groupTypeValues.includes(value as GroupType);
+export const groupTypeConverter = (value: string, defaultValue: GroupType = 'any'): GroupType =>
+  isGroupType(value) ? value : defaultValue;
 
 /**
  * Object to be stored in cache
@@ -112,18 +89,18 @@ const validTransitiveGroupMemberScopes = [
  * @param {IGraph} graph
  * @param {string} query - what to search for
  * @param {number} [top=10] - number of groups to return
- * @param {GroupType} [groupTypes=GroupType.any] - the type of group to search for
+ * @param {GroupType} [groupTypes=["any"]] - the type of group to search for
  * @returns {Promise<Group[]>} An array of Groups
  */
 export const findGroups = async (
   graph: IGraph,
   query: string,
   top = 10,
-  groupTypes: GroupType = GroupType.any,
+  groupTypes: GroupType[] = ['any'],
   groupFilters = ''
 ): Promise<Group[]> => {
   let cache: CacheStore<CacheGroupQuery>;
-  const key = `${query ? query : '*'}*${groupTypes}*${groupFilters}:${top}`;
+  const key = `${query ? query : '*'}*${groupTypes.join('+')}*${groupFilters}:${top}`;
 
   if (getIsGroupsCacheEnabled()) {
     cache = CacheService.getCache(schemas.groups, schemas.groups.stores.groupsQuery);
@@ -149,28 +126,24 @@ export const findGroups = async (
     filterQuery += `${query ? ' and ' : ''}${groupFilters}`;
   }
 
-  if (groupTypes !== GroupType.any) {
+  if (!groupTypes.includes('any')) {
     const batch = graph.createBatch<CollectionResponse<Group>>();
 
     const filterGroups: string[] = [];
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison, no-bitwise
-    if (GroupType.unified === (groupTypes & GroupType.unified)) {
+    if (groupTypes.includes('unified')) {
       filterGroups.push("groupTypes/any(c:c+eq+'Unified')");
     }
 
-    // eslint-disable-next-line no-bitwise, @typescript-eslint/no-unsafe-enum-comparison
-    if (GroupType.security === (groupTypes & GroupType.security)) {
+    if (groupTypes.includes('security')) {
       filterGroups.push('(mailEnabled eq false and securityEnabled eq true)');
     }
 
-    // eslint-disable-next-line no-bitwise, @typescript-eslint/no-unsafe-enum-comparison
-    if (GroupType.mailenabledsecurity === (groupTypes & GroupType.mailenabledsecurity)) {
+    if (groupTypes.includes('mailenabledsecurity')) {
       filterGroups.push('(mailEnabled eq true and securityEnabled eq true)');
     }
 
-    // eslint-disable-next-line no-bitwise, @typescript-eslint/no-unsafe-enum-comparison
-    if (GroupType.distribution === (groupTypes & GroupType.distribution)) {
+    if (groupTypes.includes('distribution')) {
       filterGroups.push('(mailEnabled eq true and securityEnabled eq false)');
     }
 
@@ -241,7 +214,7 @@ export const findGroups = async (
  * @param {string} groupId - what to search for
  * @param {number} [top=10] - number of groups to return
  * @param {boolean} [transitive=false] - whether the return should contain a flat list of all nested members
- * @param {GroupType} [groupTypes=GroupType.any] - the type of group to search for
+ * @param {GroupType} [groupTypes=["any"]] - the type of group to search for
  * @returns {Promise<Group[]>} An array of Groups
  */
 export const findGroupsFromGroup = async (
@@ -250,10 +223,10 @@ export const findGroupsFromGroup = async (
   groupId: string,
   top = 10,
   transitive = false,
-  groupTypes: GroupType = GroupType.any
+  groupTypes: GroupType[] = ['any']
 ): Promise<Group[]> => {
   let cache: CacheStore<CacheGroupQuery>;
-  const key = `${groupId}:${query || '*'}:${groupTypes}:${transitive}`;
+  const key = `${groupId}:${query || '*'}:${groupTypes.join('+')}:${transitive}`;
 
   if (getIsGroupsCacheEnabled()) {
     cache = CacheService.getCache(schemas.groups, schemas.groups.stores.groupsQuery);
@@ -273,26 +246,22 @@ export const findGroupsFromGroup = async (
     filterQuery = `(startswith(displayName,'${query}') or startswith(mailNickname,'${query}') or startswith(mail,'${query}'))`;
   }
 
-  if (groupTypes !== GroupType.any) {
+  if (!groupTypes.includes('any')) {
     const filterGroups = [];
 
-    // eslint-disable-next-line no-bitwise, @typescript-eslint/no-unsafe-enum-comparison
-    if (GroupType.unified === (groupTypes & GroupType.unified)) {
+    if (groupTypes.includes('unified')) {
       filterGroups.push("groupTypes/any(c:c+eq+'Unified')");
     }
 
-    // eslint-disable-next-line no-bitwise, @typescript-eslint/no-unsafe-enum-comparison
-    if (GroupType.security === (groupTypes & GroupType.security)) {
+    if (groupTypes.includes('security')) {
       filterGroups.push('(mailEnabled eq false and securityEnabled eq true)');
     }
 
-    // eslint-disable-next-line no-bitwise, @typescript-eslint/no-unsafe-enum-comparison
-    if (GroupType.mailenabledsecurity === (groupTypes & GroupType.mailenabledsecurity)) {
+    if (groupTypes.includes('mailenabledsecurity')) {
       filterGroups.push('(mailEnabled eq true and securityEnabled eq true)');
     }
 
-    // eslint-disable-next-line no-bitwise, @typescript-eslint/no-unsafe-enum-comparison
-    if (GroupType.distribution === (groupTypes & GroupType.distribution)) {
+    if (groupTypes.includes('distribution')) {
       filterGroups.push('(mailEnabled eq true and securityEnabled eq false)');
     }
 
@@ -448,7 +417,7 @@ export const findGroupsFromGroupIds = async (
   query: string,
   groupIds: string[],
   top = 10,
-  groupTypes: GroupType = GroupType.any,
+  groupTypes: GroupType[] = ['any'],
   filters = ''
 ): Promise<Group[]> => {
   const foundGroups: Group[] = [];

--- a/packages/mgt-components/src/graph/graph.user.ts
+++ b/packages/mgt-components/src/graph/graph.user.ts
@@ -442,7 +442,7 @@ export const findUsers = async (graph: IGraph, query: string, top = 10, userFilt
  * @param {string} query
  * @param {string} groupId - the group to query
  * @param {number} [top=10] - number of people to return
- * @param {PersonType} [personType=PersonType.person] - the type of person to search for
+ * @param {PersonType} [personType='person'] - the type of person to search for
  * @param {boolean} [transitive=false] - whether the return should contain a flat list of all nested members
  * @returns {(Promise<User[]>)}
  */
@@ -451,7 +451,7 @@ export const findGroupMembers = async (
   query: string,
   groupId: string,
   top = 10,
-  personType: PersonType = PersonType.person,
+  personType: PersonType = 'person',
   transitive = false,
   userFilters = '',
   peopleFilters = ''
@@ -483,9 +483,9 @@ export const findGroupMembers = async (
   }
 
   let apiUrl = `/groups/${groupId}/${transitive ? 'transitiveMembers' : 'members'}`;
-  if (personType === PersonType.person) {
+  if (personType === 'person') {
     apiUrl += '/microsoft.graph.user';
-  } else if (personType === PersonType.group) {
+  } else if (personType === 'group') {
     apiUrl += '/microsoft.graph.group';
     if (query) {
       filter = `startswith(displayName,'${query}') or startswith(mail,'${query}')`;
@@ -523,7 +523,7 @@ export const findUsersFromGroupIds = async (
   query: string,
   groupIds: string[],
   top = 10,
-  personType: PersonType = PersonType.person,
+  personType: PersonType = 'person',
   transitive = false,
   groupFilters = ''
 ): Promise<User[]> => {

--- a/packages/mgt-components/src/graph/types.ts
+++ b/packages/mgt-components/src/graph/types.ts
@@ -39,38 +39,52 @@ export type AvatarSize = 'small' | 'large' | 'auto';
  */
 export type OfficeGraphInsightString = 'trending' | 'used' | 'shared';
 
+const viewTypes = ['image', 'oneline', 'twolines', 'threelines', 'fourlines'] as const;
 /**
  * Enumeration to define what parts of the person component render
  *
  * @export
- * @enum {number}
+ * @enum {string}
  */
-export enum ViewType {
-  /**
-   * Render only the avatar
-   */
-  image = 2,
+export type ViewType = (typeof viewTypes)[number];
 
-  /**
-   * Render the avatar and one line of text
-   */
-  oneline = 3,
+export const isViewType = (value: unknown): value is ViewType => {
+  return typeof value === 'string' && viewTypes.includes(value as ViewType);
+};
 
-  /**
-   * Render the avatar and two lines of text
-   */
-  twolines = 4,
+export const viewTypeConverter = (value: string, defaultValue: ViewType = 'twolines'): ViewType => {
+  if (isViewType(value)) {
+    return value;
+  }
+  return defaultValue;
+};
 
-  /**
-   * Render the avatar and three lines of text
-   */
-  threelines = 5,
+// {
+//   /**
+//    * Render only the avatar
+//    */
+//   image = 2,
 
-  /**
-   * Render the avatar and four lines of text
-   */
-  fourlines = 6
-}
+//   /**
+//    * Render the avatar and one line of text
+//    */
+//   oneline = 3,
+
+//   /**
+//    * Render the avatar and two lines of text
+//    */
+//   twolines = 4,
+
+//   /**
+//    * Render the avatar and three lines of text
+//    */
+//   threelines = 5,
+
+//   /**
+//    * Render the avatar and four lines of text
+//    */
+//   fourlines = 6
+// }
 
 /**
  * Postion describes the position of the dropdown

--- a/packages/mgt-components/src/graph/types.ts
+++ b/packages/mgt-components/src/graph/types.ts
@@ -35,7 +35,7 @@ export type IDynamicPerson = (IUser | IContact | IGroup) & {
 export type AvatarSize = 'small' | 'large' | 'auto';
 
 /**
- * Insight string types used to retrive OneDrive files
+ * Insight string types used to retrieve OneDrive files
  */
 export type OfficeGraphInsightString = 'trending' | 'used' | 'shared';
 
@@ -58,33 +58,6 @@ export const viewTypeConverter = (value: string, defaultValue: ViewType = 'twoli
   }
   return defaultValue;
 };
-
-// {
-//   /**
-//    * Render only the avatar
-//    */
-//   image = 2,
-
-//   /**
-//    * Render the avatar and one line of text
-//    */
-//   oneline = 3,
-
-//   /**
-//    * Render the avatar and two lines of text
-//    */
-//   twolines = 4,
-
-//   /**
-//    * Render the avatar and three lines of text
-//    */
-//   threelines = 5,
-
-//   /**
-//    * Render the avatar and four lines of text
-//    */
-//   fourlines = 6
-// }
 
 /**
  * Postion describes the position of the dropdown

--- a/packages/mgt-react/src/generated/person.ts
+++ b/packages/mgt-react/src/generated/person.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import { IDynamicPerson,AvatarSize,PersonCardInteraction,ViewType } from '@microsoft/mgt-components';
+import { IDynamicPerson,AvatarSize,AvatarType,PersonCardInteraction,ViewType } from '@microsoft/mgt-components';
 import { registerMgtPersonComponent } from '@microsoft/mgt-components';
 import { TemplateContext,TemplateRenderedData } from '@microsoft/mgt-element';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -21,7 +21,7 @@ export type PersonProps = {
 	fetchImage?: boolean;
 	disableImageFetch?: boolean;
 	verticalLayout?: boolean;
-	avatarType?: string;
+	avatarType?: AvatarType;
 	personPresence?: MicrosoftGraph.Presence;
 	personCardInteraction?: PersonCardInteraction;
 	line1Property?: string;

--- a/packages/providers/mgt-electron-provider/src/Authenticator/ElectronAuthenticator.ts
+++ b/packages/providers/mgt-electron-provider/src/Authenticator/ElectronAuthenticator.ts
@@ -76,7 +76,7 @@ export interface MsalElectronConfig {
 /**
  * Prompt type for consent or login
  *
- * @enum {number}
+ * @enum {string}
  */
 enum promptType {
   /**
@@ -88,7 +88,7 @@ enum promptType {
 /**
  * State of Authentication Provider
  *
- * @enum {number}
+ * @enum {string}
  */
 enum AuthState {
   /**

--- a/packages/providers/mgt-msal2-provider/src/Msal2Provider.ts
+++ b/packages/providers/mgt-msal2-provider/src/Msal2Provider.ts
@@ -178,7 +178,7 @@ export interface Msal2PublicClientApplicationConfig extends Msal2ConfigBase {
  * Prompt type enum
  *
  * @export
- * @enum {number}
+ * @enum {string}
  */
 export enum PromptType {
   SELECT_ACCOUNT = 'select_account',

--- a/packages/providers/mgt-teamsfx-provider/README.md
+++ b/packages/providers/mgt-teamsfx-provider/README.md
@@ -57,7 +57,7 @@ To learn more about authentication providers, see [Providers](./providers.md).
         public render(): void {
             return (
                 <div>
-                    <Person personQuery="me" view={ViewType.threelines}></Person>
+                    <Person personQuery="me" view="threelines"></Person>
                 </div>
             );
         }

--- a/packages/providers/mgt-teamsfx-provider/README.md
+++ b/packages/providers/mgt-teamsfx-provider/README.md
@@ -49,7 +49,7 @@ To learn more about authentication providers, see [Providers](./providers.md).
 
     ```html
         <!-- Using HTML -->
-        <mgt-person query="me" view="threeLines"></mgt-person>
+        <mgt-person query="me" view="threelines"></mgt-person>
     ```
 
     ```ts

--- a/samples/react-contoso/src/components/DirectReports.tsx
+++ b/samples/react-contoso/src/components/DirectReports.tsx
@@ -16,7 +16,7 @@ import {
 
 import { SkeletonItem } from '@fluentui/react-components';
 import { FeedRegular } from '@fluentui/react-icons';
-import { Get, MgtTemplateProps, Person, PersonCardInteraction, ViewType } from '@microsoft/mgt-react';
+import { Get, MgtTemplateProps, Person } from '@microsoft/mgt-react';
 import React from 'react';
 
 export interface IIndicentsProps {}
@@ -39,7 +39,7 @@ const getColumns = (shimmered: boolean): TableColumnDefinition<any>[] => {
             {shimmered ? (
               <SkeletonItem shape="rectangle" style={{ width: '120px' }} />
             ) : (
-              <Person userId={item.id} view={ViewType.oneline} personCardInteraction={PersonCardInteraction.hover} />
+              <Person userId={item.id} view="oneline" personCardInteraction="hover" />
             )}
           </TableCellLayout>
         );

--- a/samples/react-contoso/src/components/Messages.tsx
+++ b/samples/react-contoso/src/components/Messages.tsx
@@ -71,7 +71,7 @@ export function Messages(props: MgtTemplateProps) {
       <a className={styles.link} href={email.webLink} target="_blank" rel="noreferrer">
         <div className={styles.header}>
           <div>
-            <Person personQuery={email.sender?.emailAddress?.address} personCardInteraction="hover" />
+            <Person personQuery={email.sender?.emailAddress?.address} personCardInteraction="hover" view="oneline" />
           </div>
         </div>
         <div className={styles.title}>

--- a/samples/react-contoso/src/components/Messages.tsx
+++ b/samples/react-contoso/src/components/Messages.tsx
@@ -1,4 +1,4 @@
-import { MgtTemplateProps, Person, PersonCardInteraction, ViewType } from '@microsoft/mgt-react';
+import { MgtTemplateProps, Person } from '@microsoft/mgt-react';
 import { makeStyles, mergeClasses, shorthands } from '@fluentui/react-components';
 
 const useStyles = makeStyles({
@@ -71,11 +71,7 @@ export function Messages(props: MgtTemplateProps) {
       <a className={styles.link} href={email.webLink} target="_blank" rel="noreferrer">
         <div className={styles.header}>
           <div>
-            <Person
-              personQuery={email.sender?.emailAddress?.address}
-              view={ViewType.oneline}
-              personCardInteraction={PersonCardInteraction.hover}
-            />
+            <Person personQuery={email.sender?.emailAddress?.address} personCardInteraction="hover" />
           </div>
         </div>
         <div className={styles.title}>

--- a/samples/react-contoso/src/pages/HomePage.tsx
+++ b/samples/react-contoso/src/pages/HomePage.tsx
@@ -4,7 +4,6 @@ import {
   FileList,
   File,
   Person,
-  PersonCardInteraction,
   Spinner,
   Agenda,
   PersonCard,
@@ -42,7 +41,12 @@ const HomePage: React.FunctionComponent = () => {
         driveId="b!M5IeZ2QKf0y18TIIXsDQkecHx1QrukxCte8X3n6ka6yn409-utaER7M2W9uRO4yB"
         itemId="01WEUQSTSBWERA5VH4BFALQBXUDVUMT22G"
       />
-      <Person personQuery="LeeG@wgww6.onmicrosoft.com" personCardInteraction={PersonCardInteraction.click} />
+      <Person
+        personQuery="LeeG@wgww6.onmicrosoft.com"
+        personCardInteraction="click"
+        avatarType="initials"
+        avatarSize="auto"
+      />
       <Agenda />
       <PersonCard personQuery="LeeG@wgww6.onmicrosoft.com" />
     </>

--- a/samples/react-contoso/src/pages/Search/FilesResults.tsx
+++ b/samples/react-contoso/src/pages/Search/FilesResults.tsx
@@ -1,7 +1,7 @@
 import { SearchResults } from '@microsoft/mgt-react';
 import * as React from 'react';
 import { IResultsProps } from './IResultsProps';
-import { MgtTemplateProps, Person, File, PersonCardInteraction, ViewType } from '@microsoft/mgt-react';
+import { MgtTemplateProps, Person, File } from '@microsoft/mgt-react';
 import {
   DataGrid,
   DataGridBody,
@@ -101,7 +101,7 @@ const getColumns = (shimmered: boolean, styles): TableColumnDefinition<any>[] =>
               <SkeletonItem shape="rectangle" style={{ width: '120px' }} />
             ) : (
               <div className={styles.fileContainer}>
-                <File fileDetails={item.resource} view={ViewType.image} />
+                <File fileDetails={item.resource} view="image" />
                 <span className={styles.fileTitle}>{item.resource.listItem.fields.title}</span>
               </div>
             )}
@@ -148,11 +148,7 @@ const getColumns = (shimmered: boolean, styles): TableColumnDefinition<any>[] =>
                 <SkeletonItem style={{ width: '120px' }} />
               </div>
             ) : (
-              <Person
-                personQuery={item.resource.createdBy.user.email}
-                view={ViewType.oneline}
-                personCardInteraction={PersonCardInteraction.hover}
-              />
+              <Person personQuery={item.resource.createdBy.user.email} view="oneline" personCardInteraction="hover" />
             )}
           </TableCellLayout>
         );

--- a/specs/mgt-people-picker.md
+++ b/specs/mgt-people-picker.md
@@ -79,6 +79,6 @@ The following events are fired from the component.
 
 | Object store | Cached data    | Remarks                                                            |
 | ------------ | -------------- | ------------------------------------------------------------------ |
-| `groups`     | List of groups | Used when `type` is set to `PersonType.group`                      |
-| `people`     | List of people | Used when `type` is set to `PersonType.person` or `PersonType.any` |
+| `groups`     | List of groups | Used when `type` is set to `group`                      |
+| `people`     | List of people | Used when `type` is set to `person` or `any` |
 | `users`      | List of users  | Used when `groupId` specified                                      |

--- a/stories/components/fileList/fileList.properties.stories.js
+++ b/stories/components/fileList/fileList.properties.stories.js
@@ -111,9 +111,9 @@ export const getFileListByExtensionsAndSize = () => html`
   `;
 
 export const fileListItemView = () => html`
-    <mgt-file-list item-view="oneLine" page-size=3></mgt-file-list>
-    <mgt-file-list item-view="twoLines" page-size=3></mgt-file-list>
-    <mgt-file-list item-view="threeLines" page-size=3></mgt-file-list>
+    <mgt-file-list item-view="oneline" page-size=3></mgt-file-list>
+    <mgt-file-list item-view="twolines" page-size=3></mgt-file-list>
+    <mgt-file-list item-view="threelines" page-size=3></mgt-file-list>
   `;
 
 export const clearCacheAndReload = () => html`

--- a/stories/components/get/get.stories.js
+++ b/stories/components/get/get.stories.js
@@ -102,7 +102,7 @@ export const GetEmail = () => html`
 `;
 
 export const ExtendingPersonCard = () => html`
-  <mgt-person person-query="Isaiah" view="twoLines" person-card="hover">
+  <mgt-person person-query="Isaiah" view="twolines" person-card="hover">
     <template data-type="person-card">
       <mgt-person-card inherit-details>
         <template data-type="additional-details">

--- a/stories/components/person/person.properties.stories.js
+++ b/stories/components/person/person.properties.stories.js
@@ -15,22 +15,22 @@ export default {
 };
 
 export const userId = () => html`
-   <mgt-person user-id="2804bc07-1e1f-4938-9085-ce6d756a32d2" view="twoLines"></mgt-person>
+   <mgt-person user-id="2804bc07-1e1f-4938-9085-ce6d756a32d2" view="twolines"></mgt-person>
  `;
 
 export const personCard = () => html`
    <div class="example">
      <div style="margin-bottom:10px">Person card Hover</div>
-     <mgt-person person-query="me" view="twoLines" person-card="hover"></mgt-person>
+     <mgt-person person-query="me" view="twolines" person-card="hover"></mgt-person>
    </div>
    <div class="example">
      <div style="margin-bottom:10px">Person card Click</div>
-     <mgt-person person-query="me" view="twoLines" person-card="click"></mgt-person>
+     <mgt-person person-query="me" view="twolines" person-card="click"></mgt-person>
    </div>
  `;
 
 export const setPersonDetails = () => html`
-   <mgt-person class="my-person" view="twoLines" line2-property="title" person-card="hover" fetch-image> </mgt-person>
+   <mgt-person class="my-person" view="twolines" line2-property="title" person-card="hover" fetch-image> </mgt-person>
    <script>
      const person = document.querySelector('.my-person');
 
@@ -72,24 +72,24 @@ export const changeUserId = () => html`
 
 export const personFallbackDetails = () => html`
    <div class="example">
-   <mgt-person person-query="mbowen" view="twoLines" show-presence fallback-details='{"displayName":"Megan Bowen"}'></mgt-person>
+   <mgt-person person-query="mbowen" view="twolines" show-presence fallback-details='{"displayName":"Megan Bowen"}'></mgt-person>
  </div>
  <div class="example">
-   <mgt-person person-query="mbowen" view="twoLines" show-presence
+   <mgt-person person-query="mbowen" view="twolines" show-presence
      fallback-details='{"mail":"MeganB@M365x214355.onmicrosoft.com"}'></mgt-person>
  </div>
  <div class="example">
-   <mgt-person person-query="mbowen" view="twoLines" show-presence
+   <mgt-person person-query="mbowen" view="twolines" show-presence
      fallback-details='{"mail":"MeganB@M365x214355.onmicrosoft.com","displayName":"Megan Bowen"}'></mgt-person>
  </div>
  <!-- No Fallback details -->
  <div class="example">
-   <mgt-person person-query="mbowen" view="twoLines" show-presence
+   <mgt-person person-query="mbowen" view="twolines" show-presence
      fallback-details='{}'></mgt-person>
  </div>
 <!-- Correct Person Query and Fallback Details -->
  <div class="example">
-   <mgt-person person-query="bowen" view="twoLines" show-presence
+   <mgt-person person-query="bowen" view="twolines" show-presence
    fallback-details='{"mail":"Noone@M365x214355.onmicrosoft.com","displayName":"Someone"}'></mgt-person>
  </div>
  
@@ -134,7 +134,7 @@ export const personView = () => html`
      <mgt-person person-query="me" id="online3" show-presence view="threelines"></mgt-person>
    </div>
    <div class="example">
-     <mgt-person person-query="me" id="online4" show-presence view="fourLines" ></mgt-person>
+     <mgt-person person-query="me" id="online4" show-presence view="fourlines" ></mgt-person>
    </div>
 
    <script>
@@ -183,14 +183,14 @@ export const personPresence = () => html`
      }
  </style>
    <div>Show presence</div>
-   <mgt-person person-query="me" show-presence view="twoLines" class="example"></mgt-person>
+   <mgt-person person-query="me" show-presence view="twolines" class="example"></mgt-person>
    <div>Set presence</div>
-   <mgt-person person-query="me" id="online" person-presence="{activity: 'Available', availability:'Available', id:null}" show-presence view="twoLines" class="example"></mgt-person>
+   <mgt-person person-query="me" id="online" person-presence="{activity: 'Available', availability:'Available', id:null}" show-presence view="twolines" class="example"></mgt-person>
    <div>Presence Line properties</div>
    <mgt-person
      person-query="me"
      show-presence
-     view="twoLines"
+     view="twolines"
      class="example"
      line1-property="presenceAvailability"
      line2-property="presenceActivity"
@@ -302,14 +302,14 @@ export const personPresenceDisplayAll = () => html`
      }
    </style>
    <div class="title"><span>Presence badge on big avatars: </span></div>
-   <mgt-person id="online" person-query="me" show-presence view="twoLines"></mgt-person>
-   <mgt-person id="onlineOof" person-query="Isaiah Langer" show-presence view="twoLines"></mgt-person>
-   <mgt-person id="busy" person-query="bobk@tailspintoys.com" show-presence view="twoLines"></mgt-person>
-   <mgt-person id="busyOof" person-query="Diego Siciliani" show-presence view="twoLines"></mgt-person>
-   <mgt-person id="dnd" person-query="Lynne Robbins" show-presence view="twoLines"></mgt-person>
-   <mgt-person id="dndOof" person-query="EmilyB" show-presence view="twoLines"></mgt-person>
-   <mgt-person id="away" person-query="BrianJ" show-presence view="twoLines"></mgt-person>
-   <mgt-person id="oof" person-query="JoniS@M365x214355.onmicrosoft.com" show-presence view="twoLines"></mgt-person>
+   <mgt-person id="online" person-query="me" show-presence view="twolines"></mgt-person>
+   <mgt-person id="onlineOof" person-query="Isaiah Langer" show-presence view="twolines"></mgt-person>
+   <mgt-person id="busy" person-query="bobk@tailspintoys.com" show-presence view="twolines"></mgt-person>
+   <mgt-person id="busyOof" person-query="Diego Siciliani" show-presence view="twolines"></mgt-person>
+   <mgt-person id="dnd" person-query="Lynne Robbins" show-presence view="twolines"></mgt-person>
+   <mgt-person id="dndOof" person-query="EmilyB" show-presence view="twolines"></mgt-person>
+   <mgt-person id="away" person-query="BrianJ" show-presence view="twolines"></mgt-person>
+   <mgt-person id="oof" person-query="JoniS@M365x214355.onmicrosoft.com" show-presence view="twolines"></mgt-person>
    <div class="title"><span>Presence badge on small avatars: </span></div>
    <mgt-person class="small" id="online-small" person-query="me" show-presence></mgt-person>
    <mgt-person class="small" id="onlineOof-small" person-query="Isaiah Langer" show-presence></mgt-person>
@@ -379,7 +379,7 @@ export const moreExamples = () => html`
 
    <div class="example">
      <div>Two lines</div>
-     <mgt-person person-query="me" view="twoLines"></mgt-person>
+     <mgt-person person-query="me" view="twolines"></mgt-person>
    </div>
 
    <div class="example">
@@ -389,7 +389,7 @@ export const moreExamples = () => html`
        person-query="me"
        line1-property="givenName"
        line2-property="jobTitle,mail"
-       view="twoLines"
+       view="twolines"
      ></mgt-person>
    </div>
 
@@ -400,12 +400,12 @@ export const moreExamples = () => html`
 
    <div class="example">
      <div>Different styles (see css tab for style)</div>
-     <mgt-person class="styled-person" person-query="me" view="twoLines"></mgt-person>
+     <mgt-person class="styled-person" person-query="me" view="twolines"></mgt-person>
    </div>
 
    <div class="example" style="width: 200px">
      <div>Overflow</div>
-     <mgt-person person-query="me" view="twoLines"></mgt-person>
+     <mgt-person person-query="me" view="twolines"></mgt-person>
    </div>
 
   <div class="example">
@@ -422,7 +422,7 @@ export const moreExamples = () => html`
     <div>Additional Person properties</div>
     <mgt-person
       person-query="me"
-      view="twoLines"
+      view="twolines"
       line1-property="displayName"
       line2-property="officeLocation"
     ></mgt-person>
@@ -435,14 +435,14 @@ export const moreExamples = () => html`
       <li role="menuitem" data-is-focusable="true" class="ui-list__item" tabindex="0">
         <mgt-person
           person-query="me"
-          view="twoLines"
+          view="twolines"
           line2-property="jobTitle"
         ></mgt-person>
       </li>
       <li role="menuitem" data-is-focusable="true" class="ui-list__item" tabindex="-1">
         <mgt-person
           user-id="2804bc07-1e1f-4938-9085-ce6d756a32d2"
-          view="twoLines"
+          view="twolines"
           line2-property="jobTitle"
         ></mgt-person>
       </li>
@@ -452,11 +452,11 @@ export const moreExamples = () => html`
 `;
 
 export const personDetailExamples = () => html`
-<mgt-person person-details='{"displayName":"Frank Herbert","mail":"herbert@dune.net","givenName":null,"surname":null,"personType":{}}' view="twoLines"></mgt-person>
+<mgt-person person-details='{"displayName":"Frank Herbert","mail":"herbert@dune.net","givenName":null,"surname":null,"personType":{}}' view="twolines"></mgt-person>
 <br>
-<mgt-person person-details='{"displayName":"Frank van Herbert","mail":"herbert@dune.net","givenName":null,"surname":null,"personType":{}}' view="twoLines"></mgt-person>
+<mgt-person person-details='{"displayName":"Frank van Herbert","mail":"herbert@dune.net","givenName":null,"surname":null,"personType":{}}' view="twolines"></mgt-person>
 <br>
-<mgt-person person-details='{"displayName":"Frank Herbert","mail":"herbert@dune.net","givenName":"Frank","surname":null,"personType":{}}' view="twoLines"></mgt-person>
+<mgt-person person-details='{"displayName":"Frank Herbert","mail":"herbert@dune.net","givenName":"Frank","surname":null,"personType":{}}' view="twolines"></mgt-person>
 <br>
-<mgt-person person-details='{"displayName":"Frank Herbert","mail":"herbert@dune.net","givenName":null,"surname":"Herbert","personType":{}}' view="twoLines"></mgt-person>
+<mgt-person person-details='{"displayName":"Frank Herbert","mail":"herbert@dune.net","givenName":null,"surname":"Herbert","personType":{}}' view="twolines"></mgt-person>
  `;

--- a/stories/components/person/person.stories.js
+++ b/stories/components/person/person.stories.js
@@ -15,7 +15,7 @@ export default {
   tags: ['autodocs'],
   parameters: {
     docs: {
-      source: { code: '<mgt-person person-query="me" view="twoLines"></mgt-person>' }
+      source: { code: '<mgt-person person-query="me" view="twolines"></mgt-person>' }
     }
   }
 };
@@ -23,13 +23,13 @@ export default {
 export const person = () => html`
   <mgt-person person-query="me"></mgt-person>
   <br>
-  <mgt-person person-query="me" view="oneLine"></mgt-person>
+  <mgt-person person-query="me" view="oneline"></mgt-person>
   <br>
-  <mgt-person person-query="me" view="twoLines"></mgt-person>
+  <mgt-person person-query="me" view="twolines"></mgt-person>
   <br>
-  <mgt-person person-query="me" view="threeLines"></mgt-person>
+  <mgt-person person-query="me" view="threelines"></mgt-person>
   <br>
-  <mgt-person person-query="me" view="fourLines"></mgt-person>
+  <mgt-person person-query="me" view="fourlines"></mgt-person>
 `;
 
 export const events = () => html`
@@ -106,7 +106,7 @@ export const RTL = () => html`
       <mgt-person person-query="me" class="example" vertical-layout id="online3" view="threelines"></mgt-person>
     </div>
     <div class="row">
-      <mgt-person person-query="me" class="example" vertical-layout id="online4" view="fourLines"></mgt-person>
+      <mgt-person person-query="me" class="example" vertical-layout id="online4" view="fourlines"></mgt-person>
     </div>
   </body>
   <style>
@@ -128,7 +128,7 @@ export const personVertical = () => html`
   <mgt-person person-query="me" class="example" vertical-layout view="threelines" class="example"></mgt-person>
 </div>
 <div class="row">
-  <mgt-person person-query="me" class="example" vertical-layout view="fourLines" class="example"></mgt-person>
+  <mgt-person person-query="me" class="example" vertical-layout view="fourlines" class="example"></mgt-person>
 </div>
 
 <!-- With Presence; Check JS tab -->
@@ -143,12 +143,12 @@ export const personVertical = () => html`
   <mgt-person person-query="me" class="example" vertical-layout id="online3" show-presence view="threelines" class="example"></mgt-person>
 </div>
 <div class="row">
-  <mgt-person person-query="me" class="example" vertical-layout id="online4" show-presence view="fourLines" class="example"></mgt-person>
+  <mgt-person person-query="me" class="example" vertical-layout id="online4" show-presence view="fourlines" class="example"></mgt-person>
 </div>
 
 <!-- Person unauthenticated vertical layout-->
 <div class="row">
-	<mgt-person person-query="mbowen" vertical-layout view="twoLines" fallback-details='{"mail":"MeganB@M365x214355.onmicrosoft.com"}'>
+	<mgt-person person-query="mbowen" vertical-layout view="twolines" fallback-details='{"mail":"MeganB@M365x214355.onmicrosoft.com"}'>
 	</mgt-person>
 </div>
 

--- a/stories/components/person/person.templating.stories.js
+++ b/stories/components/person/person.templating.stories.js
@@ -39,7 +39,7 @@ export const noDataTemplate = () => html`
   `;
 
 export const retemplateMetadata = () => html`
-  <mgt-person person-query="me" view="threeLines">
+  <mgt-person person-query="me" view="threelines">
     <template data-type="line1">
       <div>
         Hello, my name is: {{person.displayName}}
@@ -59,7 +59,7 @@ export const retemplateMetadata = () => html`
 
   <br/>
 
-  <mgt-person person-query="me" view="fourLines">
+  <mgt-person person-query="me" view="fourlines">
     <template data-type="line1">
       <div>
         Hello, my name is: {{person.displayName}}

--- a/stories/components/personCard/personCard.properties.stories.js
+++ b/stories/components/personCard/personCard.properties.stories.js
@@ -40,7 +40,7 @@ export const inheritDetails = () => html`
       font-size: 12px;
     }
   </style>
-  <mgt-person person-query="me" view="twoLines" person-card="hover">
+  <mgt-person person-query="me" view="twolines" person-card="hover">
     <template data-type="person-card">
       <mgt-person-card inherit-details></mgt-person-card>
     </template>

--- a/stories/samples/general.stories.js
+++ b/stories/samples/general.stories.js
@@ -103,8 +103,8 @@ export const cache = () => html`
 >
 
 <mgt-login></mgt-login>
-<mgt-person person-query="me" view="twoLines" person-card="hover" show-presence></mgt-person>
-<mgt-person user-id="4782e723-f4f4-4af3-a76e-25e3bab0d896" view="twoLines"></mgt-person>
+<mgt-person person-query="me" view="twolines" person-card="hover" show-presence></mgt-person>
+<mgt-person user-id="4782e723-f4f4-4af3-a76e-25e3bab0d896" view="twolines"></mgt-person>
 <mgt-people-picker></mgt-people-picker>
 <mgt-people-picker type="group"></mgt-people-picker>
 <mgt-people-picker group-id="02bd9fd6-8f93-4758-87c3-1fb73740a315"></mgt-people-picker>

--- a/stories/samples/templating.stories.js
+++ b/stories/samples/templating.stories.js
@@ -18,7 +18,7 @@ export default {
 };
 
 export const PersonCardAdditionalDetails = () => html`
-  <mgt-person person-query="me" view="twoLines" person-card="hover">
+  <mgt-person person-query="me" view="twolines" person-card="hover">
     <template data-type="person-card">
       <mgt-person-card inherit-details>
         <template data-type="additional-details">
@@ -255,7 +255,7 @@ export const GroupedEmail = () => html`
       <div>
         <div data-for="group in groupMail(value)">
           <div class="header">
-            <mgt-person person-query="{{ group[0] }}" view="oneLine" person-card="hover"></mgt-person>
+            <mgt-person person-query="{{ group[0] }}" view="oneline" person-card="hover"></mgt-person>
           </div>
           <div data-for="message in group[1]" class="email">
             <h2>{{ message.subject }}</h2>
@@ -320,7 +320,7 @@ export const TeamsMessages = () => html`
 <mgt-get id="messagesGet" version="beta">
 <template data-type="value">
   <div data-if="!deletedDateTime && messageType == 'message'" class="teams-message">
-    <mgt-person user-id="{{from.user.id}}" view="oneLine" person-card="hover"></mgt-person>
+    <mgt-person user-id="{{from.user.id}}" view="oneline" person-card="hover"></mgt-person>
     <div data-props="@click: messageClick, innerHTML: body.content"></div>
     <div class="reply hidden">
       <input></input>

--- a/tsconfig.web-test-runner.json
+++ b/tsconfig.web-test-runner.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     // Needed to mix class fields and reactive properties in Lit elements https://lit.dev/docs/components/properties/#avoiding-issues-with-class-fields
-    "useDefineForClassFields": false
+    "useDefineForClassFields": false,
+    // Needed to ensure that string union types work as expected in tests
+    "verbatimModuleSyntax": true
   },
   "include": ["packages/**/src/**/*.ts"],
   "exclude": ["node_modules", "lib"]

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -46,6 +46,7 @@ export default {
     }),
     // https://modern-web.dev/docs/dev-server/plugins/esbuild/
     esbuildPlugin({
+      target: 'auto',
       ts: true,
       tsconfig: fileURLToPath(new URL('./tsconfig.web-test-runner.json', import.meta.url))
     })


### PR DESCRIPTION
Closes #2942 

### PR Type

- Feature

### Description of the changes

rework all enum based component attribute properties as string unions for consistency between react and web components

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: https://github.com/microsoftgraph/microsoft-graph-docs/pull/23438
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
There are many breaking changes in this PR for React consumers of the library, this simplifies the usage of the components

Old style:
```tsx
import { PersonCardInteraction, ViewType, Person } from '@microsoft/mgt-react';

// snip
return <Person personCardInteraction={PersonCardInteraction.click} view={ViewType.twolines}  personQuery="me"/>
```

Old style:
```tsx
import { Person } from '@microsoft/mgt-react';

// snip
return <Person personCardInteraction="click" view="twolines"  personQuery="me" />
```

Thanks to the use of string unions we still get intellisense and type checking on these props, they're just simpler to use and align to the web component attributes e.g. 

```html
<mgt-person person-card="click" view="twolines" person-query="me"></mgt-person>
```