### PR TITLE
fix(a11y): correct luminosity contrast in mgt-file and mgt-login text colors

### DIFF
--- a/stories/components/file/file.style.stories.js
+++ b/stories/components/file/file.style.stories.js
@@ -34,7 +34,7 @@ export const customCSSProperties = () => html`
       --file-margin: 3px 4px;
       --file-line1-font-size: 15px;
       --file-line1-font-weight: 500;
-      --file-line1-color: gray;
+      --file-line1-color: blue;
       --file-line1-text-transform: capitalize;
       --file-line2-font-size:14px;
       --file-line2-font-weight:300;

--- a/stories/components/login/login.styles.stories.js
+++ b/stories/components/login/login.styles.stories.js
@@ -18,10 +18,10 @@ export const customCSSProperties = () => html`
 <mgt-login class="login"></mgt-login>
 <style>
   .login {
-    --login-signed-out-button-background: red;
+    --login-signed-out-button-background: black;
     --login-signed-out-button-hover-background: orange;
-    --login-signed-out-button-text-color: purple;
-    --login-signed-in-background: red;
+    --login-signed-out-button-text-color: white;
+    --login-signed-in-background: black;
     --login-signed-in-hover-background: green;
     --login-button-padding:5px;
     --login-popup-background-color: blue;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #3094  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

### PR checklist
- [ ] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
