### PR TITLE
fix: implement caching on the card state for person card

### DIFF
--- a/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.graph.ts
+++ b/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.graph.ts
@@ -6,7 +6,7 @@
  */
 
 import { BatchResponse, CacheItem, CacheService, CacheStore, IBatch, IGraph, prepScopes } from '@microsoft/mgt-element';
-import { Chat, ChatMessage, File, Message } from '@microsoft/microsoft-graph-types';
+import { Chat, ChatMessage } from '@microsoft/microsoft-graph-types';
 import { Profile } from '@microsoft/microsoft-graph-types-beta';
 
 import { getEmailFromGraphEntity } from '../../graph/graph.people';

--- a/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.graph.ts
+++ b/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.graph.ts
@@ -5,8 +5,8 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { BatchResponse, IBatch, IGraph, prepScopes } from '@microsoft/mgt-element';
-import { Chat, ChatMessage } from '@microsoft/microsoft-graph-types';
+import { BatchResponse, CacheItem, CacheService, CacheStore, IBatch, IGraph, prepScopes } from '@microsoft/mgt-element';
+import { Chat, ChatMessage, File, Message } from '@microsoft/microsoft-graph-types';
 import { Profile } from '@microsoft/microsoft-graph-types-beta';
 
 import { getEmailFromGraphEntity } from '../../graph/graph.people';
@@ -15,6 +15,7 @@ import { MgtPersonCardState } from './mgt-person-card.types';
 import { MgtPersonCardConfig } from './MgtPersonCardConfig';
 import { validUserByIdScopes } from '../../graph/graph.user';
 import { validInsightScopes } from '../../graph/graph.files';
+import { schemas } from '../../graph/cacheStores';
 
 const userProperties =
   'businessPhones,companyName,department,displayName,givenName,jobTitle,mail,mobilePhone,officeLocation,preferredLanguage,surname,userPrincipalName,id,accountEnabled';
@@ -26,6 +27,11 @@ const batchKeys = {
   people: 'people',
   person: 'person'
 };
+
+interface CacheCardState extends MgtPersonCardState, CacheItem { }
+
+export const getCardStateInvalidationTime = (): number =>
+  CacheService.config.users.invalidationPeriod || CacheService.config.defaultInvalidationPeriod;
 
 /**
  * Get data to populate the person card
@@ -44,6 +50,12 @@ export const getPersonCardGraphData = async (
 ): Promise<MgtPersonCardState> => {
   const userId = personDetails.id;
   const email = getEmailFromGraphEntity(personDetails);
+  const cache: CacheStore<CacheCardState> = CacheService.getCache<CacheCardState>(schemas.users, schemas.users.stores.cardState);
+  const cardState = await cache.getValue(userId)
+
+  if (cardState && getCardStateInvalidationTime() > Date.now() - cardState.timeCached) {
+    return cardState;
+  }
 
   const isContactOrGroup =
     'classification' in personDetails ||
@@ -100,6 +112,8 @@ export const getPersonCardGraphData = async (
   if (data.directReports && data.directReports.length > 0) {
     data.directReports = data.directReports.filter(report => report.accountEnabled);
   }
+
+  await cache.putValue(userId, data)
 
   return data;
 };

--- a/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.graph.ts
+++ b/packages/mgt-components/src/components/mgt-person-card/mgt-person-card.graph.ts
@@ -28,7 +28,7 @@ const batchKeys = {
   person: 'person'
 };
 
-interface CacheCardState extends MgtPersonCardState, CacheItem { }
+interface CacheCardState extends MgtPersonCardState, CacheItem {}
 
 export const getCardStateInvalidationTime = (): number =>
   CacheService.config.users.invalidationPeriod || CacheService.config.defaultInvalidationPeriod;
@@ -50,8 +50,11 @@ export const getPersonCardGraphData = async (
 ): Promise<MgtPersonCardState> => {
   const userId = personDetails.id;
   const email = getEmailFromGraphEntity(personDetails);
-  const cache: CacheStore<CacheCardState> = CacheService.getCache<CacheCardState>(schemas.users, schemas.users.stores.cardState);
-  const cardState = await cache.getValue(userId)
+  const cache: CacheStore<CacheCardState> = CacheService.getCache<CacheCardState>(
+    schemas.users,
+    schemas.users.stores.cardState
+  );
+  const cardState = await cache.getValue(userId);
 
   if (cardState && getCardStateInvalidationTime() > Date.now() - cardState.timeCached) {
     return cardState;
@@ -113,7 +116,7 @@ export const getPersonCardGraphData = async (
     data.directReports = data.directReports.filter(report => report.accountEnabled);
   }
 
-  await cache.putValue(userId, data)
+  await cache.putValue(userId, data);
 
   return data;
 };

--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -38,6 +38,7 @@ import { personCardConverter, type PersonCardInteraction } from './../PersonCard
 import { styles } from './mgt-person-css';
 import { AvatarType, MgtPersonConfig, avatarTypeConverter } from './mgt-person-types';
 import { strings } from './strings';
+import { getPersonCardGraphData } from '../mgt-person-card/mgt-person-card.graph';
 
 /**
  * Person properties part of original set provided by graph by default
@@ -938,14 +939,14 @@ export class MgtPerson extends MgtTemplatedTaskComponent {
       const template = this.renderTemplate('line1', { person });
       details.push(html`
            <div class="line1" part="detail-line" @click=${() =>
-             this.handleLine1Clicked()} role="presentation" aria-label="${line1text}">${template}</div>
+          this.handleLine1Clicked()} role="presentation" aria-label="${line1text}">${template}</div>
          `);
     } else {
       // Render the line1 property value
       if (line1text) {
         details.push(html`
              <div class="line1" part="detail-line" @click=${() =>
-               this.handleLine1Clicked()} role="presentation" aria-label="${line1text}">${line1text}</div>
+            this.handleLine1Clicked()} role="presentation" aria-label="${line1text}">${line1text}</div>
            `);
       }
     }
@@ -958,14 +959,14 @@ export class MgtPerson extends MgtTemplatedTaskComponent {
         const template = this.renderTemplate('line2', { person });
         details.push(html`
            <div class="line2" part="detail-line" @click=${() =>
-             this.handleLine2Clicked()} role="presentation" aria-label="${text}">${template}</div>
+            this.handleLine2Clicked()} role="presentation" aria-label="${text}">${template}</div>
          `);
       } else {
         // Render the line2 property value
         if (text) {
           details.push(html`
              <div class="line2" part="detail-line" @click=${() =>
-               this.handleLine2Clicked()} role="presentation" aria-label="${text}">${text}</div>
+              this.handleLine2Clicked()} role="presentation" aria-label="${text}">${text}</div>
            `);
         }
       }
@@ -979,14 +980,14 @@ export class MgtPerson extends MgtTemplatedTaskComponent {
         const template = this.renderTemplate('line3', { person });
         details.push(html`
            <div class="line3" part="detail-line" @click=${() =>
-             this.handleLine3Clicked()} role="presentation" aria-label="${text}">${template}</div>
+            this.handleLine3Clicked()} role="presentation" aria-label="${text}">${template}</div>
          `);
       } else {
         // Render the line3 property value
         if (text) {
           details.push(html`
              <div class="line3" part="detail-line" @click=${() =>
-               this.handleLine3Clicked()} role="presentation" aria-label="${text}">${text}</div>
+              this.handleLine3Clicked()} role="presentation" aria-label="${text}">${text}</div>
            `);
         }
       }
@@ -1201,6 +1202,12 @@ export class MgtPerson extends MgtTemplatedTaskComponent {
     }
 
     details = this.personDetailsInternal || this.personDetails || this.fallbackDetails;
+
+    // load card data at this point
+    if (this.personCardInteraction !== 'none') {
+      // perform the batch requests and cache
+      void getPersonCardGraphData(graph, details, this.personQuery === 'me')
+    }
 
     // populate presence
     const defaultPresence: Presence = {

--- a/packages/mgt-components/src/components/mgt-person/mgt-person.ts
+++ b/packages/mgt-components/src/components/mgt-person/mgt-person.ts
@@ -939,14 +939,14 @@ export class MgtPerson extends MgtTemplatedTaskComponent {
       const template = this.renderTemplate('line1', { person });
       details.push(html`
            <div class="line1" part="detail-line" @click=${() =>
-          this.handleLine1Clicked()} role="presentation" aria-label="${line1text}">${template}</div>
+             this.handleLine1Clicked()} role="presentation" aria-label="${line1text}">${template}</div>
          `);
     } else {
       // Render the line1 property value
       if (line1text) {
         details.push(html`
              <div class="line1" part="detail-line" @click=${() =>
-            this.handleLine1Clicked()} role="presentation" aria-label="${line1text}">${line1text}</div>
+               this.handleLine1Clicked()} role="presentation" aria-label="${line1text}">${line1text}</div>
            `);
       }
     }
@@ -959,14 +959,14 @@ export class MgtPerson extends MgtTemplatedTaskComponent {
         const template = this.renderTemplate('line2', { person });
         details.push(html`
            <div class="line2" part="detail-line" @click=${() =>
-            this.handleLine2Clicked()} role="presentation" aria-label="${text}">${template}</div>
+             this.handleLine2Clicked()} role="presentation" aria-label="${text}">${template}</div>
          `);
       } else {
         // Render the line2 property value
         if (text) {
           details.push(html`
              <div class="line2" part="detail-line" @click=${() =>
-              this.handleLine2Clicked()} role="presentation" aria-label="${text}">${text}</div>
+               this.handleLine2Clicked()} role="presentation" aria-label="${text}">${text}</div>
            `);
         }
       }
@@ -980,14 +980,14 @@ export class MgtPerson extends MgtTemplatedTaskComponent {
         const template = this.renderTemplate('line3', { person });
         details.push(html`
            <div class="line3" part="detail-line" @click=${() =>
-            this.handleLine3Clicked()} role="presentation" aria-label="${text}">${template}</div>
+             this.handleLine3Clicked()} role="presentation" aria-label="${text}">${template}</div>
          `);
       } else {
         // Render the line3 property value
         if (text) {
           details.push(html`
              <div class="line3" part="detail-line" @click=${() =>
-              this.handleLine3Clicked()} role="presentation" aria-label="${text}">${text}</div>
+               this.handleLine3Clicked()} role="presentation" aria-label="${text}">${text}</div>
            `);
         }
       }
@@ -1206,7 +1206,7 @@ export class MgtPerson extends MgtTemplatedTaskComponent {
     // load card data at this point
     if (this.personCardInteraction !== 'none') {
       // perform the batch requests and cache
-      void getPersonCardGraphData(graph, details, this.personQuery === 'me')
+      void getPersonCardGraphData(graph, details, this.personQuery === 'me');
     }
 
     // populate presence

--- a/packages/mgt-components/src/graph/cacheStores.ts
+++ b/packages/mgt-components/src/graph/cacheStores.ts
@@ -21,9 +21,10 @@ export const schemas = {
     stores: {
       users: 'users',
       usersQuery: 'usersQuery',
-      userFilters: 'userFilters'
+      userFilters: 'userFilters',
+      cardState: 'cardState'
     },
-    version: 3
+    version: 4
   },
   photos: {
     name: 'photos',


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #3260  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
- Added caching of the response data from the batch requests performed for the card state.
- If a person has `person-card` attribute set, do a call for card state batches . This will hit the cache first, if no cache is found, the network call is made and the response is cached. This enable any person card interaction on person to be faster as the data is already in cache.

### PR checklist
- [ ] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [ ] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [ ] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
Maybe cache to a lower time limit to avoid stale data on updated sections like `messages`?