### PR TITLE
fix: remove the check for an editor before setting the files object.

### DIFF
--- a/.storybook/addons/codeEditorAddon/codeAddon.js
+++ b/.storybook/addons/codeEditorAddon/codeAddon.js
@@ -300,16 +300,14 @@ export const withCodeEditor = makeDecorator({
       editor.style.width = null;
     });
 
-    if (isEditorEnabled()) {
-      editor.files = {
-        html: beautifyContent('html', storyHtml),
-        react: beautifyContent('js', reactCode),
-        js: beautifyContent('js', scriptCode),
-        css: beautifyContent('css', styleCode)
-      };
+    editor.files = {
+      html: beautifyContent('html', storyHtml),
+      react: beautifyContent('js', reactCode),
+      js: beautifyContent('js', scriptCode),
+      css: beautifyContent('css', styleCode)
+    };
 
-      editor.title = getStoryTitle(context);
-    }
+    editor.title = getStoryTitle(context);
 
     return root;
   }


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #3003 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
remove the check for an editor before setting the files object.
### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
