### PR TITLE
fix: version bump

### DIFF
--- a/packages/mgt-components/package.json
+++ b/packages/mgt-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/mgt-components",
-  "version": "3.0.1",
+  "version": "4.2.0",
   "description": "The Microsoft Graph Toolkit Components",
   "keywords": [
     "microsoft graph",
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoftgraph/microsoft-graph-toolkit"
+    "url": "git+https://github.com/microsoftgraph/microsoft-graph-toolkit.git"
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/packages/mgt-element/package.json
+++ b/packages/mgt-element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/mgt-element",
-  "version": "3.0.1",
+  "version": "4.2.0",
   "description": "Microsoft Graph Toolkit base classes",
   "homepage": "https://github.com/microsoftgraph/microsoft-graph-toolkit",
   "bugs": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoftgraph/microsoft-graph-toolkit"
+    "url": "git+https://github.com/microsoftgraph/microsoft-graph-toolkit.git"
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/packages/mgt-react/package.json
+++ b/packages/mgt-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/mgt-react",
-  "version": "3.0.1",
+  "version": "4.2.0",
   "description": "Microsoft Graph Toolkit React wrapper class",
   "author": "Microsoft",
   "license": "MIT",
@@ -19,7 +19,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoftgraph/microsoft-graph-toolkit"
+    "url": "git+https://github.com/microsoftgraph/microsoft-graph-toolkit.git"
   },
   "bugs": {
     "url": "https://github.com/microsoftgraph/microsoft-graph-toolkit/issues"

--- a/packages/mgt-spfx-utils/package.json
+++ b/packages/mgt-spfx-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/mgt-spfx-utils",
-  "version": "3.0.1",
+  "version": "4.2.0",
   "description": "Helper utilities for loading MGT based libraries and web parts in a SPFx context",
   "main": "./dist/es6/index.js",
   "types": "./dist/es6/index.d.ts",
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoftgraph/microsoft-graph-toolkit"
+    "url": "git+https://github.com/microsoftgraph/microsoft-graph-toolkit.git"
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/packages/mgt/package.json
+++ b/packages/mgt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/mgt",
-  "version": "3.0.1",
+  "version": "4.2.0",
   "description": "The Microsoft Graph Toolkit",
   "keywords": [
     "microsoft graph",
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoftgraph/microsoft-graph-toolkit"
+    "url": "git+https://github.com/microsoftgraph/microsoft-graph-toolkit.git"
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/packages/providers/mgt-electron-provider/package.json
+++ b/packages/providers/mgt-electron-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/mgt-electron-provider",
-  "version": "3.0.1",
+  "version": "4.2.0",
   "description": "The Microsoft Graph Toolkit Electron Provider",
   "keywords": [
     "microsoft graph",
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoftgraph/microsoft-graph-toolkit"
+    "url": "git+https://github.com/microsoftgraph/microsoft-graph-toolkit.git"
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/packages/providers/mgt-mock-provider/package.json
+++ b/packages/providers/mgt-mock-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/mgt-mock-provider",
-  "version": "3.0.1",
+  "version": "4.2.0",
   "description": "The Microsoft Graph Toolkit Mock Provider",
   "keywords": [
     "microsoft graph",
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoftgraph/microsoft-graph-toolkit"
+    "url": "git+https://github.com/microsoftgraph/microsoft-graph-toolkit.git"
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/packages/providers/mgt-msal2-provider/package.json
+++ b/packages/providers/mgt-msal2-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/mgt-msal2-provider",
-  "version": "3.0.1",
+  "version": "4.2.0",
   "description": "The Microsoft Graph Toolkit Msal 2.0 Provider",
   "keywords": [
     "microsoft graph",
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoftgraph/microsoft-graph-toolkit"
+    "url": "git+https://github.com/microsoftgraph/microsoft-graph-toolkit.git"
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/packages/providers/mgt-proxy-provider/package.json
+++ b/packages/providers/mgt-proxy-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/mgt-proxy-provider",
-  "version": "3.0.1",
+  "version": "4.2.0",
   "description": "The Microsoft Graph Toolkit Proxy Provider",
   "keywords": [
     "microsoft graph",
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoftgraph/microsoft-graph-toolkit"
+    "url": "git+https://github.com/microsoftgraph/microsoft-graph-toolkit.git"
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/packages/providers/mgt-sharepoint-provider/package.json
+++ b/packages/providers/mgt-sharepoint-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/mgt-sharepoint-provider",
-  "version": "3.0.1",
+  "version": "4.2.0",
   "description": "The Microsoft Graph Toolkit SharePoint Provider",
   "keywords": [
     "microsoft graph",
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoftgraph/microsoft-graph-toolkit"
+    "url": "git+https://github.com/microsoftgraph/microsoft-graph-toolkit.git"
   },
   "author": "Microsoft",
   "license": "MIT",

--- a/packages/providers/mgt-teamsfx-provider/package.json
+++ b/packages/providers/mgt-teamsfx-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/mgt-teamsfx-provider",
-  "version": "3.0.1",
+  "version": "4.2.0",
   "description": "The Microsoft Graph Toolkit TeamsFx Provider",
   "keywords": [
     "microsoft graph",
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoftgraph/microsoft-graph-toolkit"
+    "url": "git+https://github.com/microsoftgraph/microsoft-graph-toolkit.git"
   },
   "author": "Microsoft",
   "license": "MIT",


### PR DESCRIPTION
also normalizes git urls in package.json as expected for publishing