### PR TITLE
chore: remove notification to teams toolkit

### DIFF
--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -74,14 +74,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Notify TeamsFx Repo
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.TEAMSFX_REPO_ACCESS_TOKEN }}
-          repository: OfficeDev/TeamsFx
-          event-type: graph-toolkit-released
-          client-payload: '{"version": "${{ needs.version.outputs.package-version }}"}'
-
   storybook:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The TeamsFX auth provider only relies on the interface, so if there are no changes to the TeamsFX auth provider, we do not need to track the version of the Graph Toolkit any more. So remove this notification.