### PR TITLE
fix: handle popup login errors

### DIFF
--- a/packages/providers/mgt-msal2-provider/src/Msal2Provider.ts
+++ b/packages/providers/mgt-msal2-provider/src/Msal2Provider.ts
@@ -24,7 +24,8 @@ import {
   InteractionRequiredAuthError,
   SsoSilentRequest,
   EventMessage,
-  AuthenticationResult
+  AuthenticationResult,
+  BrowserAuthError
 } from '@azure/msal-browser';
 import { AuthenticationProviderOptions } from '@microsoft/microsoft-graph-client';
 
@@ -476,8 +477,24 @@ export class Msal2Provider extends IProvider {
       domainHint: this._domainHint
     };
     if (this._loginType === LoginType.Popup) {
-      const response = await this._publicClientApplication.loginPopup(loginRequest);
-      this.handleResponse(response?.account);
+      try {
+        const response = await this._publicClientApplication.loginPopup(loginRequest);
+        this.handleResponse(response?.account);
+      } catch (error) {
+        switch (true) {
+          case error instanceof BrowserAuthError && error.errorCode === 'user_cancelled':
+            console.warn('🦒: User cancelled the login flow.');
+            this.setState(ProviderState.SignedOut);
+            break;
+          case error instanceof BrowserAuthError && error.errorCode === 'interaction_in_progress':
+            console.warn('🦒: Login already in progess. Close the popup to login again.');
+            this.setState(ProviderState.SignedOut);
+            break;
+          default:
+            console.error('🦒: Error occurred during login:', error);
+            throw error;
+        }
+      }
     } else {
       const loginRedirectRequest: RedirectRequest = { ...loginRequest };
       await this._publicClientApplication.loginRedirect(loginRedirectRequest);


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #3070 <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes
Handle errors when user cancels sing-in popup, or tries to login when there's an already existing login process.
### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
How to test: Ensure that you initialize MSAL2 with  loginType: LoginType.Popup and first try to login and close the popup, then second click the sign in button multiple times without closing the popup.