### PR TITLE
fix: route signed-out sandbox proxy to graphexplorer.microsoft.com

### DIFF
--- a/.storybook/addons/codeEditorAddon/codeAddon.js
+++ b/.storybook/addons/codeEditorAddon/codeAddon.js
@@ -254,7 +254,7 @@ export const withCodeEditor = makeDecorator({
                   content="default-src 'self';
                     script-src 'self' 'unsafe-inline';
                     style-src 'self' 'unsafe-inline';
-                    connect-src https://graph.microsoft.com https://graph.microsoft.us https://dod-graph.microsoft.us https://graph.microsoft.de https://microsoftgraph.chinacloudapi.cn https://canary.graph.microsoft.com https://login.microsoftonline.com https://cdn.graph.office.net https://graph.office.net 'self';
+                    connect-src https://graph.microsoft.com https://graph.microsoft.us https://dod-graph.microsoft.us https://graph.microsoft.de https://microsoftgraph.chinacloudapi.cn https://canary.graph.microsoft.com https://login.microsoftonline.com https://graphexplorer.microsoft.com 'self';
                     img-src 'self' data: blob: https://*.microsoft.com https://*.microsoftonline.com https://*.sharepoint.com https://*.office.com https://*.office365.com https://*.windows.net;
                     font-src 'self' https://static2.sharepointonline.com;
                     frame-src https://login.microsoftonline.com 'self';

--- a/.storybook/post-process-index-file.js
+++ b/.storybook/post-process-index-file.js
@@ -60,7 +60,7 @@ function addCspTag(filePath) {
       ' '
     )} 'self';style-src 'report-sample' 'unsafe-inline' ${styleHashes.join(
       ' '
-    )} 'self';font-src static2.sharepointonline.com 'self';connect-src https://cdn.graph.office.net https://graph.office.net https://login.microsoftonline.com https://graph.microsoft.com https://mgt.dev 'self';img-src data: https: 'self';frame-src https://login.microsoftonline.com 'self';default-src 'self'; base-uri 'self'; upgrade-insecure-requests; form-action 'self';report-to https://csp.microsoft.com/report/MGT-Playground"
+    )} 'self';font-src static2.sharepointonline.com 'self';connect-src https://graphexplorer.microsoft.com https://login.microsoftonline.com https://graph.microsoft.com https://mgt.dev 'self';img-src data: https: 'self';frame-src https://login.microsoftonline.com 'self';default-src 'self'; base-uri 'self'; upgrade-insecure-requests; form-action 'self';report-to https://csp.microsoft.com/report/MGT-Playground"
   />`;
   const updatedHtmlDocument = htmlDocument.replace(
     /<head>/,

--- a/packages/mgt-element/src/mock/MockMiddleware.ts
+++ b/packages/mgt-element/src/mock/MockMiddleware.ts
@@ -6,7 +6,6 @@
  */
 
 import { Context, Middleware } from '@microsoft/microsoft-graph-client';
-import { SessionCache, storageAvailable } from '../utils/SessionCache';
 
 /**
  * Implements Middleware for the Mock Client to escape
@@ -23,14 +22,6 @@ export class MockMiddleware implements Middleware {
   private _nextMiddleware: Middleware;
 
   private static _baseUrl: string;
-
-  private static _cache: SessionCache;
-  private static get _sessionCache(): SessionCache {
-    if (!this._cache && storageAvailable('sessionStorage')) {
-      this._cache = new SessionCache();
-    }
-    return this._cache;
-  }
 
   public async execute(context: Context): Promise<void> {
     try {
@@ -52,7 +43,7 @@ export class MockMiddleware implements Middleware {
   }
 
   /**
-   * Gets the base url for the mock graph, either from the session cache or from the endpoint service
+   * Gets the base url for the mock graph.
    *
    * @static
    * @return {string} the base url for the mock graph to use.
@@ -60,31 +51,9 @@ export class MockMiddleware implements Middleware {
    */
   public static async getBaseUrl() {
     if (!this._baseUrl) {
-      const sessionEndpoint = this._sessionCache?.getItem('endpointURL');
-      if (sessionEndpoint) {
-        this._baseUrl = sessionEndpoint;
-      } else {
-        try {
-          // get the url we should be using from the endpoint service
-          const response = await fetch('https://cdn.graph.office.net/en-us/graph/api/proxy/endpoint');
-          const base: unknown = await response.json();
-          if (typeof base !== 'string') {
-            MockMiddleware.setBaseFallbackUrl();
-          } else {
-            this._baseUrl = base + '?url=';
-          }
-        } catch {
-          // fallback to hardcoded value
-          MockMiddleware.setBaseFallbackUrl();
-        }
-        this._sessionCache?.setItem('endpointURL', this._baseUrl);
-      }
+      this._baseUrl = 'https://graphexplorer.microsoft.com/api/proxy?url=';
     }
 
-    return this._baseUrl;
-  }
-
-  private static setBaseFallbackUrl() {
-    this._baseUrl = 'https://graph.office.net/en-us/graph/api/proxy?url=';
+    return await Promise.resolve(this._baseUrl);
   }
 }


### PR DESCRIPTION
## Summary
Updates the sandbox proxy used to fetch Graph data on the Storybook site when users are **not signed in**, switching from `graph.office.net` to `https://graphexplorer.microsoft.com/api/proxy`.

## Changes
- **`packages/mgt-element/src/mock/MockMiddleware.ts`**: `getBaseUrl()` now returns `https://graphexplorer.microsoft.com/api/proxy?url=` directly. Removed the `cdn.graph.office.net` endpoint-discovery `fetch`, the `graph.office.net` fallback, and the `sessionStorage` caching (which could otherwise serve a stale host to returning users). Request rewriting (`?url=` + `encodeURIComponent`) is unchanged.
- **CSP `connect-src` allowlists** updated to add `https://graphexplorer.microsoft.com` and remove `https://cdn.graph.office.net` / `https://graph.office.net`:
  - `.storybook/post-process-index-file.js` (main site)
  - `.storybook/addons/codeEditorAddon/codeAddon.js` (code-editor playground iframe)

## Notes
- `MockGraph.create()` derives `customHosts` from `getBaseUrl()`, so it picks up the new host automatically — no change needed there.

## Validation
- `tsc --noEmit` on `mgt-element` passes.
- Ran the Storybook dev server locally and confirmed signed-out components fetch via `https://graphexplorer.microsoft.com/api/proxy?url=...` without CSP violations.