### PR TITLE
fix: add a shimmer for the loading state of person component

### DIFF
--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -5,17 +5,22 @@
  * -------------------------------------------------------------------------------------------
  */
 
+import { fluentSkeleton } from '@fluentui/web-components';
 import {
   MgtTemplatedTaskComponent,
   ProviderState,
   Providers,
+  buildComponentName,
   customElementHelper,
-  mgtHtml
+  mgtHtml,
+  registerComponent
 } from '@microsoft/mgt-element';
 import { Presence } from '@microsoft/microsoft-graph-types';
-import { html, TemplateResult, nothing } from 'lit';
+import { TemplateResult, html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { isContact, isUser } from '../../graph/entityType';
 import { findPeople, getEmailFromGraphEntity } from '../../graph/graph.people';
 import { getGroupImage, getPersonImage } from '../../graph/graph.photos';
 import { getUserPresence } from '../../graph/graph.presence';
@@ -23,17 +28,15 @@ import { findUsers, getMe, getUser } from '../../graph/graph.user';
 import { getUserWithPhoto } from '../../graph/graph.userWithPhoto';
 import { AvatarSize, IDynamicPerson, ViewType, viewTypeConverter } from '../../graph/types';
 import '../../styles/style-helper';
+import { registerFluentComponents } from '../../utils/FluentComponents';
 import { SvgIcon, getSvg } from '../../utils/SvgHelper';
+import { IExpandable, IHistoryClearer } from '../mgt-person-card/types';
 import '../sub-components/mgt-flyout/mgt-flyout';
 import { MgtFlyout, registerMgtFlyoutComponent } from '../sub-components/mgt-flyout/mgt-flyout';
-import { type PersonCardInteraction, personCardConverter } from './../PersonCardInteraction';
+import { personCardConverter, type PersonCardInteraction } from './../PersonCardInteraction';
 import { styles } from './mgt-person-css';
-import { MgtPersonConfig, AvatarType, avatarTypeConverter } from './mgt-person-types';
+import { AvatarType, MgtPersonConfig, avatarTypeConverter } from './mgt-person-types';
 import { strings } from './strings';
-import { isUser, isContact } from '../../graph/entityType';
-import { ifDefined } from 'lit/directives/if-defined.js';
-import { buildComponentName, registerComponent } from '@microsoft/mgt-element';
-import { IExpandable, IHistoryClearer } from '../mgt-person-card/types';
 
 /**
  * Person properties part of original set provided by graph by default
@@ -55,6 +58,8 @@ export const defaultPersonProperties = [
 ];
 
 export const registerMgtPersonComponent = () => {
+  registerFluentComponents(fluentSkeleton);
+
   // register self first to avoid infinte loop due to circular ref between person and person card
   registerComponent('person', MgtPerson);
 
@@ -575,6 +580,7 @@ export class MgtPerson extends MgtTemplatedTaskComponent {
         ${personTemplate}
       </div>
     `;
+    // return this.renderLoading();
   };
 
   /**
@@ -585,7 +591,20 @@ export class MgtPerson extends MgtTemplatedTaskComponent {
    * @memberof MgtPerson
    */
   protected renderLoading = (): TemplateResult => {
-    return this.renderTemplate('loading', null) || html``;
+    return (
+      this.renderTemplate('loading', null) ||
+      html`
+        <div class="person-root small oneline">
+          <div class="avatar-wrapper">
+            <fluent-skeleton shimmer class="shimmer icon" shape="circle"></fluent-skeleton>
+          </div>
+          <div class="details-wrapper">
+            <div class="line1">
+              <fluent-skeleton shimmer class="shimmer text" shape="rect"></fluent-skeleton>
+            </div>
+          </div>
+        </div>`
+    );
   };
 
   /**


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #797  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Adds a shimmer for the loading state in mgt-person

### PR checklist
- [ ] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
