### PR TITLE
fix: disable input in single select mode and default userIds and groupIds

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -543,7 +543,12 @@ export class MgtPeoplePicker extends MgtTemplatedTaskComponent {
   };
 
   private get hasMaxSelections(): boolean {
-    return this.selectionMode === 'single' && this.selectedPeople.length >= 1;
+    return (
+      this.selectionMode === 'single' &&
+      (this.selectedPeople.length >= 1 ||
+        this.defaultSelectedUserIds.length >= 1 ||
+        this.defaultSelectedGroupIds.length >= 1)
+    );
   }
 
   /**
@@ -1032,6 +1037,9 @@ export class MgtPeoplePicker extends MgtTemplatedTaskComponent {
         !this.defaultSelectedUsers.length &&
         !this.defaultSelectedGroups.length
       ) {
+        if (this.hasMaxSelections) {
+          this.disableTextInput();
+        }
         this.defaultSelectedUsers = await getUsersForUserIds(graph, this.defaultSelectedUserIds, '', this.userFilters);
         this.defaultSelectedGroups = await getGroupsForGroupIds(
           graph,

--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -502,11 +502,6 @@ export class MgtPeoplePicker extends MgtTemplatedTaskComponent {
    */
   @state() private _foundPeople: IDynamicPerson[];
 
-  /**
-   * Checks if the input has maximum selected people in single select mode.
-   */
-  @state() private _hasMaxSelections = false;
-
   constructor() {
     super();
 
@@ -546,6 +541,11 @@ export class MgtPeoplePicker extends MgtTemplatedTaskComponent {
       this.enableTextInput();
     }
   };
+
+  private get hasMaxSelections(): boolean {
+    return this.selectionMode === 'single' && this.selectedPeople.length >= 1;
+  }
+
   /**
    * Focuses the input element when focus is called
    *
@@ -682,7 +682,7 @@ export class MgtPeoplePicker extends MgtTemplatedTaskComponent {
    */
   protected renderInput(selectedPeopleTemplate: TemplateResult): TemplateResult {
     const placeholder = this.disabled ? '' : this.placeholder || this.strings.inputPlaceholderText;
-    const maxSelectionsAriaLabel = this._hasMaxSelections ? this.strings.maxSelectionsAriaLabel : '';
+    const maxSelectionsAriaLabel = this.hasMaxSelections ? this.strings.maxSelectionsAriaLabel : '';
 
     const searchIcon = html`<span class="search-icon">${getSvg(SvgIcon.Search)}</span>`;
     const startSlot = this.selectedPeople?.length > 0 ? selectedPeopleTemplate : searchIcon;
@@ -693,13 +693,13 @@ export class MgtPeoplePicker extends MgtTemplatedTaskComponent {
         slot="anchor"
         id="people-picker-input"
         role="combobox"
-        placeholder=${this._hasMaxSelections ? this.strings.maxSelectionsPlaceHolder : placeholder}
+        placeholder=${this.hasMaxSelections ? this.strings.maxSelectionsPlaceHolder : placeholder}
         aria-label=${this.ariaLabel || maxSelectionsAriaLabel || placeholder || this.strings.selectContact}
         aria-expanded=${this.flyout?.isOpen ?? false}
-        @click="${this._hasMaxSelections ? undefined : this.handleInputClick}"
-        @focus="${this._hasMaxSelections ? undefined : this.gainedFocus}"
-        @keydown="${this._hasMaxSelections ? undefined : this.onUserKeyDown}"
-        @input="${this._hasMaxSelections ? undefined : this.onUserInput}"
+        @click="${this.hasMaxSelections ? undefined : this.handleInputClick}"
+        @focus="${this.hasMaxSelections ? undefined : this.gainedFocus}"
+        @keydown="${this.hasMaxSelections ? undefined : this.onUserKeyDown}"
+        @input="${this.hasMaxSelections ? undefined : this.onUserInput}"
         @blur="${this.lostFocus}"
         ?disabled=${this.disabled}
       >
@@ -931,11 +931,6 @@ export class MgtPeoplePicker extends MgtTemplatedTaskComponent {
     let people = this.people;
     const input = this.userInput.toLowerCase();
     const provider = Providers.globalProvider;
-    this._hasMaxSelections =
-      this.selectionMode === 'single' &&
-      (this.selectedPeople.length >= 1 ||
-        this.defaultSelectedUserIds.length >= 1 ||
-        this.defaultSelectedGroupIds.length >= 1);
 
     if (people?.length) {
       if (input) {
@@ -1054,7 +1049,7 @@ export class MgtPeoplePicker extends MgtTemplatedTaskComponent {
 
         this.selectedPeople = [...this.defaultSelectedUsers, ...this.defaultSelectedGroups];
 
-        if (this._hasMaxSelections) {
+        if (this.hasMaxSelections) {
           this.disableTextInput();
         }
         this.requestUpdate();
@@ -1399,7 +1394,7 @@ export class MgtPeoplePicker extends MgtTemplatedTaskComponent {
   // handle suggestion list item click
   private handleSuggestionClick(person: IDynamicPerson): void {
     this.addPerson(person);
-    if (this._hasMaxSelections) {
+    if (this.hasMaxSelections) {
       this.disableTextInput();
       this.input.value = '';
     }
@@ -1483,7 +1478,7 @@ export class MgtPeoplePicker extends MgtTemplatedTaskComponent {
           this.addPerson(foundPerson);
           this.hideFlyout();
           this.input.value = '';
-          if (this._hasMaxSelections) {
+          if (this.hasMaxSelections) {
             this.disableTextInput();
           }
           return;

--- a/stories/components/peoplePicker/peoplePicker.properties.stories.js
+++ b/stories/components/peoplePicker/peoplePicker.properties.stories.js
@@ -41,6 +41,12 @@ export const singleSelectMode = () => html`
     <button aria-label="close modal" id="close-modal">X</button>
 </div>
 
+<h2> Single select with default selected user Ids</h2>
+<mgt-people-picker default-selected-user-ids="e3d0513b-449e-4198-ba6f-bd97ae7cae85" selection-mode="single"></mgt-people-picker>
+
+<h2> Single select with default selected group Ids</h2>
+<mgt-people-picker default-selected-group-ids="94cb7dd0-cb3b-49e0-ad15-4efeb3c7d3e9" selection-mode="single"></mgt-people-picker>
+
 <style>
 #modal-content {
   height: 200px;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #3066  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Disables input on people-picker single-select mode in the case of default selected user Ids and group Ids 

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
