### PR TITLE
fix(search-results): add templating stories

### DIFF
--- a/stories/components/searchResults/searchResults.templating.stories.js
+++ b/stories/components/searchResults/searchResults.templating.stories.js
@@ -1,0 +1,39 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
+import { html } from 'lit';
+import { withCodeEditor } from '../../../.storybook/addons/codeEditorAddon/codeAddon';
+
+export default {
+  title: 'Components / mgt-search-results / Templating',
+  component: 'search-results',
+  decorators: [withCodeEditor]
+};
+
+export const DefaultTemplates = () => html`
+  <mgt-search-results query-string="contoso" entity-types="site">
+    <template data-type="default">
+        <div data-for="result in value[0].hitsContainers[0].hits">
+        <div class="displayName">{{result.resource.displayName}}</div>
+        </div>
+    </template>
+    <template data-type="loading">
+        Loading
+    </template>
+  </mgt-search-results>
+`;
+
+export const noDataTemplate = () => html`
+  <div>
+    <div>No data template</div>
+    <mgt-search-results query-string="xyxy" entity-types="driveItem">
+        <template data-type="no-data">
+        <div>No results found</div>
+        </template>
+    </mgt-search-results>
+</div>
+  `;


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #3415  <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

<!-- - Bugfix -->
Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
Documentation content changes
<!-- - Other... Please describe: -->

### Description of the changes
Add default and no-data template stories for mgt-search-results

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [x] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Other information
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
