### PR TITLE
fixed file list pagination not working when filtering file extensions

### DIFF
--- a/packages/mgt-components/src/components/mgt-file-list/mgt-file-list.ts
+++ b/packages/mgt-components/src/components/mgt-file-list/mgt-file-list.ts
@@ -807,9 +807,14 @@ export class MgtFileList extends MgtTemplatedTaskComponent implements CardSectio
       if (this.fileExtensions?.length > 0) {
         // retrive all pages before filtering
         if (this.pageIterator?.value) {
-          while (this.pageIterator.hasNext) {
-            await fetchNextAndCacheForFilesPageIterator(this.pageIterator);
+          // Since we're fetching all results, we max out the page size
+          // instead of using the user-specified page size.
+          const maxPageSizeFileIterator = await getFilesIterator(graph, 1000);
+          while (maxPageSizeFileIterator.hasNext) {
+            await fetchNextAndCacheForFilesPageIterator(maxPageSizeFileIterator);
           }
+          // Recreate iterator with all results
+          this.pageIterator = GraphPageIterator.createFromValue(graph, maxPageSizeFileIterator.value);
           files = this.pageIterator.value;
           this._preloadedFiles = [];
         }
@@ -820,6 +825,7 @@ export class MgtFileList extends MgtTemplatedTaskComponent implements CardSectio
             }
           }
         });
+        this._preloadedFiles = [...filteredByFileExtension];
       }
 
       if (filteredByFileExtension?.length >= 0) {


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes # [3413](https://github.com/microsoftgraph/microsoft-graph-toolkit/issues/3413)

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

- Bugfix

### Description of the changes

- Fixed broken pagination when filtering by extension. This was caused by `this._preloadedFiles` not being updated after fetching data in `mgt-file-list.ts`. 
- Additionally, files will now be fetched using the maximum pagination size because the pagination is done on the client side here. after everything is fetched, pagination will use the user-defined page size normally.

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [x] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
- [x] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

