### PR TITLE
fix(a11y): improve contrast ratio on component style stories

### DIFF
--- a/stories/components/person/person.properties.stories.js
+++ b/stories/components/person/person.properties.stories.js
@@ -351,7 +351,7 @@ export const moreExamples = () => html`
 
      .styled-person {
        --default-font-family: 'Comic Sans MS', cursive, sans-serif;
-       --person-line1-text-color: red;
+       --person-line1-text-color: #CB1919;
        --person-avatar-size: 60px;
        --default-font-size: 20px;
        --person-line2-text-color: green;
@@ -361,7 +361,7 @@ export const moreExamples = () => html`
 
     .person-initials {
       --person-initials-text-color: yellow;
-      --person-initials-background-color: red;
+      --person-initials-background-color: #CB1919;
       --person-avatar-size: 60px;
       --person-avatar-border-radius: 10% 35%;
     }

--- a/stories/components/planner/planner.style.stories.js
+++ b/stories/components/planner/planner.style.stories.js
@@ -58,7 +58,7 @@ export const customCSSProperties = () => html`
 
         --task-title-text-font-size: large;
         --task-title-text-font-weight: 500;
-        --task-complete-title-text-color: green;
+        --task-complete-title-text-color: #066406;
         --task-incomplete-title-text-color: purple;
 
         --task-icons-width: 32px;
@@ -70,7 +70,7 @@ export const customCSSProperties = () => html`
 
         --task-complete-background-color: powderblue;
         --task-incomplete-background-color: salmon;
-        --task-complete-border: 2px dashed green;
+        --task-complete-border: 2px dashed #066406;
         --task-incomplete-border: 2px double red;
         --task-complete-border-radius: 8px;
         --task-incomplete-border-radius: 12px;

--- a/stories/components/planner/planner.style.stories.js
+++ b/stories/components/planner/planner.style.stories.js
@@ -108,6 +108,9 @@ export const customCSSProperties = () => html`
         --dot-options-menu-shadow-color: yellow;
         --dot-options-menu-item-color: maroon;
         --dot-options-menu-item-hover-background-color: white;
+
+        /** affects the assignments dropdown **/
+        --arrow-options-button-font-color: #004074;
       }
   </style>
   <mgt-planner class="tasks"></mgt-planner>


### PR DESCRIPTION
<!-- Review contributing guidelines before creating PRs -->
<!-- https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/main/CONTRIBUTING.md -->

Closes #3370
Closes #3372   <!-- REQUIRED: Add the issue number (ex: #12) so the issue is automatically closed when PR is merged -->

### PR Type
<!-- Please uncomment one or more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

### Description of the changes

Corrects contrast ratio in elements

### PR checklist
- [x] Project builds (`yarn build`) and changes have been tested in at least two supported browsers (Edge + non-Chromium based browser)
- [ ] All public APIs (classes, methods, etc) have been documented following the jsdoc syntax
- [x] [Stories](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Storybook#writing-stories) have been added and existing stories have been tested
- [ ] Added appropriate [documentation](https://github.com/microsoftgraph/microsoft-graph-toolkit/wiki/Documentation). Docs PR: <!-- Link to docs PR here -->
<!-- Please uncomment if any Accessibility related changes -->
<!-- - [ ] Accessibility tested and approved-->
- [ ] License header has been added to all new source files (`yarn setLicense`)
- [x] Contains **NO** breaking changes

### Testing
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->

1. Open Desktop Accessibility Insights.
2. Go through the provided link and ensure the mgt-planner `custom css properties` story and mgt-person `More Examples` story have the required contrast ratios between the previously flagged elements.