### PR TITLE
fix:add padding to the list of direct reports in person-card

### DIFF
--- a/packages/mgt-components/src/components/mgt-organization/mgt-organization.scss
+++ b/packages/mgt-components/src/components/mgt-organization/mgt-organization.scss
@@ -138,6 +138,7 @@ $organization-direct-report-person-avatar-size: var(--organization-direct-report
 
       .direct-report {
         margin-right: 4px;
+        padding: 4px 0;
         cursor: pointer;
       }
     }


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #3261  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Added a 4px padding, top and bottom of elements in the direct reports list.

### PR checklist
- [ ] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
![image](https://github.com/user-attachments/assets/5ffc34f5-5789-4757-996d-56acdc4ed542)
