### PR TITLE
fix(a11y): focus on uploaded file and narrate status

### DIFF
--- a/packages/mgt-components/src/components/mgt-file-list/mgt-file-upload/mgt-file-upload.scss
+++ b/packages/mgt-components/src/components/mgt-file-list/mgt-file-upload/mgt-file-upload.scss
@@ -31,6 +31,10 @@ $file-upload-border-drag: var(--file-upload-border-drag, 1px dashed #0078d4);
     margin-top: 30px;
   }
 
+  .focus,:focus {
+    outline: none;
+  }
+
   fluent-button {
     .upload-icon {
       path {

--- a/packages/mgt-components/src/components/mgt-file-list/mgt-file-upload/mgt-file-upload.ts
+++ b/packages/mgt-components/src/components/mgt-file-list/mgt-file-upload/mgt-file-upload.ts
@@ -339,16 +339,16 @@ export class MgtFileUpload extends MgtBaseComponent {
   constructor() {
     super();
     this.filesToUpload = [];
-    this.addEventListener('__uploadfailed', this.focusOnUpload)
-    this.addEventListener('__uploadsuccess', this.focusOnUpload)
+    this.addEventListener('__uploadfailed', this.focusOnUpload);
+    this.addEventListener('__uploadsuccess', this.focusOnUpload);
   }
 
   focusOnUpload() {
     const uploadDom = this.renderRoot.querySelector<HTMLElement>('mgt-file[part="upload"]');
-    if(uploadDom) {
-      uploadDom.setAttribute("tabindex", "0")
-      uploadDom.classList.add("upload");
-      uploadDom.focus()
+    if (uploadDom) {
+      uploadDom.setAttribute('tabindex', '0');
+      uploadDom.classList.add('upload');
+      uploadDom.focus();
     }
   }
 
@@ -477,13 +477,13 @@ export class MgtFileUpload extends MgtBaseComponent {
     const folder =
       folderTabStyle + (fileItem.fieldUploadResponse === 'lastModifiedDateTime' ? ' file-upload-dialog-success' : '');
 
-    const isDescription = fileItem.fieldUploadResponse === 'description'
+    const isDescription = fileItem.fieldUploadResponse === 'description';
     const description = classMap({
       description: isDescription
     });
 
     const completedTemplate = !fileItem.completed ? this.renderFileUploadTemplate(fileItem) : html``;
-    const failOrSuccess = isDescription? strings.failUploadFile: strings.successUploadFile;
+    const failOrSuccess = isDescription ? strings.failUploadFile : strings.successUploadFile;
     return mgtHtml`
         <div class="${completed}">
           <div class="${folder}">
@@ -1134,7 +1134,7 @@ export class MgtFileUpload extends MgtBaseComponent {
       fileUpload.completed = true;
       void super.requestStateUpdate(true);
       void clearFilesCache();
-      this.fireCustomEvent('__uploadsuccess')
+      this.fireCustomEvent('__uploadsuccess');
     }, 500);
   }
 
@@ -1151,7 +1151,7 @@ export class MgtFileUpload extends MgtBaseComponent {
       fileUpload.fieldUploadResponse = 'description';
       fileUpload.completed = true;
       void super.requestStateUpdate(true);
-      this.fireCustomEvent('__uploadfailed')
+      this.fireCustomEvent('__uploadfailed');
     }, 500);
   }
 

--- a/packages/mgt-components/src/components/mgt-file-list/mgt-file-upload/mgt-file-upload.ts
+++ b/packages/mgt-components/src/components/mgt-file-list/mgt-file-upload/mgt-file-upload.ts
@@ -344,7 +344,7 @@ export class MgtFileUpload extends MgtBaseComponent {
   }
 
   focusOnUpload() {
-    const uploadDom = this.renderRoot.querySelector('mgt-file[part="upload"]')
+    const uploadDom: HTMLElement | null = this.renderRoot.querySelector('mgt-file[part="upload"]');
     if(uploadDom) {
       uploadDom.setAttribute("tabindex", "0")
       uploadDom.classList.add("upload");

--- a/packages/mgt-components/src/components/mgt-file-list/mgt-file-upload/mgt-file-upload.ts
+++ b/packages/mgt-components/src/components/mgt-file-list/mgt-file-upload/mgt-file-upload.ts
@@ -337,6 +337,7 @@ export class MgtFileUpload extends MgtBaseComponent {
   private _excludedFileType = false;
 
   constructor() {
+    /* eslint-disable @typescript-eslint/unbound-method */
     super();
     this.filesToUpload = [];
     this.addEventListener('__uploadfailed', this.focusOnUpload);

--- a/packages/mgt-components/src/components/mgt-file-list/mgt-file-upload/mgt-file-upload.ts
+++ b/packages/mgt-components/src/components/mgt-file-list/mgt-file-upload/mgt-file-upload.ts
@@ -344,7 +344,7 @@ export class MgtFileUpload extends MgtBaseComponent {
   }
 
   focusOnUpload() {
-    const uploadDom: HTMLElement | null = this.renderRoot.querySelector('mgt-file[part="upload"]');
+    const uploadDom = this.renderRoot.querySelector<HTMLElement>('mgt-file[part="upload"]');
     if(uploadDom) {
       uploadDom.setAttribute("tabindex", "0")
       uploadDom.classList.add("upload");

--- a/packages/mgt-components/src/components/mgt-file-list/mgt-file-upload/mgt-file-upload.ts
+++ b/packages/mgt-components/src/components/mgt-file-list/mgt-file-upload/mgt-file-upload.ts
@@ -339,6 +339,17 @@ export class MgtFileUpload extends MgtBaseComponent {
   constructor() {
     super();
     this.filesToUpload = [];
+    this.addEventListener('__uploadfailed', this.focusOnUpload)
+    this.addEventListener('__uploadsuccess', this.focusOnUpload)
+  }
+
+  focusOnUpload() {
+    const uploadDom = this.renderRoot.querySelector('mgt-file[part="upload"]')
+    if(uploadDom) {
+      uploadDom.setAttribute("tabindex", "0")
+      uploadDom.classList.add("upload");
+      uploadDom.focus()
+    }
   }
 
   /**
@@ -466,12 +477,13 @@ export class MgtFileUpload extends MgtBaseComponent {
     const folder =
       folderTabStyle + (fileItem.fieldUploadResponse === 'lastModifiedDateTime' ? ' file-upload-dialog-success' : '');
 
+    const isDescription = fileItem.fieldUploadResponse === 'description'
     const description = classMap({
-      description: fileItem.fieldUploadResponse === 'description'
+      description: isDescription
     });
 
     const completedTemplate = !fileItem.completed ? this.renderFileUploadTemplate(fileItem) : html``;
-
+    const failOrSuccess = isDescription? strings.failUploadFile: strings.successUploadFile;
     return mgtHtml`
         <div class="${completed}">
           <div class="${folder}">
@@ -484,6 +496,7 @@ export class MgtFileUpload extends MgtBaseComponent {
                   .fileDetails=${fileItem.driveItem}
                   .view=${fileItem.view}
                   .line2Property=${fileItem.fieldUploadResponse}
+                  aria-label="${fileItem.driveItem.name} ${failOrSuccess}"
                   part="upload"
                   class="mgt-file-item">
                 </mgt-file>
@@ -1121,6 +1134,7 @@ export class MgtFileUpload extends MgtBaseComponent {
       fileUpload.completed = true;
       void super.requestStateUpdate(true);
       void clearFilesCache();
+      this.fireCustomEvent('__uploadsuccess')
     }, 500);
   }
 
@@ -1137,6 +1151,7 @@ export class MgtFileUpload extends MgtBaseComponent {
       fileUpload.fieldUploadResponse = 'description';
       fileUpload.completed = true;
       void super.requestStateUpdate(true);
+      this.fireCustomEvent('__uploadfailed')
     }, 500);
   }
 

--- a/packages/mgt-components/src/components/mgt-file-list/mgt-file-upload/strings.ts
+++ b/packages/mgt-components/src/components/mgt-file-list/mgt-file-upload/strings.ts
@@ -6,7 +6,8 @@
  */
 
 export const strings = {
-  failUploadFile: 'File upload fail.',
+  failUploadFile: 'File upload failed',
+  successUploadFile: 'File upload succeeded',
   cancelUploadFile: 'File cancel.',
   buttonUploadFile: 'Upload Files',
   maximumFilesTitle: 'Maximum files',


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #3110  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Created custom events to be fired on successful or failed file upload attempts
Focus on the uploaded file
Set aria-label text to narrate the file name and status of upload

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
