### PR TITLE
fix(a11y): correct people-picker placeholder luminosity contrast

### DIFF
--- a/stories/components/peoplePicker/peoplePicker.style.stories.js
+++ b/stories/components/peoplePicker/peoplePicker.style.stories.js
@@ -24,7 +24,7 @@ export const customCSSProperties = () => html`
     --people-picker-dropdown-result-background-color: yellow;
     --people-picker-dropdown-result-hover-background-color: gold;
     --people-picker-dropdown-result-focus-background-color: green;
-    --people-picker-no-results-text-color: orange;
+    --people-picker-no-results-text-color: white;
     --people-picker-input-background: gray;
     --people-picker-input-border-color: yellow;
     --people-picker-input-hover-background: green;

--- a/stories/components/peoplePicker/peoplePicker.style.stories.js
+++ b/stories/components/peoplePicker/peoplePicker.style.stories.js
@@ -34,7 +34,7 @@ export const customCSSProperties = () => html`
 
     --people-picker-input-placeholder-focus-text-color: yellow;
     --people-picker-input-placeholder-hover-text-color: gold;
-    --people-picker-input-placeholder-text-color: white;
+    --people-picker-input-placeholder-text-color: black;
     --people-picker-search-icon-color: yellow;
     --people-picker-remove-selected-close-icon-color: blue;
     --people-picker-font-size: 16px;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #3128  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
