### PR TITLE
fix(a11y): set the title and aria-label for the screen sizing buttons

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -156,6 +156,13 @@ const xmlns = 'http://www.w3.org/2000/svg';
 window.onload = () => {
   addUsefulLinks();
 };
+// Dirty hack. the screen size btns set the title on clicking it. Thus, when you
+// set the correct title, after clicking for full screen, the set title is 
+// overridden to the precious problematic value. This is a catch-all hack
+// to just ensure any clicks on the btn resets to the correct title.
+window.onclick = () =>{
+  resetScreenSizingBtnTitles()
+}
 
 function addUsefulLinks() {
   const linkStyle = 'color: black; text-decoration: none; text-align: center; cursor: pointer; padding-right: 0.5rem;';
@@ -266,6 +273,7 @@ function addUsefulLinks() {
   }
 
   setEventOnMenuClick();
+  resetScreenSizingBtnTitles();
 }
 
 function createSvg(svgPath) {
@@ -285,6 +293,23 @@ function createSvg(svgPath) {
 
   svgElem.appendChild(svgElemPath);
   return svgElem;
+}
+
+function resetScreenSizingBtnTitles () {
+  const titles = {
+    'Exit full screen [F]': 'Exit full screen',
+    'Go full screen [F]': 'Go full screen'
+  }
+
+  const screenSizingBtns = document.getElementsByClassName('css-6jc9zw');
+  for (let i = 0; i < screenSizingBtns.length; i++) {
+    const btn = screenSizingBtns[i];
+    const title = btn.getAttribute('title');
+    // zooming in/out btns share the same class, prefer their titles when they
+    // are not found in the titles object above.
+    btn.setAttribute('title', titles[title] ?? title);
+    btn.setAttribute('aria-label', titles[title] ?? title);
+  }
 }
 
 const injectScripts = () => {

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -156,10 +156,11 @@ const xmlns = 'http://www.w3.org/2000/svg';
 window.onload = () => {
   addUsefulLinks();
 };
-// Dirty hack. the screen size btns set the title on clicking it. Thus, when you
-// set the correct title, after clicking for full screen, the set title is 
-// overridden to the precious problematic value. This is a catch-all hack
-// to just ensure any clicks on the btn resets to the correct title.
+// Dirty hack. The screen sizing btn resets the title on clicking it. When you
+// set the correct title during the window loading event, after clicking the
+// button for a full screen or exit of a full screen, the set title is 
+// overridden to the previous problematic value. This is a catch-all hack on the
+// window click event to just ensure any clicks on the btn resets to the correct title.
 window.onclick = () =>{
   resetScreenSizingBtnTitles()
 }


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #3075  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->
 - Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Rewrites the title attribute value for the screen sizing buttons
Sets the aria-label attribute value to the title value of the sizing buttons

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
