### PR TITLE
fix: set add button to disabled until task name is provided

### DIFF
--- a/packages/mgt-components/src/components/mgt-planner/mgt-planner.ts
+++ b/packages/mgt-components/src/components/mgt-planner/mgt-planner.ts
@@ -870,6 +870,7 @@ export class MgtPlanner extends MgtTemplatedTaskComponent {
       : html`
           <fluent-button
             class="add-task"
+            ?disabled=${!this._newTaskName}
             @click=${this.onAddTaskClick}
             @keydown=${this.onAddTaskKeyDown}
             appearance="neutral">

--- a/stories/samples/general.stories.js
+++ b/stories/samples/general.stories.js
@@ -42,7 +42,7 @@ export const Localization = () => html`
           noResultsFound: 'لم يتم العثور على نتائج',
           loadingMessage: 'Loading...'
         },
-        tasks: {
+        planner: {
           removeTaskSubtitle: 'delete',
           cancelNewTaskSubtitle: 'canceltest',
           newTaskPlaceholder: 'newTaskTest',


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #2302  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

 - Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
- Set the add button to disabled until the task name is provided.
- fix planner localization string

### PR checklist
- [ ] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
