### PR TITLE
feat: bot names and avatars

### DIFF
--- a/packages/mgt-chat/src/components/Chat/Chat.tsx
+++ b/packages/mgt-chat/src/components/Chat/Chat.tsx
@@ -1,19 +1,23 @@
 import { FluentThemeProvider, MessageThread, SendBox, MessageThreadStyles } from '@azure/communication-react';
 import { FluentTheme } from '@fluentui/react';
 import { FluentProvider, makeStyles, shorthands, webLightTheme } from '@fluentui/react-components';
-import { Person, Spinner } from '@microsoft/mgt-react';
+import { Spinner } from '@microsoft/mgt-react';
+import { enableMapSet } from 'immer';
 import React, { useEffect, useState } from 'react';
-import { StatefulGraphChatClient } from '../../statefulClient/StatefulGraphChatClient';
-import { useGraphChatClient } from '../../statefulClient/useGraphChatClient';
-import { onRenderMessage } from '../../utils/chat';
-import { renderMGTMention } from '../../utils/mentions';
-import { registerAppIcons } from '../styles/registerIcons';
+import { ChatAvatar } from '../ChatAvatar/ChatAvatar';
 import { ChatHeader } from '../ChatHeader/ChatHeader';
+import { BotInfoContext } from '../Context/BotInfoContext';
 import { Error } from '../Error/Error';
 import { LoadingMessagesErrorIcon } from '../Error/LoadingMessageErrorIcon';
 import { OpenTeamsLinkError } from '../Error/OpenTeams';
 import { RequireValidChatId } from '../Error/RequireAValidChatId';
 import { TypeANewMessage } from '../Error/TypeANewMessage';
+import { registerAppIcons } from '../styles/registerIcons';
+import { BotInfoClient } from '../../statefulClient/BotInfoClient';
+import { StatefulGraphChatClient } from '../../statefulClient/StatefulGraphChatClient';
+import { useGraphChatClient } from '../../statefulClient/useGraphChatClient';
+import { onRenderMessage } from '../../utils/chat';
+import { renderMGTMention } from '../../utils/mentions';
 
 registerAppIcons();
 
@@ -79,7 +83,8 @@ const messageThreadStyles: MessageThreadStyles = {
       zIndex: 'unset',
       '& div[data-ui-status]': {
         display: 'inline-flex',
-        justifyContent: 'center'
+        justifyContent: 'center',
+        flexDirection: 'column'
       }
     }
   },
@@ -106,9 +111,13 @@ const messageThreadStyles: MessageThreadStyles = {
 };
 
 export const Chat = ({ chatId }: IMgtChatProps) => {
+  useEffect(() => {
+    enableMapSet();
+  }, []);
   const styles = useStyles();
   const chatClient: StatefulGraphChatClient = useGraphChatClient(chatId);
-  const [chatState, setChatState] = useState(chatClient.getState());
+  const [botInfoClient] = useState(() => new BotInfoClient());
+  const [chatState, setChatState] = useState(() => chatClient.getState());
   useEffect(() => {
     chatClient.onStateChange(setChatState);
     return () => {
@@ -124,74 +133,74 @@ export const Chat = ({ chatId }: IMgtChatProps) => {
   const placeholderText = disabled ? 'You cannot send a message' : 'Type a message...';
 
   return (
-    <FluentThemeProvider fluentTheme={FluentTheme}>
-      <FluentProvider id="fluentui" theme={webLightTheme} className={styles.fullHeight}>
-        <div className={styles.chat}>
-          <ChatHeader chatState={chatState} />
-          {chatState.userId && chatId && chatState.messages.length > 0 ? (
-            <>
-              <div className={styles.chatMessages}>
-                <MessageThread
-                  userId={chatState.userId}
-                  messages={chatState.messages}
-                  showMessageDate={true}
-                  disableEditing={chatState.disableEditing}
-                  numberOfChatMessagesToReload={chatState.numberOfChatMessagesToReload}
-                  onLoadPreviousChatMessages={chatState.onLoadPreviousChatMessages}
-                  // TODO: Messages date rendering is behind beta flag, find out how to enable it
-                  // onDisplayDateTimeString={(date: Date) => date.toISOString()}
+    <BotInfoContext.Provider value={botInfoClient}>
+      <FluentThemeProvider fluentTheme={FluentTheme}>
+        <FluentProvider id="fluentui" theme={webLightTheme} className={styles.fullHeight}>
+          <div className={styles.chat}>
+            <ChatHeader chatState={chatState} />
+            {chatState.userId && chatId && chatState.messages.length > 0 ? (
+              <>
+                <div className={styles.chatMessages}>
+                  <MessageThread
+                    userId={chatState.userId}
+                    messages={chatState.messages}
+                    showMessageDate={true}
+                    disableEditing={chatState.disableEditing}
+                    numberOfChatMessagesToReload={chatState.numberOfChatMessagesToReload}
+                    onLoadPreviousChatMessages={chatState.onLoadPreviousChatMessages}
+                    // TODO: Messages date rendering is behind beta flag, find out how to enable it
+                    // onDisplayDateTimeString={(date: Date) => date.toISOString()}
 
-                  // current behavior for re-send is a delete call with the clientMessageId and the a new send call
-                  onDeleteMessage={chatState.onDeleteMessage}
-                  onSendMessage={chatState.onSendMessage}
-                  onUpdateMessage={chatState.onUpdateMessage}
-                  // render props
-                  onRenderAvatar={(userId?: string) => {
-                    return (
-                      <Person userId={userId} avatarSize="small" personCardInteraction="hover" showPresence={true} />
-                    );
-                  }}
-                  styles={messageThreadStyles}
-                  mentionOptions={{
-                    displayOptions: {
-                      onRenderMention: renderMGTMention(chatState)
-                    }
-                  }}
-                  onRenderMessage={onRenderMessage}
-                />
-              </div>
-              <div className={styles.chatInput}>
-                <SendBox onSendMessage={chatState.onSendMessage} strings={{ placeholderText }} />
-              </div>
-            </>
-          ) : (
-            <>
-              {isLoading && (
-                <div className={styles.spinner}>
-                  <Spinner /> <br />
-                  {chatState.status}
+                    // current behavior for re-send is a delete call with the clientMessageId and the a new send call
+                    onDeleteMessage={chatState.onDeleteMessage}
+                    onSendMessage={chatState.onSendMessage}
+                    onUpdateMessage={chatState.onUpdateMessage}
+                    // render props
+                    onRenderAvatar={(userId?: string) => {
+                      return userId ? <ChatAvatar chatId={chatId} avatarId={userId} /> : <></>;
+                    }}
+                    styles={messageThreadStyles}
+                    mentionOptions={{
+                      displayOptions: {
+                        onRenderMention: renderMGTMention(chatState)
+                      }
+                    }}
+                    onRenderMessage={onRenderMessage}
+                  />
                 </div>
-              )}
-              {chatState.status === 'no messages' && (
-                <Error
-                  icon={LoadingMessagesErrorIcon}
-                  message="No messages were found for this chat."
-                  subheading={TypeANewMessage}
-                ></Error>
-              )}
-              {chatState.status === 'no chat id' && (
-                <Error message="No chat id has been provided." subheading={RequireValidChatId}></Error>
-              )}
-              {chatState.status === 'error' && (
-                <Error message="We're sorry—we've run into an issue.." subheading={OpenTeamsLinkError}></Error>
-              )}
-              <div className={styles.chatInput}>
-                <SendBox disabled={disabled} onSendMessage={chatState.onSendMessage} strings={{ placeholderText }} />
-              </div>
-            </>
-          )}
-        </div>
-      </FluentProvider>
-    </FluentThemeProvider>
+                <div className={styles.chatInput}>
+                  <SendBox onSendMessage={chatState.onSendMessage} strings={{ placeholderText }} />
+                </div>
+              </>
+            ) : (
+              <>
+                {isLoading && (
+                  <div className={styles.spinner}>
+                    <Spinner /> <br />
+                    {chatState.status}
+                  </div>
+                )}
+                {chatState.status === 'no messages' && (
+                  <Error
+                    icon={LoadingMessagesErrorIcon}
+                    message="No messages were found for this chat."
+                    subheading={TypeANewMessage}
+                  ></Error>
+                )}
+                {chatState.status === 'no chat id' && (
+                  <Error message="No chat id has been provided." subheading={RequireValidChatId}></Error>
+                )}
+                {chatState.status === 'error' && (
+                  <Error message="We're sorry—we've run into an issue.." subheading={OpenTeamsLinkError}></Error>
+                )}
+                <div className={styles.chatInput}>
+                  <SendBox disabled={disabled} onSendMessage={chatState.onSendMessage} strings={{ placeholderText }} />
+                </div>
+              </>
+            )}
+          </div>
+        </FluentProvider>
+      </FluentThemeProvider>
+    </BotInfoContext.Provider>
   );
 };

--- a/packages/mgt-chat/src/components/ChatAvatar/BotAvatar.tsx
+++ b/packages/mgt-chat/src/components/ChatAvatar/BotAvatar.tsx
@@ -1,0 +1,36 @@
+import { Person, ViewType } from '@microsoft/mgt-react';
+import React, { FC, useEffect } from 'react';
+import { useBotInfo } from '../../statefulClient/useBotInfo';
+import { ChatAvatarProps } from './ChatAvatar';
+
+type BotAvatarProps = ChatAvatarProps & {
+  view?: ViewType;
+};
+
+export const BotAvatar: FC<BotAvatarProps> = ({ chatId, avatarId, view = 'image' }) => {
+  const botInfo = useBotInfo();
+
+  useEffect(() => {
+    if (chatId && avatarId && !botInfo?.botInfo.has(avatarId)) {
+      void botInfo?.loadBotInfo(chatId, avatarId);
+    }
+  }, [chatId, avatarId, botInfo]);
+
+  return (
+    <div>
+      <Person
+        personDetails={{
+          id: avatarId,
+          displayName: botInfo?.botInfo.has(avatarId)
+            ? botInfo.botInfo.get(avatarId)?.teamsAppDefinition?.displayName
+            : '',
+          personImage: botInfo?.botIcons.has(avatarId) ? botInfo.botIcons.get(avatarId) : ''
+        }}
+        avatarSize="small"
+        personCardInteraction="none"
+        view={view}
+        showPresence={false}
+      />
+    </div>
+  );
+};

--- a/packages/mgt-chat/src/components/ChatAvatar/ChatAvatar.tsx
+++ b/packages/mgt-chat/src/components/ChatAvatar/ChatAvatar.tsx
@@ -1,0 +1,61 @@
+import { Person } from '@microsoft/mgt-react';
+import React, { FC, memo, useContext, useEffect, useState } from 'react';
+import { botPrefix } from '../../statefulClient/buildBotId';
+import { BotInfoContext } from '../Context/BotInfoContext';
+
+interface ChatAvatarProps {
+  /**
+   * The chat id
+   */
+  chatId: string;
+  /**
+   * The id of the entity to get the avatar for
+   * for bots this is prefixed with 'botId::'
+   *
+   */
+  avatarId: string;
+}
+
+const BotAvatar: FC<ChatAvatarProps> = ({ chatId, avatarId }) => {
+  const botInfoClient = useContext(BotInfoContext);
+  const [botInfo, setBotInfo] = useState(() => botInfoClient?.getState());
+  useEffect(() => {
+    if (botInfoClient) {
+      botInfoClient.onStateChange(setBotInfo);
+      return () => botInfoClient.offStateChange(setBotInfo);
+    }
+  }, [botInfoClient]);
+
+  useEffect(() => {
+    if (chatId && avatarId && !botInfo?.botInfo.has(avatarId)) {
+      void botInfo?.loadBotInfo(chatId, avatarId);
+    }
+  }, [chatId, avatarId, botInfo]);
+
+  return (
+    <div>
+      {/* {botInfo?.botInfo.has(avatarId) ? botInfo.botInfo.get(avatarId)?.teamsAppDefinition?.displayName || '' : null} */}
+      <Person
+        personDetails={{
+          id: avatarId,
+          displayName: botInfo?.botInfo.has(avatarId)
+            ? botInfo.botInfo.get(avatarId)?.teamsAppDefinition?.displayName
+            : '',
+          personImage: botInfo?.botIcons.has(avatarId) ? botInfo.botIcons.get(avatarId) : ''
+        }}
+        avatarSize="small"
+        personCardInteraction="none"
+        showPresence={false}
+      />
+    </div>
+  );
+};
+
+const AvatarSwitcher: FC<ChatAvatarProps> = ({ chatId, avatarId }) =>
+  avatarId.startsWith(botPrefix) ? (
+    <BotAvatar chatId={chatId} avatarId={avatarId.replace(botPrefix, '')} />
+  ) : (
+    <Person userId={avatarId} avatarSize="small" personCardInteraction="hover" showPresence={true} />
+  );
+
+export const ChatAvatar = memo(AvatarSwitcher);

--- a/packages/mgt-chat/src/components/ChatAvatar/ChatAvatar.tsx
+++ b/packages/mgt-chat/src/components/ChatAvatar/ChatAvatar.tsx
@@ -1,9 +1,9 @@
 import { Person } from '@microsoft/mgt-react';
-import React, { FC, memo, useContext, useEffect, useState } from 'react';
+import React, { FC, memo } from 'react';
 import { botPrefix } from '../../statefulClient/buildBotId';
-import { BotInfoContext } from '../Context/BotInfoContext';
+import { BotAvatar } from './BotAvatar';
 
-interface ChatAvatarProps {
+export interface ChatAvatarProps {
   /**
    * The chat id
    */
@@ -15,41 +15,6 @@ interface ChatAvatarProps {
    */
   avatarId: string;
 }
-
-const BotAvatar: FC<ChatAvatarProps> = ({ chatId, avatarId }) => {
-  const botInfoClient = useContext(BotInfoContext);
-  const [botInfo, setBotInfo] = useState(() => botInfoClient?.getState());
-  useEffect(() => {
-    if (botInfoClient) {
-      botInfoClient.onStateChange(setBotInfo);
-      return () => botInfoClient.offStateChange(setBotInfo);
-    }
-  }, [botInfoClient]);
-
-  useEffect(() => {
-    if (chatId && avatarId && !botInfo?.botInfo.has(avatarId)) {
-      void botInfo?.loadBotInfo(chatId, avatarId);
-    }
-  }, [chatId, avatarId, botInfo]);
-
-  return (
-    <div>
-      {/* {botInfo?.botInfo.has(avatarId) ? botInfo.botInfo.get(avatarId)?.teamsAppDefinition?.displayName || '' : null} */}
-      <Person
-        personDetails={{
-          id: avatarId,
-          displayName: botInfo?.botInfo.has(avatarId)
-            ? botInfo.botInfo.get(avatarId)?.teamsAppDefinition?.displayName
-            : '',
-          personImage: botInfo?.botIcons.has(avatarId) ? botInfo.botIcons.get(avatarId) : ''
-        }}
-        avatarSize="small"
-        personCardInteraction="none"
-        showPresence={false}
-      />
-    </div>
-  );
-};
 
 const AvatarSwitcher: FC<ChatAvatarProps> = ({ chatId, avatarId }) =>
   avatarId.startsWith(botPrefix) ? (

--- a/packages/mgt-chat/src/components/ChatHeader/OneToOneChatHeader.tsx
+++ b/packages/mgt-chat/src/components/ChatHeader/OneToOneChatHeader.tsx
@@ -3,6 +3,8 @@ import { AadUserConversationMember, Chat } from '@microsoft/microsoft-graph-type
 import { Person } from '@microsoft/mgt-react';
 import { ChatHeaderProps } from './ChatTitle';
 import { makeStyles } from '@fluentui/react-components';
+import { useBotInfo } from '../../statefulClient/useBotInfo';
+import { BotAvatar } from '../ChatAvatar/BotAvatar';
 
 const getOtherParticipantUserId = (chat?: Chat, currentUserId = '') =>
   (chat?.members as AadUserConversationMember[])?.find(m => m.userId !== currentUserId)?.userId;
@@ -14,16 +16,36 @@ const useStyles = makeStyles({
   }
 });
 export const OneToOneChatHeader = ({ chat, currentUserId }: ChatHeaderProps) => {
+  const botInfo = useBotInfo();
   const styles = useStyles();
   const id = getOtherParticipantUserId(chat, currentUserId);
-  return id ? (
-    <Person
-      className={styles.person}
-      userId={id}
-      view="oneline"
-      avatarSize="small"
-      personCardInteraction="hover"
-      showPresence={true}
-    />
-  ) : null;
+  if (!chat?.id) return null;
+  if (id) {
+    return (
+      <Person
+        className={styles.person}
+        userId={id}
+        view="oneline"
+        avatarSize="small"
+        personCardInteraction="hover"
+        showPresence={true}
+      />
+    );
+  } else if (botInfo?.chatBots.has(chat.id)) {
+    return (
+      <>
+        {Array.from(botInfo.chatBots.get(chat.id)!).map(bot =>
+          bot.teamsAppDefinition?.bot?.id ? (
+            <BotAvatar
+              key={bot.teamsAppDefinition.bot.id}
+              chatId={chat.id!}
+              avatarId={bot.teamsAppDefinition.bot.id}
+              view="oneline"
+            />
+          ) : null
+        )}
+      </>
+    );
+  }
+  return null;
 };

--- a/packages/mgt-chat/src/components/Context/BotInfoContext.ts
+++ b/packages/mgt-chat/src/components/Context/BotInfoContext.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+import { BotInfoClient } from '../../statefulClient/BotInfoClient';
+
+export const BotInfoContext = createContext<BotInfoClient | undefined>(undefined);

--- a/packages/mgt-chat/src/statefulClient/BaseStatefulClient.ts
+++ b/packages/mgt-chat/src/statefulClient/BaseStatefulClient.ts
@@ -1,0 +1,75 @@
+import { BetaGraph, IGraph, Providers } from '@microsoft/mgt-element';
+import { produce } from 'immer';
+import { StatefulClient } from './StatefulClient';
+import { graph } from '../utils/graph';
+import { GraphConfig } from './GraphConfig';
+
+export abstract class BaseStatefulClient<T> implements StatefulClient<T> {
+  private _graph: IGraph | undefined;
+
+  protected get graph(): IGraph | undefined {
+    if (this._graph) return this._graph;
+    if (Providers.globalProvider?.graph) {
+      this._graph = graph('mgt-chat', GraphConfig.version);
+    }
+    return this._graph;
+  }
+
+  protected set graph(value: IGraph | undefined) {
+    this._graph = value;
+  }
+
+  protected get betaGraph(): BetaGraph | undefined {
+    const g = this.graph;
+    if (g) return BetaGraph.fromGraph(g);
+
+    return undefined;
+  }
+
+  private _subscribers: ((state: T) => void)[] = [];
+  /**
+   * Register a callback to receive state updates
+   *
+   * @param {(state: GraphChatClient) => void} handler
+   * @memberof StatefulGraphChatClient
+   */
+  public onStateChange(handler: (state: T) => void): void {
+    if (!this._subscribers.includes(handler)) {
+      this._subscribers.push(handler);
+    }
+  }
+
+  /**
+   * Unregister a callback from receiving state updates
+   *
+   * @param {(state: GraphChatClient) => void} handler
+   * @memberof StatefulGraphChatClient
+   */
+  public offStateChange(handler: (state: T) => void): void {
+    const index = this._subscribers.indexOf(handler);
+    if (index !== -1) {
+      this._subscribers = this._subscribers.splice(index, 1);
+    }
+  }
+
+  /**
+   * Calls each subscriber with the next state to be emitted
+   *
+   * @param recipe - a function which produces the next state to be emitted
+   */
+  protected notifyStateChange(recipe: (draft: T) => void) {
+    this.state = produce(this.state, recipe);
+    this._subscribers.forEach(handler => handler(this.state));
+  }
+
+  protected abstract state: T;
+  /**
+   * Return the current state of the chat client
+   *
+   * @return {{GraphChatClient}
+   * @memberof StatefulGraphChatClient
+   */
+  public getState(): T {
+    return this.state;
+  }
+}

--- a/packages/mgt-chat/src/statefulClient/BotInfoClient.ts
+++ b/packages/mgt-chat/src/statefulClient/BotInfoClient.ts
@@ -1,0 +1,50 @@
+import { TeamsAppInstallation } from '@microsoft/microsoft-graph-types-beta';
+import { BaseStatefulClient } from './BaseStatefulClient';
+import { loadBotInChat, loadBotIcon } from './graph.chat';
+
+export interface BotInfo {
+  botInfo: Map<string, TeamsAppInstallation>;
+  botIcons: Map<string, string>;
+  loadBotInfo: (chatId: string, appId: string) => Promise<void>;
+}
+
+const requestKey = (chatId: string, appId: string) => `${chatId}::${appId}`;
+
+export class BotInfoClient extends BaseStatefulClient<BotInfo> {
+  private readonly infoRequestMap = new Map<string, Promise<unknown>>();
+
+  public loadBotInfo = async (chatId: string, appId: string) => {
+    const beta = this.betaGraph;
+    if (!beta) return;
+    const key = requestKey(chatId, appId);
+    if (!this.infoRequestMap.has(key)) {
+      const requestPromise = loadBotInChat(beta, chatId, appId);
+      this.infoRequestMap.set(key, requestPromise);
+      const botInfo = await requestPromise;
+      if (botInfo?.value.length > 0) {
+        // update state with the text info
+        this.notifyStateChange((draft: BotInfo) => {
+          botInfo.value.forEach(app => {
+            if (app.teamsAppDefinition?.bot?.id) {
+              draft.botInfo.set(app.teamsAppDefinition?.bot?.id, app);
+            }
+          });
+        });
+        // load the appIcon for each bot
+        for (const app of botInfo.value) {
+          const appIcon = await loadBotIcon(beta, app);
+          this.notifyStateChange((draft: BotInfo) => {
+            if (app.teamsAppDefinition?.bot?.id) {
+              draft.botIcons.set(app.teamsAppDefinition?.bot?.id, appIcon);
+            }
+          });
+        }
+      }
+    }
+  };
+  protected state: BotInfo = {
+    botInfo: new Map<string, TeamsAppInstallation>(),
+    botIcons: new Map<string, string>(),
+    loadBotInfo: this.loadBotInfo
+  };
+}

--- a/packages/mgt-chat/src/statefulClient/BotInfoClient.ts
+++ b/packages/mgt-chat/src/statefulClient/BotInfoClient.ts
@@ -4,6 +4,7 @@ import { loadBotInChat, loadBotIcon } from './graph.chat';
 
 export interface BotInfo {
   botInfo: Map<string, TeamsAppInstallation>;
+  chatBots: Map<string, Set<TeamsAppInstallation>>;
   botIcons: Map<string, string>;
   loadBotInfo: (chatId: string, appId: string) => Promise<void>;
 }
@@ -27,6 +28,10 @@ export class BotInfoClient extends BaseStatefulClient<BotInfo> {
           botInfo.value.forEach(app => {
             if (app.teamsAppDefinition?.bot?.id) {
               draft.botInfo.set(app.teamsAppDefinition?.bot?.id, app);
+              if (!draft.chatBots.has(chatId)) {
+                draft.chatBots.set(chatId, new Set());
+              }
+              draft.chatBots.get(chatId)?.add(app);
             }
           });
         });
@@ -44,6 +49,7 @@ export class BotInfoClient extends BaseStatefulClient<BotInfo> {
   };
   protected state: BotInfo = {
     botInfo: new Map<string, TeamsAppInstallation>(),
+    chatBots: new Map<string, Set<TeamsAppInstallation>>(),
     botIcons: new Map<string, string>(),
     loadBotInfo: this.loadBotInfo
   };

--- a/packages/mgt-chat/src/statefulClient/BotInfoClient.ts
+++ b/packages/mgt-chat/src/statefulClient/BotInfoClient.ts
@@ -6,20 +6,20 @@ export interface BotInfo {
   botInfo: Map<string, TeamsAppInstallation>;
   chatBots: Map<string, Set<TeamsAppInstallation>>;
   botIcons: Map<string, string>;
-  loadBotInfo: (chatId: string, appId: string) => Promise<void>;
+  loadBotInfo: (chatId: string, botId: string) => Promise<void>;
 }
 
-const requestKey = (chatId: string, appId: string) => `${chatId}::${appId}`;
+const requestKey = (chatId: string, botId: string) => `${chatId}::${botId}`;
 
 export class BotInfoClient extends BaseStatefulClient<BotInfo> {
   private readonly infoRequestMap = new Map<string, Promise<unknown>>();
 
-  public loadBotInfo = async (chatId: string, appId: string) => {
+  public loadBotInfo = async (chatId: string, botId: string) => {
     const beta = this.betaGraph;
     if (!beta) return;
-    const key = requestKey(chatId, appId);
+    const key = requestKey(chatId, botId);
     if (!this.infoRequestMap.has(key)) {
-      const requestPromise = loadBotInChat(beta, chatId, appId);
+      const requestPromise = loadBotInChat(beta, chatId, botId);
       this.infoRequestMap.set(key, requestPromise);
       const botInfo = await requestPromise;
       if (botInfo?.value.length > 0) {

--- a/packages/mgt-chat/src/statefulClient/StatefulClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulClient.ts
@@ -1,0 +1,18 @@
+export interface StatefulClient<T> {
+  /**
+   * Get the current state of the client
+   */
+  getState(): T;
+  /**
+   * Register a callback to receive state updates
+   *
+   * @param handler Callback to receive state updates
+   */
+  onStateChange(handler: (state: T) => void): void;
+  /**
+   * Remove a callback from receiving state updates
+   *
+   * @param handler Callback to be unregistered
+   */
+  offStateChange(handler: (state: T) => void): void;
+}

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatClient.ts
@@ -16,7 +16,6 @@ import {
 import { IDynamicPerson, getUserWithPhoto } from '@microsoft/mgt-components';
 import {
   ActiveAccountChanged,
-  IGraph,
   LoginChangedEvent,
   ProviderState,
   Providers,
@@ -35,7 +34,6 @@ import {
   ChatMessageMention,
   NullableOption
 } from '@microsoft/microsoft-graph-types';
-import { produce } from 'immer';
 import { v4 as uuid } from 'uuid';
 import { currentUserId, currentUserName } from '../utils/currentUser';
 import { graph } from '../utils/graph';
@@ -60,6 +58,85 @@ import {
 import { updateMessageContentWithImage } from '../utils/updateMessageContentWithImage';
 import { GraphChatClientStatus, isChatMessage } from '../utils/types';
 import { rewriteEmojiContentToHTML } from '../utils/rewriteEmojiContent';
+import { buildBotId } from './buildBotId';
+import { BaseStatefulClient } from './BaseStatefulClient';
+
+const hasUnsupportedContent = (content: string, attachments: ChatMessageAttachment[]): boolean => {
+  const unsupportedContentTypes = [
+    'application/vnd.microsoft.card.codesnippet',
+    'application/vnd.microsoft.card.fluid',
+    'application/vnd.microsoft.card.fluidEmbedCard',
+    'reference'
+  ];
+  const isUnsupported: boolean[] = [];
+
+  if (attachments.length) {
+    for (const attachment of attachments) {
+      const contentType = attachment?.contentType ?? '';
+      isUnsupported.push(unsupportedContentTypes.includes(contentType));
+    }
+  } else {
+    // checking content with <attachment> tags
+    const unsupportedContentRegex = /<\/?attachment>/gim;
+    const contentUnsupported = Boolean(content) && unsupportedContentRegex.test(content);
+    isUnsupported.push(contentUnsupported);
+  }
+  return isUnsupported.every(e => e === true);
+};
+
+const buildAcsMessage = (
+  graphMessage: ChatMessage,
+  currentUser: string,
+  messageId: string,
+  content: string
+): GraphChatMessage => {
+  const senderId = graphMessage.from?.user?.id ?? buildBotId(graphMessage.from?.application) ?? undefined;
+  const chatId = graphMessage?.chatId ?? '';
+  const id = graphMessage?.id ?? '';
+  const chatUrl = `https://teams.microsoft.com/l/message/${chatId}/${id}?context={"contextType":"chat"}`;
+  const attachments = graphMessage?.attachments ?? [];
+
+  let messageData: GraphChatMessage = {
+    messageId,
+    contentType: graphMessage.body?.contentType ?? 'text',
+    messageType: 'chat',
+    content,
+    senderDisplayName: graphMessage.from?.user?.displayName ?? graphMessage.from?.application?.displayName ?? undefined,
+    createdOn: new Date(graphMessage.createdDateTime ?? Date.now()),
+    editedOn: graphMessage.lastEditedDateTime ? new Date(graphMessage.lastEditedDateTime) : undefined,
+    senderId,
+    mine: senderId === currentUser,
+    status: 'seen',
+    attached: 'top',
+    hasUnsupportedContent: hasUnsupportedContent(content, attachments),
+    rawChatUrl: chatUrl
+  };
+  if (graphMessage?.policyViolation) {
+    messageData = Object.assign(messageData, {
+      messageType: 'blocked',
+      link: 'https://go.microsoft.com/fwlink/?LinkId=2132837'
+    });
+  }
+  return messageData;
+};
+
+/**
+ * Teams mentions are in the pattern <at id="1">User</at>. This replacement
+ * changes the mentions pattern to <msft-mention id="1">User</msft-mention>
+ * which will trigger the `mentionOptions` prop to be called in MessageThread.
+ *
+ * @param content is the message with mentions.
+ * @returns string with replaced mention parts.
+ */
+const updateMentionsContent = (content: string): string => {
+  const msftMention = `<msft-mention id="$1">$2</msft-mention>`;
+  const atRegex = /<at\sid="(\d+)">([a-z0-9_.-\s]+)<\/at>/gim;
+  content = content
+    .replace(/&nbsp;<at/gim, '<at')
+    .replace(/at>&nbsp;/gim, 'at>')
+    .replace(atRegex, msftMention);
+  return content;
+};
 
 // 1x1 grey pixel
 const placeholderImageContent =
@@ -115,25 +192,6 @@ export type GraphChatClient = Pick<
     activeErrorMessages: Error[];
   };
 
-interface StatefulClient<T> {
-  /**
-   * Get the current state of the client
-   */
-  getState(): T;
-  /**
-   * Register a callback to receive state updates
-   *
-   * @param handler Callback to receive state updates
-   */
-  onStateChange(handler: (state: T) => void): void;
-  /**
-   * Remove a callback from receiving state updates
-   *
-   * @param handler Callback to be unregistered
-   */
-  offStateChange(handler: (state: T) => void): void;
-}
-
 interface CreatedOn {
   createdOn: Date;
 }
@@ -185,12 +243,10 @@ interface MessageConversion {
  */
 const graphImageUrlRegex = /(<img[^>]+)src=(["']https:\/\/graph\.microsoft\.com[^"']*["'])/;
 
-class StatefulGraphChatClient implements StatefulClient<GraphChatClient> {
+class StatefulGraphChatClient extends BaseStatefulClient<GraphChatClient> {
   private readonly _eventEmitter: ThreadEventEmitter;
   private readonly _cache: MessageCache;
-  private _graph: IGraph = Providers.globalProvider.graph;
-  private _notificationClient: GraphNotificationClient;
-  private _subscribers: ((state: GraphChatClient) => void)[] = [];
+  private _notificationClient: GraphNotificationClient | undefined;
   private get _messagesPerCall() {
     return 5;
   }
@@ -199,12 +255,12 @@ class StatefulGraphChatClient implements StatefulClient<GraphChatClient> {
   private _userDisplayName = '';
 
   constructor() {
+    super();
     this.updateUserInfo();
     Providers.globalProvider.onStateChanged(this.onLoginStateChanged);
     Providers.globalProvider.onActiveAccountChanged(this.onActiveAccountChanged);
     this._eventEmitter = new ThreadEventEmitter();
     this.registerEventListeners();
-    this._notificationClient = new GraphNotificationClient(this._eventEmitter, this._graph);
     this._cache = new MessageCache();
   }
 
@@ -214,7 +270,7 @@ class StatefulGraphChatClient implements StatefulClient<GraphChatClient> {
    * and won't throw a TypeError when you access graph.forComponent.
    */
   private updateGraphNotificationClient() {
-    this._graph = graph('mgt-chat', GraphConfig.version);
+    this.graph = graph('mgt-chat', GraphConfig.version);
     this._notificationClient = new GraphNotificationClient(this._eventEmitter, this.graph);
   }
 
@@ -223,51 +279,6 @@ class StatefulGraphChatClient implements StatefulClient<GraphChatClient> {
    */
   public tearDown() {
     this._notificationClient?.tearDown();
-  }
-
-  /**
-   * Register a callback to receive state updates
-   *
-   * @param {(state: GraphChatClient) => void} handler
-   * @memberof StatefulGraphChatClient
-   */
-  public onStateChange(handler: (state: GraphChatClient) => void): void {
-    if (!this._subscribers.includes(handler)) {
-      this._subscribers.push(handler);
-    }
-  }
-
-  /**
-   * Unregister a callback from receiving state updates
-   *
-   * @param {(state: GraphChatClient) => void} handler
-   * @memberof StatefulGraphChatClient
-   */
-  public offStateChange(handler: (state: GraphChatClient) => void): void {
-    const index = this._subscribers.indexOf(handler);
-    if (index !== -1) {
-      this._subscribers = this._subscribers.splice(index, 1);
-    }
-  }
-
-  /**
-   * Calls each subscriber with the next state to be emitted
-   *
-   * @param recipe - a function which produces the next state to be emitted
-   */
-  private notifyStateChange(recipe: (draft: GraphChatClient) => void) {
-    this._state = produce(this._state, recipe);
-    this._subscribers.forEach(handler => handler(this._state));
-  }
-
-  /**
-   * Return the current state of the chat client
-   *
-   * @return {{GraphChatClient}
-   * @memberof StatefulGraphChatClient
-   */
-  public getState(): GraphChatClient {
-    return this._state;
   }
 
   /**
@@ -444,8 +455,10 @@ class StatefulGraphChatClient implements StatefulClient<GraphChatClient> {
         const tasks: Promise<unknown>[] = [this.loadChatData()];
         // subscribing to notifications will trigger the chatMessageNotificationsSubscribed event
         // this client will then load the chat and messages when that event listener is called
-        tasks.push(this._notificationClient.subscribeToChatNotifications(this._chatId, this._sessionId));
-        await Promise.all(tasks);
+        if (this._notificationClient) {
+          tasks.push(this._notificationClient.subscribeToChatNotifications(this._chatId, this._sessionId));
+          await Promise.all(tasks);
+        }
       } catch (e) {
         this.updateErrorState(e as Error);
       }
@@ -458,6 +471,13 @@ class StatefulGraphChatClient implements StatefulClient<GraphChatClient> {
   }
 
   private async loadChatData() {
+    if (!this.graph) {
+      this.notifyStateChange((draft: GraphChatClient) => {
+        draft.status = 'error';
+        draft.activeErrorMessages.push(new Error('Graph client not available'));
+      });
+      return;
+    }
     this.notifyStateChange((draft: GraphChatClient) => {
       draft.status = 'loading messages';
     });
@@ -486,6 +506,13 @@ class StatefulGraphChatClient implements StatefulClient<GraphChatClient> {
   }
 
   private async loadDeltaData(chatId: string, lastModified: string): Promise<ChatMessage[]> {
+    if (!this.graph) {
+      this.notifyStateChange((draft: GraphChatClient) => {
+        draft.status = 'error';
+        draft.activeErrorMessages.push(new Error('Graph client not available'));
+      });
+      throw new Error('Graph client not available');
+    }
     const result: ChatMessage[] = [];
     let response = await loadChatThreadDelta(this.graph, chatId, lastModified, this._messagesPerCall);
     result.push(...response.value);
@@ -597,6 +624,13 @@ class StatefulGraphChatClient implements StatefulClient<GraphChatClient> {
   };
 
   private async buildSystemContentMessage(message: ChatMessage): Promise<SystemMessage> {
+    if (!this.graph) {
+      this.notifyStateChange((draft: GraphChatClient) => {
+        draft.status = 'error';
+        draft.activeErrorMessages.push(new Error('Graph client not available'));
+      });
+      throw new Error('Graph client not available');
+    }
     const eventDetail = message.eventDetail as ChatMessageEvents;
     let messageContent = '';
     const awaits: Promise<IDynamicPerson>[] = [];
@@ -669,6 +703,13 @@ detail: ${JSON.stringify(eventDetail)}`);
     if (!this._nextLink) {
       return true;
     }
+    if (!this.graph) {
+      this.notifyStateChange((draft: GraphChatClient) => {
+        draft.status = 'error';
+        draft.activeErrorMessages.push(new Error('Graph client not available'));
+      });
+      throw new Error('Graph client not available');
+    }
     const messages: MessageCollection = await loadMoreChatMessages(this.graph, this._nextLink);
     await this._cache.cacheMessages(this._chatId, messages.value, true, messages.nextLink);
     await this.writeMessagesToState(messages);
@@ -684,6 +725,14 @@ detail: ${JSON.stringify(eventDetail)}`);
    */
   public sendMessage = async (content: string) => {
     if (!content) return;
+
+    if (!this.graph) {
+      this.notifyStateChange((draft: GraphChatClient) => {
+        draft.status = 'error';
+        draft.activeErrorMessages.push(new Error('Graph client not available'));
+      });
+      return;
+    }
 
     const pendingId = uuid();
 
@@ -739,9 +788,17 @@ detail: ${JSON.stringify(eventDetail)}`);
    */
   public deleteMessage = async (messageId: string): Promise<void> => {
     if (!messageId) return;
-    const message = this._state.messages.find(m => m.messageId === messageId) as AcsChatMessage;
+
+    if (!this.graph) {
+      this.notifyStateChange((draft: GraphChatClient) => {
+        draft.status = 'error';
+        draft.activeErrorMessages.push(new Error('Graph client not available'));
+      });
+      return;
+    }
+    const message = this.state.messages.find(m => m.messageId === messageId) as AcsChatMessage;
     // only messages not persisted to graph should have a clientMessageId
-    const uncommitted = this._state.messages.find(
+    const uncommitted = this.state.messages.find(
       m => (m as AcsChatMessage).clientMessageId === messageId
     ) as AcsChatMessage;
     if (message?.mine) {
@@ -775,7 +832,15 @@ detail: ${JSON.stringify(eventDetail)}`);
    */
   public updateMessage = async (messageId: string, content: string) => {
     if (!messageId || !content) return;
-    const message = this._state.messages.find(m => m.messageId === messageId) as AcsChatMessage;
+
+    if (!this.graph) {
+      this.notifyStateChange((draft: GraphChatClient) => {
+        draft.status = 'error';
+        draft.activeErrorMessages.push(new Error('Graph client not available'));
+      });
+      return;
+    }
+    const message = this.state.messages.find(m => m.messageId === messageId) as AcsChatMessage;
     if (message?.mine && message.content) {
       this.notifyStateChange((draft: GraphChatClient) => {
         const updating = draft.messages.find(m => m.messageId === messageId) as AcsChatMessage;
@@ -859,6 +924,13 @@ detail: ${JSON.stringify(eventDetail)}`);
   };
 
   private readonly checkForMissedMessages = async () => {
+    if (!this.graph) {
+      this.notifyStateChange((draft: GraphChatClient) => {
+        draft.status = 'error';
+        draft.activeErrorMessages.push(new Error('Graph client not available'));
+      });
+      return;
+    }
     const messages: MessageCollection = await loadChatThread(this.graph, this.chatId, this._messagesPerCall);
     const messageConversions = messages.value
       // trying to filter out messages on the graph request causes a 400
@@ -887,7 +959,7 @@ detail: ${JSON.stringify(eventDetail)}`);
       });
     }
     const hasOverlapWithExistingMessages = messages.value.some(m =>
-      this._state.messages.find(sm => sm.messageId === m.id)
+      this.state.messages.find(sm => sm.messageId === m.id)
     );
     if (!hasOverlapWithExistingMessages) {
       // TODO handle the case where there were a lot of missed messages and we ned to get the next page of messages.
@@ -956,6 +1028,13 @@ detail: ${JSON.stringify(eventDetail)}`);
   }
 
   private readonly addChatMembers = async (userIds: string[], history?: Date): Promise<void> => {
+    if (!this.graph) {
+      this.notifyStateChange((draft: GraphChatClient) => {
+        draft.status = 'error';
+        draft.activeErrorMessages.push(new Error('Graph client not available'));
+      });
+      return;
+    }
     await addChatMembers(this.graph, this.chatId, userIds, history);
   };
 
@@ -968,6 +1047,13 @@ detail: ${JSON.stringify(eventDetail)}`);
    */
   private readonly removeChatMember = async (membershpId: string): Promise<void> => {
     if (!membershpId) return;
+    if (!this.graph) {
+      this.notifyStateChange((draft: GraphChatClient) => {
+        draft.status = 'error';
+        draft.activeErrorMessages.push(new Error('Graph client not available'));
+      });
+      return;
+    }
     const isPresent = this._chat?.members?.findIndex(m => m.id === membershpId) ?? -1;
     if (isPresent === -1) return;
     await removeChatMember(this.graph, this.chatId, membershpId);
@@ -979,6 +1065,13 @@ detail: ${JSON.stringify(eventDetail)}`);
   }
 
   private processMessageContent(graphMessage: ChatMessage, currentUser: string): MessageConversion {
+    if (!this.graph) {
+      this.notifyStateChange((draft: GraphChatClient) => {
+        draft.status = 'error';
+        draft.activeErrorMessages.push(new Error('Graph client not available'));
+      });
+      throw new Error('Graph client not available');
+    }
     const conversion: MessageConversion = {};
     // using a record here lets us track which image in the content each request is for
     const futureImages: Record<number, Promise<string | null>> = {};
@@ -998,7 +1091,7 @@ detail: ${JSON.stringify(eventDetail)}`);
       index++;
       match = this.graphImageMatch(messageResult);
     }
-    let placeholderMessage = this.buildAcsMessage(graphMessage, currentUser, messageId, messageResult);
+    let placeholderMessage = buildAcsMessage(graphMessage, currentUser, messageId, messageResult);
     conversion.currentValue = placeholderMessage;
     // local function to update the message with data from each of the resolved image requests
     const updateMessage = async () => {
@@ -1029,97 +1122,26 @@ detail: ${JSON.stringify(eventDetail)}`);
     let result: MessageConversion = {};
     content = rewriteEmojiContentToHTML(content);
     // Handle any mentions in the content
-    content = this.updateMentionsContent(content);
+    content = updateMentionsContent(content);
 
     const imageMatch = this.graphImageMatch(content ?? '');
     if (imageMatch) {
       // if the message contains an image, we need to fetch the image and replace the placeholder
       result = this.processMessageContent(graphMessage, currentUser);
     } else {
-      result.currentValue = this.buildAcsMessage(graphMessage, currentUser, messageId, content);
+      result.currentValue = buildAcsMessage(graphMessage, currentUser, messageId, content);
     }
     return result;
   }
 
-  /**
-   * Teams mentions are in the pattern <at id="1">User</at>. This replacement
-   * changes the mentions pattern to <msft-mention id="1">User</msft-mention>
-   * which will trigger the `mentionOptions` prop to be called in MessageThread.
-   *
-   * @param content is the message with mentions.
-   * @returns string with replaced mention parts.
-   */
-  private updateMentionsContent(content: string): string {
-    const msftMention = `<msft-mention id="$1">$2</msft-mention>`;
-    const atRegex = /<at\sid="(\d+)">([a-z0-9_.-\s]+)<\/at>/gim;
-    content = content
-      .replace(/&nbsp;<at/gim, '<at')
-      .replace(/at>&nbsp;/gim, 'at>')
-      .replace(atRegex, msftMention);
-    return content;
-  }
-
-  private hasUnsupportedContent(content: string, attachments: ChatMessageAttachment[]): boolean {
-    const unsupportedContentTypes = [
-      'application/vnd.microsoft.card.codesnippet',
-      'application/vnd.microsoft.card.fluid',
-      'application/vnd.microsoft.card.fluidEmbedCard',
-      'reference'
-    ];
-    const isUnsupported: boolean[] = [];
-
-    if (attachments.length) {
-      for (const attachment of attachments) {
-        const contentType = attachment?.contentType ?? '';
-        isUnsupported.push(unsupportedContentTypes.includes(contentType));
-      }
-    } else {
-      // checking content with <attachment> tags
-      const unsupportedContentRegex = /<\/?attachment>/gim;
-      const contentUnsupported = Boolean(content) && unsupportedContentRegex.test(content);
-      isUnsupported.push(contentUnsupported);
-    }
-    return isUnsupported.every(e => e === true);
-  }
-
-  private buildAcsMessage(
-    graphMessage: ChatMessage,
-    currentUser: string,
-    messageId: string,
-    content: string
-  ): GraphChatMessage {
-    const senderId = graphMessage.from?.user?.id ?? graphMessage.from?.application?.id ?? undefined;
-    const chatId = graphMessage?.chatId ?? '';
-    const id = graphMessage?.id ?? '';
-    const chatUrl = `https://teams.microsoft.com/l/message/${chatId}/${id}?context={"contextType":"chat"}`;
-    const attachments = graphMessage?.attachments ?? [];
-
-    let messageData: GraphChatMessage = {
-      messageId,
-      contentType: graphMessage.body?.contentType ?? 'text',
-      messageType: 'chat',
-      content,
-      senderDisplayName:
-        graphMessage.from?.user?.displayName ?? graphMessage.from?.application?.displayName ?? undefined,
-      createdOn: new Date(graphMessage.createdDateTime ?? Date.now()),
-      editedOn: graphMessage.lastEditedDateTime ? new Date(graphMessage.lastEditedDateTime) : undefined,
-      senderId,
-      mine: senderId === currentUser,
-      status: 'seen',
-      attached: 'top',
-      hasUnsupportedContent: this.hasUnsupportedContent(content, attachments),
-      rawChatUrl: chatUrl
-    };
-    if (graphMessage?.policyViolation) {
-      messageData = Object.assign(messageData, {
-        messageType: 'blocked',
-        link: 'https://go.microsoft.com/fwlink/?LinkId=2132837'
-      });
-    }
-    return messageData;
-  }
-
   private readonly renameChat = async (topic: string | null): Promise<void> => {
+    if (!this.graph) {
+      this.notifyStateChange((draft: GraphChatClient) => {
+        draft.status = 'error';
+        draft.activeErrorMessages.push(new Error('Graph client not available'));
+      });
+      return;
+    }
     await updateChatTopic(this.graph, this.chatId, topic);
     this.notifyStateChange(() => void (this._chat = { ...this._chat, ...{ topic } }));
   };
@@ -1163,18 +1185,6 @@ detail: ${JSON.stringify(eventDetail)}`);
     });
   };
 
-  /**
-   * Provided the graph instance for the component with the correct SDK version decoration
-   *
-   * @readonly
-   * @private
-   * @type {IGraph}
-   * @memberof StatefulGraphChatClient
-   */
-  private get graph(): IGraph {
-    return graph('mgt-chat');
-  }
-
   private readonly _initialState: GraphChatClient = {
     status: 'initial',
     userId: '',
@@ -1202,7 +1212,7 @@ detail: ${JSON.stringify(eventDetail)}`);
    * @type {GraphChatClient}
    * @memberof StatefulGraphChatClient
    */
-  private _state: GraphChatClient = { ...this._initialState };
+  protected readonly state: GraphChatClient = { ...this._initialState };
 }
 
 export { StatefulGraphChatClient };

--- a/packages/mgt-chat/src/statefulClient/StatefulGraphChatClient.ts
+++ b/packages/mgt-chat/src/statefulClient/StatefulGraphChatClient.ts
@@ -1088,7 +1088,7 @@ detail: ${JSON.stringify(eventDetail)}`);
     messageId: string,
     content: string
   ): GraphChatMessage {
-    const senderId = graphMessage.from?.user?.id || undefined;
+    const senderId = graphMessage.from?.user?.id ?? graphMessage.from?.application?.id ?? undefined;
     const chatId = graphMessage?.chatId ?? '';
     const id = graphMessage?.id ?? '';
     const chatUrl = `https://teams.microsoft.com/l/message/${chatId}/${id}?context={"contextType":"chat"}`;
@@ -1099,7 +1099,8 @@ detail: ${JSON.stringify(eventDetail)}`);
       contentType: graphMessage.body?.contentType ?? 'text',
       messageType: 'chat',
       content,
-      senderDisplayName: graphMessage.from?.user?.displayName ?? undefined,
+      senderDisplayName:
+        graphMessage.from?.user?.displayName ?? graphMessage.from?.application?.displayName ?? undefined,
       createdOn: new Date(graphMessage.createdDateTime ?? Date.now()),
       editedOn: graphMessage.lastEditedDateTime ? new Date(graphMessage.lastEditedDateTime) : undefined,
       senderId,

--- a/packages/mgt-chat/src/statefulClient/buildBotId.ts
+++ b/packages/mgt-chat/src/statefulClient/buildBotId.ts
@@ -1,0 +1,6 @@
+import { NullableOption, Identity } from '@microsoft/microsoft-graph-types';
+
+export const botPrefix = 'botId::';
+
+export const buildBotId = (application: NullableOption<Identity> | undefined) =>
+  application?.id ? `${botPrefix}${application.id}` : undefined;

--- a/packages/mgt-chat/src/statefulClient/chatOperationScopes.tests.ts
+++ b/packages/mgt-chat/src/statefulClient/chatOperationScopes.tests.ts
@@ -22,7 +22,9 @@ describe('chatOperationScopes tests', () => {
       'Mail.ReadBasic',
       'Contacts.Read',
       'Chat.ReadWrite',
-      'ChatMember.ReadWrite'
+      'ChatMember.ReadWrite',
+      'TeamsAppInstallation.ReadForChat',
+      'AppCatalog.Read.All'
     ];
     expect(allChatScopes).to.have.members(expectedScopes);
   });

--- a/packages/mgt-chat/src/statefulClient/chatOperationScopes.ts
+++ b/packages/mgt-chat/src/statefulClient/chatOperationScopes.ts
@@ -9,12 +9,17 @@ import { getMgtPersonCardScopes } from '@microsoft/mgt-components/dist/es6/expor
 /**
  * The lowest count of scopes required to perform all chat operations
  */
-export const minimalChatScopesList = ['ChatMember.ReadWrite', 'Chat.ReadWrite'];
+export const minimalChatScopesList = [
+  'ChatMember.ReadWrite',
+  'Chat.ReadWrite',
+  'TeamsAppInstallation.ReadForChat',
+  'AppCatalog.Read.All'
+];
 
 /**
  * Object mapping chat operations to the scopes required to perform them
  */
-export const chatOperationScopes: Record<string, string[]> = {
+export const chatOperationScopesMin: Record<string, string[]> = {
   loadChat: ['Chat.ReadWrite'],
   loadChatMessages: ['Chat.ReadWrite'],
   loadChatImage: ['Chat.ReadWrite'],
@@ -23,14 +28,16 @@ export const chatOperationScopes: Record<string, string[]> = {
   deleteChatMessage: ['Chat.ReadWrite'],
   removeChatMember: ['ChatMember.ReadWrite'],
   addChatMember: ['ChatMember.ReadWrite'],
-  createChat: ['Chat.ReadWrite']
+  createChat: ['Chat.ReadWrite'],
+  loadBotsInChat: ['TeamsAppInstallation.ReadForChat'],
+  loadBotIcon: ['AppCatalog.Read.All']
 };
 
 /**
  * Object mapping chat operations to the scopes required to perform them
  * This should be used when we migrate this code to use scope aware requests
  */
-export const chatOperationScopesFullListing: Record<string, string[]> = {
+export const chatOperationScopes: Record<string, string[]> = {
   loadChat: ['Chat.ReadBasic', 'Chat.Read', 'Chat.ReadWrite'],
   loadChatMessages: ['Chat.Read', 'Chat.ReadWrite'],
   loadChatImage: ['ChannelMessage.Read.All', 'Chat.Read', 'Chat.ReadWrite', 'Group.Read.All', 'Group.ReadWrite.All'],
@@ -39,7 +46,13 @@ export const chatOperationScopesFullListing: Record<string, string[]> = {
   deleteChatMessage: ['ChannelMessage.ReadWrite', 'Chat.ReadWrite'],
   removeChatMember: ['ChatMember.ReadWrite'],
   addChatMember: ['ChatMember.ReadWrite', 'Chat.ReadWrite'],
-  createChat: ['Chat.Create', 'Chat.ReadWrite']
+  createChat: ['Chat.Create', 'Chat.ReadWrite'],
+  loadBotsInChat: [
+    'TeamsAppInstallation.ReadForChat',
+    'TeamsAppInstallation.ReadWriteSelfForChat',
+    'TeamsAppInstallation.ReadWriteForChat'
+  ],
+  loadBotIcon: ['AppCatalog.Read.All', 'AppCatalog.ReadWrite.All', 'AppCatalog.Submit']
 };
 
 /**

--- a/packages/mgt-chat/src/statefulClient/graph.chat.ts
+++ b/packages/mgt-chat/src/statefulClient/graph.chat.ts
@@ -12,10 +12,11 @@ import {
   storePhotoInCache,
   blobToBase64
 } from '@microsoft/mgt-components';
-import { CacheService, IGraph, prepScopes } from '@microsoft/mgt-element';
+import { BetaGraph, CacheService, IGraph, prepScopes } from '@microsoft/mgt-element';
 import { ResponseType } from '@microsoft/microsoft-graph-client';
 import { AadUserConversationMember, Chat, ChatMessage } from '@microsoft/microsoft-graph-types';
 import { chatOperationScopes } from './chatOperationScopes';
+import { TeamsAppInstallation } from '@microsoft/microsoft-graph-types-beta';
 
 /**
  * Generic collection response from graph
@@ -30,6 +31,8 @@ export interface GraphCollection<T = any> {
  * Object representing a collection of chat messages
  */
 export type MessageCollection = GraphCollection<ChatMessage>;
+
+export type AppCollection = GraphCollection<TeamsAppInstallation>;
 
 /**
  * Load the specified chat from graph with the members expanded
@@ -67,6 +70,55 @@ export const loadChatThread = async (
   // split the nextLink on version to maintain a relative path
   response.nextLink = response['@odata.nextLink']?.split(graph.version)[1];
   return response;
+};
+
+/**
+ * Load the app information for the specified botId in a given chat
+ *
+ * @param graph {BetaGraph} - authenticated graph client from mgt for the beta endpoints
+ * @param chatId {string} - the id of the chat to load apps for
+ * @param botId {string} - the id of the bot to load apps for
+ * @returns {Promise<AppCollection>} - a collection of apps installed in the chat
+ */
+export const loadBotInChat = async (graph: BetaGraph, chatId: string, botId: string): Promise<AppCollection> => {
+  const response = (await graph
+    .api(`/chats/${chatId}/installedApps`)
+    .expand('teamsApp,teamsAppDefinition($expand=bot,colorIcon)')
+    .filter(`teamsAppDefinition/bot/id+eq+'${botId}'`)
+    .middlewareOptions(prepScopes(chatOperationScopes.loadBotsInChat))
+    .get()) as AppCollection;
+  return response;
+};
+
+export const loadBotIcon = async (graph: BetaGraph, installedApp: TeamsAppInstallation): Promise<string> => {
+  if (installedApp.teamsApp?.distributionMethod === 'store') {
+    return loadStoreBotIcon(installedApp);
+  }
+  return loadLobBotIcon(graph, installedApp);
+};
+
+const loadLobBotIcon = async (graph: BetaGraph, installedApp: TeamsAppInstallation): Promise<string> => {
+  // GET /appCatalogs/teamsApps/{teams-app-id}/appDefinitions/{app-definition-id}/colorIcon/hostedContent/$value
+  if (installedApp.teamsApp?.id && installedApp.teamsAppDefinition?.id) {
+    const teamsAppId = installedApp.teamsApp.id;
+    const appDefinitionId = installedApp.teamsAppDefinition.id;
+    const response = (await graph
+      .api(`/appCatalogs/teamsApps/${teamsAppId}/appDefinitions/${appDefinitionId}/colorIcon/hostedContent/$value`)
+      .responseType(ResponseType.RAW)
+      .middlewareOptions(prepScopes(chatOperationScopes.loadBotIcon))
+      .get()) as Response;
+
+    return await blobToBase64(await response.blob());
+  }
+  return '';
+};
+
+const loadStoreBotIcon = async (installedApp: TeamsAppInstallation): Promise<string> => {
+  if (!installedApp.teamsAppDefinition?.colorIcon?.webUrl) return '';
+
+  const response = await fetch(installedApp.teamsAppDefinition.colorIcon.webUrl);
+
+  return await blobToBase64(await response.blob());
 };
 
 /**

--- a/packages/mgt-chat/src/statefulClient/useBotInfo.ts
+++ b/packages/mgt-chat/src/statefulClient/useBotInfo.ts
@@ -1,0 +1,14 @@
+import { useContext, useEffect, useState } from "react";
+import { BotInfoContext } from "../components/Context/BotInfoContext";
+
+export const useBotInfo = () => {
+  const botInfoClient = useContext(BotInfoContext);
+  const [botInfo, setBotInfo] = useState(() => botInfoClient?.getState());
+  useEffect(() => {
+    if (botInfoClient) {
+      botInfoClient.onStateChange(setBotInfo);
+      return () => botInfoClient.offStateChange(setBotInfo);
+    }
+  }, [botInfoClient]);
+  return botInfo;
+};

--- a/packages/mgt-chat/src/statefulClient/useBotInfo.ts
+++ b/packages/mgt-chat/src/statefulClient/useBotInfo.ts
@@ -1,5 +1,5 @@
-import { useContext, useEffect, useState } from "react";
-import { BotInfoContext } from "../components/Context/BotInfoContext";
+import { useContext, useEffect, useState } from 'react';
+import { BotInfoContext } from '../components/Context/BotInfoContext';
 
 export const useBotInfo = () => {
   const botInfoClient = useContext(BotInfoContext);

--- a/packages/mgt-chat/src/utils/reduceScopes.tests.ts
+++ b/packages/mgt-chat/src/utils/reduceScopes.tests.ts
@@ -66,6 +66,11 @@ describe('reduceScopes tests', () => {
     const actual = reduceScopes(input);
     // NOTE: the idea result here is ['user.read', 'user.write']
     // however the given result results in a higher scope count and not higher effective permissions
-    await expect(actual).to.eql(['Chat.ReadWrite', 'ChatMember.ReadWrite']);
+    await expect(actual).to.eql([
+      'Chat.ReadWrite',
+      'ChatMember.ReadWrite',
+      'TeamsAppInstallation.ReadForChat',
+      'AppCatalog.Read.All'
+    ]);
   });
 });

--- a/packages/mgt-chat/src/utils/rewriteEmojiContent.tests.ts
+++ b/packages/mgt-chat/src/utils/rewriteEmojiContent.tests.ts
@@ -12,20 +12,20 @@ describe('rewrite emoji to standard HTML', () => {
   it('rewrites an emoji correctly', async () => {
     const result = rewriteEmojiContentToHTML(`<emoji id="cool" alt="😎" title="Cool"></emoji>`);
     await expect(result).to.be.equal(
-      `<span contenteditable="false" title="Cool" type="(cool)" class="animated-emoticon-50-cool"><img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="cool" src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/cool/default/50_f.png" title="Cool" alt="😎" style="width:50px;height:50px;"></span>`
+      `<span title="Cool" type="(cool)" class="animated-emoticon-50-cool"><img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="cool" src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/cool/default/50_f.png" title="Cool" alt="😎" style="width:50px;height:50px;"></span>`
     );
   });
   it('rewrites an emoji in a p tag correctly', async () => {
     const result = rewriteEmojiContentToHTML(`<p><emoji id="cool" alt="😎" title="Cool"></emoji></p>`);
     await expect(result).to.be.equal(
-      `<p><span contenteditable="false" title="Cool" type="(cool)" class="animated-emoticon-50-cool"><img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="cool" src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/cool/default/50_f.png" title="Cool" alt="😎" style="width:50px;height:50px;"></span></p>`
+      `<p><span title="Cool" type="(cool)" class="animated-emoticon-50-cool"><img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="cool" src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/cool/default/50_f.png" title="Cool" alt="😎" style="width:50px;height:50px;"></span></p>`
     );
   });
 
   it('rewrites an emoji in a p tag with additional content correctly', async () => {
     const result = rewriteEmojiContentToHTML(`<p>Hello <emoji id="cool" alt="😎" title="Cool"></emoji></p>`);
     await expect(result).to.be.equal(
-      `<p>Hello <span contenteditable="false" title="Cool" type="(cool)" class="animated-emoticon-20-cool"><img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="cool" src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/cool/default/20_f.png" title="Cool" alt="😎" style="width:20px;height:20px;"></span></p>`
+      `<p>Hello <span title="Cool" type="(cool)" class="animated-emoticon-20-cool"><img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="cool" src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/cool/default/20_f.png" title="Cool" alt="😎" style="width:20px;height:20px;"></span></p>`
     );
   });
 
@@ -34,7 +34,7 @@ describe('rewrite emoji to standard HTML', () => {
       `<p><emoji id="hearteyes" alt="😍" title="Heart eyes"></emoji></p><p><emoji id="1f92a_zanyface" alt="🤪" title="Zany face"></emoji></p><p><emoji id="cool" alt="😎" title="Cool"></emoji></p>`
     );
     await expect(result).to.be.equal(
-      `<p><span contenteditable="false" title="Heart eyes" type="(hearteyes)" class="animated-emoticon-20-cool"><img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="hearteyes" src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/hearteyes/default/20_f.png" title="Heart eyes" alt="😍" style="width:20px;height:20px;"></span></p><p><span contenteditable="false" title="Zany face" type="(1f92a_zanyface)" class="animated-emoticon-20-cool"><img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="1f92a_zanyface" src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/1f92a_zanyface/default/20_f.png" title="Zany face" alt="🤪" style="width:20px;height:20px;"></span></p><p><span contenteditable="false" title="Cool" type="(cool)" class="animated-emoticon-20-cool"><img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="cool" src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/cool/default/20_f.png" title="Cool" alt="😎" style="width:20px;height:20px;"></span></p>`
+      `<p><span title="Heart eyes" type="(hearteyes)" class="animated-emoticon-20-cool"><img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="hearteyes" src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/hearteyes/default/20_f.png" title="Heart eyes" alt="😍" style="width:20px;height:20px;"></span></p><p><span title="Zany face" type="(1f92a_zanyface)" class="animated-emoticon-20-cool"><img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="1f92a_zanyface" src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/1f92a_zanyface/default/20_f.png" title="Zany face" alt="🤪" style="width:20px;height:20px;"></span></p><p><span title="Cool" type="(cool)" class="animated-emoticon-20-cool"><img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="cool" src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/assets/emoticons/cool/default/20_f.png" title="Cool" alt="😎" style="width:20px;height:20px;"></span></p>`
     );
   });
 });

--- a/packages/mgt-chat/src/utils/rewriteEmojiContent.ts
+++ b/packages/mgt-chat/src/utils/rewriteEmojiContent.ts
@@ -39,7 +39,6 @@ export const rewriteEmojiContentToHTML = (content: string): string => {
     const title = emoji.getAttribute('title') ?? '';
 
     const span = document.createElement('span');
-    span.setAttribute('contentEditable', 'false');
     span.setAttribute('title', title);
     span.setAttribute('type', `(${id})`);
     span.setAttribute('class', `animated-emoticon-${size}-cool`);

--- a/packages/mgt-element/src/Graph.ts
+++ b/packages/mgt-element/src/Graph.ts
@@ -147,7 +147,7 @@ export class Graph implements IGraph {
  * @returns {Graph}
  * @memberof Graph
  */
-export const createFromProvider = (provider: IProvider, version?: string, component?: Element | string): Graph => {
+export const createFromProvider = (provider: IProvider, version?: string, component?: Element | string): IGraph => {
   const middleware: Middleware[] = [
     new AuthenticationHandler(provider),
     new RetryHandler(new RetryHandlerOptions()),


### PR DESCRIPTION
Closes #2947
Closes #3060 
Closes #3068 

### PR Type

- Bugfix
- Feature

### Description of the changes

sets up a React Context + Provider model for getting Bot based data via a shared Stateful Client
refactor to create a base class for stateful clients
creates a new component for rendering chat avatars that can handle bots
stop creating two instances of the notification client
remove contenteditable attribute from emjoi html

### PR checklist
- [X] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [X] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [X] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [X] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [X] License header has been added to all new source files (`yarn setLicense`)
- [X] Contains **NO** breaking changes

### Other information
