### PR TITLE
fix: display default selected users and groups while disabling suggestions

### DIFF
--- a/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
+++ b/packages/mgt-components/src/components/mgt-people-picker/mgt-people-picker.ts
@@ -944,6 +944,39 @@ export class MgtPeoplePicker extends MgtTemplatedTaskComponent {
       const graph = provider.graph.forComponent(this);
 
       if (!input.length) {
+        if (
+          (this.defaultSelectedUserIds.length > 0 || this.defaultSelectedGroupIds.length > 0) &&
+          !this.selectedPeople.length &&
+          !this.defaultSelectedUsers.length &&
+          !this.defaultSelectedGroups.length
+        ) {
+          this.defaultSelectedUsers = await getUsersForUserIds(
+            graph,
+            this.defaultSelectedUserIds,
+            '',
+            this.userFilters
+          );
+          this.defaultSelectedGroups = await getGroupsForGroupIds(
+            graph,
+            this.defaultSelectedGroupIds,
+            this.peopleFilters
+          );
+
+          this.defaultSelectedGroups = this.defaultSelectedGroups.filter(group => {
+            return group !== null;
+          });
+
+          this.defaultSelectedUsers = this.defaultSelectedUsers.filter(user => {
+            return user !== null;
+          });
+
+          this.selectedPeople = [...this.defaultSelectedUsers, ...this.defaultSelectedGroups];
+
+          if (this.hasMaxSelections) {
+            this.disableTextInput();
+          }
+          this.requestUpdate();
+        }
         if (this.disableSuggestions) {
           this._foundPeople = [];
           return;
@@ -1027,35 +1060,6 @@ export class MgtPeoplePicker extends MgtTemplatedTaskComponent {
           }
           this.defaultPeople = people;
         }
-      }
-
-      if (
-        (this.defaultSelectedUserIds.length > 0 || this.defaultSelectedGroupIds.length > 0) &&
-        !this.selectedPeople.length &&
-        !this.defaultSelectedUsers.length &&
-        !this.defaultSelectedGroups.length
-      ) {
-        this.defaultSelectedUsers = await getUsersForUserIds(graph, this.defaultSelectedUserIds, '', this.userFilters);
-        this.defaultSelectedGroups = await getGroupsForGroupIds(
-          graph,
-          this.defaultSelectedGroupIds,
-          this.peopleFilters
-        );
-
-        this.defaultSelectedGroups = this.defaultSelectedGroups.filter(group => {
-          return group !== null;
-        });
-
-        this.defaultSelectedUsers = this.defaultSelectedUsers.filter(user => {
-          return user !== null;
-        });
-
-        this.selectedPeople = [...this.defaultSelectedUsers, ...this.defaultSelectedGroups];
-
-        if (this.hasMaxSelections) {
-          this.disableTextInput();
-        }
-        this.requestUpdate();
       }
 
       if (input) {

--- a/stories/components/peoplePicker/peoplePicker.properties.stories.js
+++ b/stories/components/peoplePicker/peoplePicker.properties.stories.js
@@ -79,9 +79,11 @@ closeModal.addEventListener('click', () => {
 `;
 
 export const disableSuggestions = () => html`
-  <mgt-people-picker disable-suggestions></mgt-people-picker>
-  <mgt-people-picker
-  default-selected-user-ids="e3d0513b-449e-4198-ba6f-bd97ae7cae85, 40079818-3808-4585-903b-02605f061225" disable-suggestions>
+</h1>Disable suggestions</h1>
+<mgt-people-picker disable-suggestions></mgt-people-picker>
+</h1>Disable suggestions with default selected user Ids</h1>
+<mgt-people-picker
+default-selected-user-ids="e3d0513b-449e-4198-ba6f-bd97ae7cae85, 40079818-3808-4585-903b-02605f061225" disable-suggestions>
 </mgt-people-picker>
 
 

--- a/stories/components/peoplePicker/peoplePicker.properties.stories.js
+++ b/stories/components/peoplePicker/peoplePicker.properties.stories.js
@@ -80,6 +80,12 @@ closeModal.addEventListener('click', () => {
 
 export const disableSuggestions = () => html`
   <mgt-people-picker disable-suggestions></mgt-people-picker>
+  <mgt-people-picker
+  default-selected-user-ids="e3d0513b-449e-4198-ba6f-bd97ae7cae85, 40079818-3808-4585-903b-02605f061225" disable-suggestions>
+</mgt-people-picker>
+
+
+  
 `;
 
 export const dynamicGroupId = () => html`

--- a/stories/components/peoplePicker/peoplePicker.properties.stories.js
+++ b/stories/components/peoplePicker/peoplePicker.properties.stories.js
@@ -79,9 +79,9 @@ closeModal.addEventListener('click', () => {
 `;
 
 export const disableSuggestions = () => html`
-</h1>Disable suggestions</h1>
+<h1>Disable suggestions</h1>
 <mgt-people-picker disable-suggestions></mgt-people-picker>
-</h1>Disable suggestions with default selected user Ids</h1>
+<h1>Disable suggestions with default selected user Ids</h1>
 <mgt-people-picker
 default-selected-user-ids="e3d0513b-449e-4198-ba6f-bd97ae7cae85, 40079818-3808-4585-903b-02605f061225" disable-suggestions>
 </mgt-people-picker>


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #3201  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Display default selected users and groups while disabling suggestions

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
